### PR TITLE
Pin GitHub Actions dependencies in CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,14 +24,14 @@ jobs:
         # Bijvoorbeeld / For example: ['java', 'javascript', 'python']
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
         with:
           languages: ${{ matrix.language }}
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Pin 4 GitHub Actions in `.github/workflows/codeql.yml` van floating version tags (`@v6`, `@v4`) naar commit SHA-referenties
- Lost de 4 open **Pinned-Dependencies** alerts op uit de [OpenSSF Scorecard](https://github.com/MinBZK/moza-poc-fbs-berichtenbox/security/code-scanning)
- Conform het patroon dat al wordt gebruikt in `scorecard.yml` en `architecture.yml`

## Wijzigingen
| Action | Was | Wordt |
|--------|-----|-------|
| `actions/checkout` | `@v6` | `@de0fac2...` (v6.0.2) |
| `github/codeql-action/init` | `@v4` | `@0d579ff...` (v4.32.6) |
| `github/codeql-action/autobuild` | `@v4` | `@0d579ff...` (v4.32.6) |
| `github/codeql-action/analyze` | `@v4` | `@0d579ff...` (v4.32.6) |

## Test plan
- [ ] CodeQL workflow draait succesvol op deze PR
- [ ] Na merge: Scorecard herberekening sluit de 4 Pinned-Dependencies alerts