### PR TITLE
Voeg ontvanger parameter en aggregation-status check toe aan getBerichtById

### DIFF
--- a/services/berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/berichtensessiecache/berichten/BerichtenCache.kt
+++ b/services/berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/berichtensessiecache/berichten/BerichtenCache.kt
@@ -20,7 +20,7 @@ interface BerichtenCache {
     fun getAggregationStatus(key: String): Uni<AggregationStatus?>
     fun getPage(key: String, page: Int, pageSize: Int): Uni<BerichtenPage?>
     fun search(ontvanger: String?, q: String, page: Int, pageSize: Int): Uni<BerichtenPage>
-    fun getById(berichtId: UUID): Uni<Bericht?>
+    fun getById(berichtId: UUID, ontvanger: String): Uni<Bericht?>
 
     companion object {
         fun cacheKey(ontvanger: String?) = "berichtensessiecache:v1:${ontvanger ?: "all"}"
@@ -178,10 +178,14 @@ class RedisBerichtenCache(
             .onFailure().invoke { e -> log.errorf(e, "RediSearch query mislukt voor q=%s, ontvanger=%s", q, ontvanger) }
     }
 
-    override fun getById(berichtId: UUID): Uni<Bericht?> {
+    override fun getById(berichtId: UUID, ontvanger: String): Uni<Bericht?> {
         val berichtKey = BerichtenCache.berichtKey(berichtId)
         return redis.hash(String::class.java).hgetall(berichtKey)
-            .map { fields -> if (fields.isEmpty()) null else hashToBericht(fields) }
+            .map { fields ->
+                if (fields.isEmpty()) return@map null
+                val bericht = hashToBericht(fields)
+                if (bericht.ontvanger != ontvanger) null else bericht
+            }
             .onFailure().invoke { e -> log.errorf(e, "Redis getById mislukt voor berichtId=%s", berichtId) }
     }
 

--- a/services/berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/berichtensessiecache/berichten/BerichtensessiecacheResource.kt
+++ b/services/berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/berichtensessiecache/berichten/BerichtensessiecacheResource.kt
@@ -74,7 +74,7 @@ class BerichtensessiecacheResource(
         requireGereedStatus(ontvanger)
 
         val bericht = awaitOrServiceUnavailable {
-            berichtensessiecacheService.getBerichtById(berichtId)
+            berichtensessiecacheService.getBerichtById(berichtId, ontvanger!!)
         } ?: throw WebApplicationException(
             "Bericht niet gevonden", Response.Status.NOT_FOUND,
         )

--- a/services/berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/berichtensessiecache/berichten/BerichtensessiecacheService.kt
+++ b/services/berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/berichtensessiecache/berichten/BerichtensessiecacheService.kt
@@ -23,9 +23,9 @@ class BerichtensessiecacheService(
         return berichtenCache.getAggregationStatus(key)
     }
 
-    fun getBerichtById(berichtId: UUID): Uni<Bericht?> {
+    fun getBerichtById(berichtId: UUID, ontvanger: String): Uni<Bericht?> {
         log.debugf("Ophalen bericht uit cache: %s", berichtId)
-        return berichtenCache.getById(berichtId)
+        return berichtenCache.getById(berichtId, ontvanger)
     }
 
     fun zoekBerichten(q: String, page: Int, pageSize: Int, ontvanger: String?, afzender: String?): Uni<BerichtenPage> {

--- a/services/berichtensessiecache/src/main/resources/openapi/berichtensessiecache-api.yaml
+++ b/services/berichtensessiecache/src/main/resources/openapi/berichtensessiecache-api.yaml
@@ -60,13 +60,7 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
         '409':
-          description: |
-            Berichten zijn nog niet opgehaald of het ophalen is nog bezig.
-            Roep eerst GET /berichten/_ophalen aan.
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Problem'
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -116,13 +110,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
         '409':
-          description: |
-            Berichten zijn nog niet opgehaald of het ophalen is nog bezig.
-            Roep eerst GET /berichten/_ophalen aan.
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Problem'
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -174,13 +162,7 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
         '409':
-          description: |
-            Berichten zijn nog niet opgehaald of het ophalen is nog bezig.
-            Roep eerst GET /berichten/_ophalen aan.
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Problem'
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -473,6 +455,14 @@ components:
             $ref: '#/components/schemas/Problem'
     NotFound:
       description: Resource niet gevonden
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+    Conflict:
+      description: |
+        Berichten zijn nog niet opgehaald of het ophalen is nog bezig.
+        Roep eerst GET /berichten/_ophalen aan.
       content:
         application/problem+json:
           schema:

--- a/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/berichtensessiecache/berichten/BerichtensessiecacheResourceTest.kt
+++ b/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/berichtensessiecache/berichten/BerichtensessiecacheResourceTest.kt
@@ -229,7 +229,7 @@ class BerichtensessiecacheResourceTest {
 
     @Test
     fun `GET bericht by id retourneert bericht uit cache met correcte velden`() {
-        val ontvanger = "byid-test-${System.nanoTime()}"
+        val ontvanger = "999993653"
 
         // Eerst ophalen zodat berichten in cache komen
         given()
@@ -248,6 +248,27 @@ class BerichtensessiecacheResourceTest {
             .body("ontvanger", `is`("999993653"))
             .body("onderwerp", `is`("Test bericht 1"))
             .body("magazijnId", `is`("magazijn-a"))
+    }
+
+    @Test
+    fun `GET bericht by id retourneert 404 als ontvanger niet overeenkomt`() {
+        val eigenOntvanger = "andere-ontvanger-${System.nanoTime()}"
+
+        // Ophalen zodat aggregation status GEREED is
+        given()
+            .queryParam("ontvanger", eigenOntvanger)
+            .`when`().get("/api/v1/berichten/_ophalen")
+            .then()
+            .statusCode(200)
+
+        // Bericht bestaat in cache maar hoort bij ontvanger "999993653", niet bij eigenOntvanger
+        given()
+            .queryParam("ontvanger", eigenOntvanger)
+            .`when`().get("/api/v1/berichten/11111111-1111-1111-1111-111111111111")
+            .then()
+            .statusCode(404)
+            .contentType("application/problem+json")
+            .body("status", `is`(404))
     }
 
     @Test

--- a/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/berichtensessiecache/berichten/MockBerichtenCache.kt
+++ b/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/berichtensessiecache/berichten/MockBerichtenCache.kt
@@ -65,8 +65,9 @@ class MockBerichtenCache : BerichtenCache {
         return Uni.createFrom().item(BerichtenPage(slice, page, pageSize, gefilterd.size.toLong(), totalPages))
     }
 
-    override fun getById(berichtId: UUID): Uni<Bericht?> {
-        return Uni.createFrom().item(byId[berichtId])
+    override fun getById(berichtId: UUID, ontvanger: String): Uni<Bericht?> {
+        val bericht = byId[berichtId]
+        return Uni.createFrom().item(if (bericht?.ontvanger == ontvanger) bericht else null)
     }
 
     override fun getPage(key: String, page: Int, pageSize: Int): Uni<BerichtenPage?> {


### PR DESCRIPTION
## Summary
- `getBerichtById` retourneerde 404 als `_ophalen` nog niet was aangeroepen, terwijl 409 verwacht werd
- `ontvanger` als verplichte query-parameter toegevoegd, consistent met `getBerichten` en `zoekBerichten`
- Aggregation-status check (BEZIG → 409, FOUT → 500) toegevoegd vóór de cache-lookup
- OpenAPI spec bijgewerkt: `ontvanger` parameter, `400` en `409` responses

### PR review verwerkt
- **H1 (Hoog):** `dataSubjectId` is weer `berichtId` (niet `ontvanger`) — herstelt traceerbaarheid
- **M2 (Medium):** 3x gedupliceerde aggregation-status check geëxtraheerd naar `requireGereedStatus()` helper
- **M3 (Medium):** Tests toegevoegd voor BEZIG → 409 en FOUT → 500 op `getBerichtById`
- **L4 (Laag):** `ontvanger`-check verplaatst naar de cache-laag (`getById(berichtId, ontvanger)`) — voorkomt dat berichten van een andere ontvanger opgehaald kunnen worden
- **L5 (Laag):** 3x inline 409-response in OpenAPI vervangen door `$ref: Conflict` component
- Foutmelding reflecteert geen `berichtId` meer naar de client

## Test plan
- [x] `GET /berichten/{id}` zonder `ontvanger` → 400
- [x] `GET /berichten/{id}` vóór `_ophalen` → 409
- [x] `GET /berichten/{id}` tijdens ophalen (BEZIG) → 409
- [x] `GET /berichten/{id}` na mislukt ophalen (FOUT) → 500
- [x] `GET /berichten/{id}` na `_ophalen` met geldig ID → 200
- [x] `GET /berichten/{id}` na `_ophalen` met onbekend ID → 404
- [x] `GET /berichten/{id}` met ontvanger die niet overeenkomt → 404
- [x] Alle 33 tests slagen

🤖 Generated with [Claude Code](https://claude.com/claude-code)