### PR TITLE
Fix PR review bevindingen: error handling, type-validatie en tests

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -17,3 +17,12 @@ services:
       - ./wiremock/mappings:/home/wiremock/mappings
       - ./wiremock/__files:/home/wiremock/__files
     command: ["--verbose"]
+
+  magazijn-b:
+    image: wiremock/wiremock:3.12.1
+    ports:
+      - "8082:8080"
+    volumes:
+      - ./wiremock/mappings:/home/wiremock/mappings
+      - ./wiremock/__files:/home/wiremock/__files
+    command: ["--verbose"]

--- a/services/berichtenlijst/src/main/kotlin/nl/rijksoverheid/moz/berichtenlijst/berichten/BerichtenCache.kt
+++ b/services/berichtenlijst/src/main/kotlin/nl/rijksoverheid/moz/berichtenlijst/berichten/BerichtenCache.kt
@@ -27,10 +27,10 @@ class RedisBerichtenCache(
     private val log = Logger.getLogger(RedisBerichtenCache::class.java)
 
     override fun store(key: String, berichten: List<Bericht>): Uni<Void> {
-        if (berichten.isEmpty()) {
-            return Uni.createFrom().voidItem()
-        }
         val listKey = listKey(key)
+        if (berichten.isEmpty()) {
+            return redis.key().del(listKey).replaceWithVoid()
+        }
         val listCommands = redis.list(String::class.java)
         val keyCommands = redis.key()
 
@@ -114,6 +114,7 @@ data class AggregationStatus(
     val mislukt: Int = 0,
 ) {
     init {
+        require(totaalMagazijnen >= 0) { "totaalMagazijnen mag niet negatief zijn" }
         require(geslaagd >= 0) { "geslaagd mag niet negatief zijn" }
         require(mislukt >= 0) { "mislukt mag niet negatief zijn" }
         require(geslaagd + mislukt <= totaalMagazijnen) { "geslaagd + mislukt mag niet groter zijn dan totaalMagazijnen" }

--- a/services/berichtenlijst/src/main/kotlin/nl/rijksoverheid/moz/berichtenlijst/berichten/BerichtenOphalenResource.kt
+++ b/services/berichtenlijst/src/main/kotlin/nl/rijksoverheid/moz/berichtenlijst/berichten/BerichtenOphalenResource.kt
@@ -44,6 +44,7 @@ class BerichtenOphalenResource(
         val initStream = berichtenCache.storeAggregationStatus(cacheKey, bezigStatus)
             .replaceWith(Multi.createFrom().empty<MagazijnStatusEvent>())
             .toMulti().flatMap { it }
+            .onFailure().invoke { e -> log.errorf(e, "Kon aggregatie-status BEZIG niet opslaan in cache voor key=%s", cacheKey) }
             .onFailure().recoverWithCompletion()
 
         val magazijnStreams = clients.map { (magazijnId, client) ->
@@ -64,7 +65,7 @@ class BerichtenOphalenResource(
                     MagazijnResult.Success(magazijnId, naam, response.berichten)
                 }
                 .onFailure(Exception::class.java).recoverWithItem { error ->
-                    log.warnf(error, "Magazijn %s (%s) ophalen mislukt", magazijnId, naam)
+                    log.errorf(error, "Magazijn %s (%s) ophalen mislukt", magazijnId, naam)
                     MagazijnResult.Failure(magazijnId, naam, error)
                 }
 
@@ -89,7 +90,7 @@ class BerichtenOphalenResource(
                             magazijnId = magazijnId,
                             naam = naam,
                             status = if (isTimeout) MagazijnStatus.TIMEOUT else MagazijnStatus.FOUT,
-                            foutmelding = result.error.message ?: result.error::class.simpleName,
+                            foutmelding = result.error.message ?: "Onbekende fout bij ophalen",
                         )
                     }
                 }

--- a/services/berichtenlijst/src/main/kotlin/nl/rijksoverheid/moz/berichtenlijst/berichten/BerichtenlijstResource.kt
+++ b/services/berichtenlijst/src/main/kotlin/nl/rijksoverheid/moz/berichtenlijst/berichten/BerichtenlijstResource.kt
@@ -12,6 +12,8 @@ import nl.rijksoverheid.moz.berichtenlijst.api.model.Link
 import nl.rijksoverheid.moz.berichtenlijst.api.model.PaginationLinks
 import org.jboss.logging.Logger
 import java.net.URI
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.time.Duration
 import java.util.UUID
 
@@ -28,8 +30,9 @@ class BerichtenlijstResource(
         ontvanger: String?,
         afzender: String?,
     ): BerichtenlijstResponse {
-        val aggregation = berichtenlijstService.getAggregationStatus(ontvanger)
-            .await().atMost(TIMEOUT)
+        val aggregation = awaitOrServiceUnavailable {
+            berichtenlijstService.getAggregationStatus(ontvanger)
+        }
 
         if (aggregation == null) {
             throw WebApplicationException(
@@ -44,20 +47,27 @@ class BerichtenlijstResource(
             )
         }
 
-        // TODO: Implementeer filtering op afzender (PoC)
+        // TODO: afzender parameter wordt momenteel genegeerd -- filter niet actief (PoC)
         val p = page ?: 0
         val ps = pageSize ?: 20
-        val result = berichtenlijstService.getBerichten(p, ps, ontvanger, afzender)
-            .await().atMost(TIMEOUT)
+        val result = awaitOrServiceUnavailable {
+            berichtenlijstService.getBerichten(p, ps, ontvanger, afzender)
+        }
         return toBerichtenlijstResponse(result, aggregation, ontvanger)
     }
 
-    // getBerichtById is blocking: het bevraagt magazijnen synchroon in een loop
+    // @Blocking vereist: de service bevraagt magazijnen synchroon via REST clients (zie BerichtenlijstService.getBerichtById)
     @Blocking
     override fun getBerichtById(berichtId: UUID): BerichtResponse {
-        val bericht = berichtenlijstService.getBerichtById(berichtId)
-            ?: throw WebApplicationException(Response.Status.NOT_FOUND)
-        return toBerichtResponse(bericht)
+        return when (val result = berichtenlijstService.getBerichtById(berichtId)) {
+            is BerichtLookupResult.Found -> toBerichtResponse(result.bericht)
+            is BerichtLookupResult.NotFound -> throw WebApplicationException(
+                "Bericht $berichtId niet gevonden", Response.Status.NOT_FOUND,
+            )
+            is BerichtLookupResult.AllMagazijnenFailed -> throw WebApplicationException(
+                "Geen magazijn bereikbaar voor bericht $berichtId. Probeer het later opnieuw.", 502,
+            )
+        }
     }
 
     override fun zoekBerichten(
@@ -67,12 +77,38 @@ class BerichtenlijstResource(
         ontvanger: String?,
         afzender: String?,
     ): BerichtenlijstResponse {
-        // TODO: Implementeer filtering op afzender (PoC)
+        val aggregation = awaitOrServiceUnavailable {
+            berichtenlijstService.getAggregationStatus(ontvanger)
+        }
+
+        if (aggregation == null) {
+            throw WebApplicationException(
+                "Berichten zijn nog niet opgehaald. Roep eerst GET /api/v1/berichten/ophalen aan.",
+                Response.Status.CONFLICT,
+            )
+        }
+        if (aggregation.status == OphalenStatus.BEZIG) {
+            throw WebApplicationException(
+                "Berichten worden momenteel opgehaald. Wacht tot het ophalen is afgerond.",
+                Response.Status.CONFLICT,
+            )
+        }
+
+        // TODO: afzender parameter wordt momenteel genegeerd -- filter niet actief (PoC)
         val p = page ?: 0
         val ps = pageSize ?: 20
-        val result = berichtenlijstService.zoekBerichten(q, p, ps, ontvanger, afzender)
-            .await().atMost(TIMEOUT)
-        return toBerichtenlijstResponse(result, null, ontvanger)
+        val result = awaitOrServiceUnavailable {
+            berichtenlijstService.zoekBerichten(q, p, ps, ontvanger, afzender)
+        }
+        return toBerichtenlijstResponse(result, aggregation, ontvanger)
+    }
+
+    private fun <T> awaitOrServiceUnavailable(block: () -> io.smallrye.mutiny.Uni<T>): T {
+        try {
+            return block().await().atMost(TIMEOUT)
+        } catch (e: java.util.concurrent.TimeoutException) {
+            throw WebApplicationException("Cache niet bereikbaar. Probeer het later opnieuw.", 503)
+        }
     }
 
     private fun toBerichtenlijstResponse(
@@ -94,7 +130,7 @@ class BerichtenlijstResource(
                 mislukt = aggregation.mislukt
             }
         }
-        val ontvangerParam = ontvanger?.let { "&ontvanger=$it" } ?: ""
+        val ontvangerParam = ontvanger?.let { "&ontvanger=${URLEncoder.encode(it, StandardCharsets.UTF_8)}" } ?: ""
         response.links = PaginationLinks().apply {
             self = Link().apply { href = URI.create("/api/v1/berichten?page=${result.page}&pageSize=${result.pageSize}$ontvangerParam") }
             first = Link().apply { href = URI.create("/api/v1/berichten?page=0&pageSize=${result.pageSize}$ontvangerParam") }

--- a/services/berichtenlijst/src/main/kotlin/nl/rijksoverheid/moz/berichtenlijst/berichten/BerichtenlijstService.kt
+++ b/services/berichtenlijst/src/main/kotlin/nl/rijksoverheid/moz/berichtenlijst/berichten/BerichtenlijstService.kt
@@ -2,6 +2,7 @@ package nl.rijksoverheid.moz.berichtenlijst.berichten
 
 import io.smallrye.mutiny.Uni
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.ProcessingException
 import jakarta.ws.rs.WebApplicationException
 import nl.rijksoverheid.moz.berichtenlijst.magazijn.MagazijnClientFactory
 import org.jboss.logging.Logger
@@ -26,7 +27,7 @@ class BerichtenlijstService(
         return berichtenCache.getAggregationStatus(key)
     }
 
-    fun getBerichtById(berichtId: UUID): Bericht? {
+    fun getBerichtById(berichtId: UUID): BerichtLookupResult {
         log.debugf("Ophalen bericht: %s", berichtId)
         val clients = clientFactory.getAllClients()
         var heeftSuccessvolAntwoord = false
@@ -34,18 +35,24 @@ class BerichtenlijstService(
             try {
                 val bericht = client.getBerichtById(berichtId.toString())
                 heeftSuccessvolAntwoord = true
-                if (bericht != null) return bericht
+                if (bericht != null) return BerichtLookupResult.Found(bericht)
+            } catch (e: WebApplicationException) {
+                if (e.response?.status == 404) {
+                    heeftSuccessvolAntwoord = true
+                } else {
+                    log.errorf(e, "Magazijn %s gaf HTTP %d voor bericht %s", magazijnId, e.response?.status, berichtId)
+                }
+            } catch (e: ProcessingException) {
+                log.errorf(e, "Magazijn %s niet bereikbaar voor bericht %s", magazijnId, berichtId)
             } catch (e: InterruptedException) {
                 Thread.currentThread().interrupt()
                 throw e
-            } catch (e: Exception) {
-                log.warnf(e, "Magazijn %s gaf fout voor bericht %s", magazijnId, berichtId)
             }
         }
         if (!heeftSuccessvolAntwoord) {
-            throw WebApplicationException("Geen magazijn bereikbaar", 502)
+            log.errorf("Alle %d magazijnen onbereikbaar voor bericht %s", clients.size, berichtId)
         }
-        return null
+        return if (heeftSuccessvolAntwoord) BerichtLookupResult.NotFound else BerichtLookupResult.AllMagazijnenFailed
     }
 
     fun zoekBerichten(q: String, page: Int, pageSize: Int, ontvanger: String?, afzender: String?): Uni<BerichtenPage> {
@@ -65,10 +72,23 @@ class BerichtenlijstService(
     }
 }
 
+sealed class BerichtLookupResult {
+    data class Found(val bericht: Bericht) : BerichtLookupResult()
+    data object NotFound : BerichtLookupResult()
+    data object AllMagazijnenFailed : BerichtLookupResult()
+}
+
 data class BerichtenPage(
     val berichten: List<Bericht>,
     val page: Int,
     val pageSize: Int,
     val totalElements: Long,
     val totalPages: Int,
-)
+) {
+    init {
+        require(page >= 0) { "page mag niet negatief zijn" }
+        require(pageSize > 0) { "pageSize moet positief zijn" }
+        require(totalElements >= 0) { "totalElements mag niet negatief zijn" }
+        require(totalPages >= 0) { "totalPages mag niet negatief zijn" }
+    }
+}

--- a/services/berichtenlijst/src/main/kotlin/nl/rijksoverheid/moz/berichtenlijst/berichten/MagazijnStatusEvent.kt
+++ b/services/berichtenlijst/src/main/kotlin/nl/rijksoverheid/moz/berichtenlijst/berichten/MagazijnStatusEvent.kt
@@ -27,4 +27,17 @@ data class MagazijnStatusEvent(
     val geslaagd: Int? = null,
     val mislukt: Int? = null,
     val totaalMagazijnen: Int? = null,
-)
+) {
+    init {
+        when (event) {
+            EventType.MAGAZIJN_STATUS -> {
+                requireNotNull(magazijnId) { "MAGAZIJN_STATUS vereist magazijnId" }
+                requireNotNull(status) { "MAGAZIJN_STATUS vereist status" }
+            }
+            EventType.OPHALEN_GEREED -> {
+                requireNotNull(totaalBerichten) { "OPHALEN_GEREED vereist totaalBerichten" }
+                requireNotNull(totaalMagazijnen) { "OPHALEN_GEREED vereist totaalMagazijnen" }
+            }
+        }
+    }
+}

--- a/services/berichtenlijst/src/main/kotlin/nl/rijksoverheid/moz/berichtenlijst/magazijn/MagazijnClientFactory.kt
+++ b/services/berichtenlijst/src/main/kotlin/nl/rijksoverheid/moz/berichtenlijst/magazijn/MagazijnClientFactory.kt
@@ -17,6 +17,11 @@ class MagazijnClientFactory(
     @PostConstruct
     fun init() {
         require(config.instances().isNotEmpty()) { "Geen magazijnen geconfigureerd" }
+        config.instances().forEach { (id, instance) ->
+            runCatching { URI.create(instance.url()) }.getOrElse {
+                throw IllegalStateException("Ongeldige URL voor magazijn '$id': ${instance.url()}", it)
+            }
+        }
         log.infof("Geconfigureerde magazijnen: %s", config.instances().keys)
     }
 

--- a/services/berichtenlijst/src/main/resources/application.properties
+++ b/services/berichtenlijst/src/main/resources/application.properties
@@ -18,9 +18,11 @@ quarkus.redis.devservices.enabled=false
 # Magazijnen configuratie
 magazijnen.instances.magazijn-a.url=http://localhost:8081
 magazijnen.instances.magazijn-a.naam=Magazijn A
+magazijnen.instances.magazijn-b.url=http://localhost:8082
+magazijnen.instances.magazijn-b.naam=Magazijn B
 
 # Notificatie Service
-notificatie.service.url=http://localhost:8082
+notificatie.service.url=http://localhost:8083
 
 # Logging
 quarkus.log.level=INFO

--- a/services/berichtenlijst/src/test/kotlin/nl/rijksoverheid/moz/berichtenlijst/berichten/BerichtenlijstResourceTest.kt
+++ b/services/berichtenlijst/src/test/kotlin/nl/rijksoverheid/moz/berichtenlijst/berichten/BerichtenlijstResourceTest.kt
@@ -196,6 +196,41 @@ class BerichtenlijstResourceTest {
     }
 
     @Test
+    fun `GET zoeken retourneert 409 als ophalen niet is aangeroepen`() {
+        given()
+            .queryParam("q", "test")
+            .queryParam("ontvanger", "onbekend-zoek-${System.nanoTime()}")
+            .`when`().get("/api/v1/berichten/zoeken")
+            .then()
+            .statusCode(409)
+            .contentType("application/problem+json")
+            .body("status", `is`(409))
+            .body("detail", containsString("nog niet opgehaald"))
+    }
+
+    @Test
+    fun `GET berichten paginering buiten bereik retourneert lege lijst`() {
+        val ontvanger = "page-range-${System.nanoTime()}"
+
+        given()
+            .queryParam("ontvanger", ontvanger)
+            .`when`().get("/api/v1/berichten/ophalen")
+            .then()
+            .statusCode(200)
+
+        given()
+            .queryParam("ontvanger", ontvanger)
+            .queryParam("page", 999)
+            .queryParam("pageSize", 2)
+            .`when`().get("/api/v1/berichten")
+            .then()
+            .statusCode(200)
+            .body("berichten.size()", `is`(0))
+            .body("totalElements", `is`(4))
+            .body("totalPages", `is`(2))
+    }
+
+    @Test
     fun `GET bericht by id retourneert 502 als alle magazijnen falen`() {
         MockMagazijnClientFactory.shouldFailA = true
         MockMagazijnClientFactory.shouldFailB = true

--- a/services/berichtenlijst/src/test/kotlin/nl/rijksoverheid/moz/berichtenlijst/berichten/MockMagazijnClientFactory.kt
+++ b/services/berichtenlijst/src/test/kotlin/nl/rijksoverheid/moz/berichtenlijst/berichten/MockMagazijnClientFactory.kt
@@ -2,6 +2,7 @@ package nl.rijksoverheid.moz.berichtenlijst.berichten
 
 import io.quarkus.test.Mock
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.ProcessingException
 import nl.rijksoverheid.moz.berichtenlijst.magazijn.MagazijnBerichtenResponse
 import nl.rijksoverheid.moz.berichtenlijst.magazijn.MagazijnClient
 import nl.rijksoverheid.moz.berichtenlijst.magazijn.MagazijnClientFactory
@@ -59,11 +60,6 @@ class MockMagazijnClientFactory : MagazijnClientFactory(MockMagazijnenConfig()) 
         var shouldFailB = false
         var shouldTimeoutA = false
         var shouldTimeoutB = false
-
-        // Backwards-compatible alias
-        var shouldFail: Boolean
-            get() = shouldFailA
-            set(value) { shouldFailA = value }
     }
 
     override fun getAllClients(): Map<String, MagazijnClient> {
@@ -84,7 +80,7 @@ class MockMagazijnClientFactory : MagazijnClientFactory(MockMagazijnenConfig()) 
             when (method.name) {
                 "getBerichten" -> {
                     if (shouldTimeout()) Thread.sleep(15_000)
-                    if (shouldFail()) throw RuntimeException("Magazijn niet beschikbaar")
+                    if (shouldFail()) throw ProcessingException("Magazijn niet beschikbaar")
                     MagazijnBerichtenResponse(
                         berichten = berichten,
                         totalElements = berichten.size.toLong(),
@@ -92,12 +88,12 @@ class MockMagazijnClientFactory : MagazijnClientFactory(MockMagazijnenConfig()) 
                     )
                 }
                 "getBerichtById" -> {
-                    if (shouldFail()) throw RuntimeException("Magazijn niet beschikbaar")
+                    if (shouldFail()) throw ProcessingException("Magazijn niet beschikbaar")
                     val berichtId = args[0] as String
                     berichten.find { it.berichtId.toString() == berichtId }
                 }
                 "zoekBerichten" -> {
-                    if (shouldFail()) throw RuntimeException("Magazijn niet beschikbaar")
+                    if (shouldFail()) throw ProcessingException("Magazijn niet beschikbaar")
                     val q = args[0] as String
                     val results = berichten.filter { it.onderwerp.contains(q, ignoreCase = true) }
                     MagazijnBerichtenResponse(


### PR DESCRIPTION
## Summary

- **4 kritieke bugs gefixt**: getBerichtById 404-vs-502 bug, stale cache bij re-fetch, silent failure in initStream, te brede exception catch
- **8 belangrijke verbeteringen**: zoekBerichten 409-guard, URL-encoding HAL links, TimeoutException handling, magazijn-b configuratie, type-validatie, startup URL-validatie
- **2 nieuwe tests**: zoekBerichten 409-guard, paginering buiten bereik

## Geadresseerde review-bevindingen

### Kritiek (must-fix)
- `getBerichtById` vangt nu `WebApplicationException(404)` apart op — retourneert correct 404 i.p.v. 502
- `BerichtenCache.store()` verwijdert oude cache-data bij lege lijst — voorkomt stale data bij re-fetch
- `initStream` logt cache-fouten voordat `recoverWithCompletion()` ze opvangt — geen stille failures meer
- `BerichtenlijstService` retourneert `BerichtLookupResult` sealed class i.p.v. `WebApplicationException` — error handling in resource, niet service (CLAUDE.md)

### Belangrijk
- `zoekBerichten` heeft nu dezelfde 409-guard als `getBerichten` — consistente lifecycle check
- HAL pagination links URL-encoden de `ontvanger` parameter — voorkomt URI-injectie
- `await().atMost()` vangt `TimeoutException` af en retourneert 503 Problem JSON
- `compose.yaml` + `application.properties` configureren nu magazijn-a én magazijn-b
- `MagazijnStatusEvent` valideert verplichte velden per event type via `init`
- `AggregationStatus` controleert `totaalMagazijnen >= 0`
- `BerichtenPage` valideert `page >= 0`, `pageSize > 0`, `totalElements >= 0`
- `MagazijnClientFactory` valideert URLs bij startup
- Backend-failures gelogd als ERROR i.p.v. WARN
- Generieke foutmelding in SSE i.p.v. interne class names
- Mock gebruikt `ProcessingException` i.p.v. `RuntimeException` — matcht echt REST client gedrag

## Test plan

- [x] Alle 22 tests slagen (inclusief 2 nieuwe)
- [ ] Handmatig testen met `docker compose up` + `./mvnw quarkus:dev`
- [ ] Controleer SSE-stream met 2 magazijnen in dev mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)