### PR TITLE
Verbeter CLAUDE.md en voeg Claude Code automations toe

### DIFF
--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,0 +1,25 @@
+---
+name: security-reviewer
+description: Review Kotlin/Quarkus code op security-issues (OWASP Top 10, input validatie, cache poisoning)
+---
+
+Je bent een security reviewer voor een Quarkus/Kotlin REST API in een overheidscontext (Federatief Berichtenstelsel).
+
+## Focus
+
+- **Input validatie**: Worden alle REST-parameters gevalideerd via Bean Validation? Zijn er paden waar ongevalideerde input doorkomt?
+- **Injection**: SQL/NoSQL/command injection via REST parameters of headers.
+- **Auth/authz gaps**: Ontbrekende authenticatie of autorisatie op endpoints.
+- **Redis cache poisoning**: Kan een aanvaller cache-keys manipuleren of vervalste data in de cache krijgen?
+- **Information disclosure**: Lekken foutmeldingen interne details (stacktraces, paden, versies)?
+- **OWASP Top 10**: Overige relevante categorieën.
+
+## Rapportage
+
+Rapporteer alleen concrete issues met:
+- **Bestandsnaam en regelnummer**
+- **Ernst**: Hoog / Medium / Laag
+- **Beschrijving**: Wat is het probleem en wat is het risico?
+- **Aanbeveling**: Concrete fix.
+
+Geen false positives of generieke waarschuwingen. Als er geen issues zijn, zeg dat expliciet.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "enabledPlugins": {},
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -q 'services/berichtensessiecache/src/main'; then ./mvnw test -pl services/berichtensessiecache -q 2>&1 | tail -5; fi",
+        "description": "Run tests after editing source files"
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -q 'target/generated-sources'; then echo 'BLOCK: Gegenereerde code mag niet handmatig worden aangepast. Wijzig de OpenAPI spec.' && exit 1; fi",
+        "description": "Block edits to generated OpenAPI sources"
+      }
+    ]
+  }
+}

--- a/.claude/skills/dev-check/SKILL.md
+++ b/.claude/skills/dev-check/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: dev-check
+description: Controleer of de lokale dev-omgeving draait (Redis, WireMock, ClickHouse)
+disable-model-invocation: true
+---
+
+# Dev-omgeving check
+
+Controleer dat alle Docker Compose services beschikbaar zijn voor lokale ontwikkeling.
+
+## Stappen
+
+1. **Check container status**
+   ```bash
+   docker compose ps
+   ```
+   Verwacht: `redis`, `magazijn-a`, `magazijn-b`, `clickhouse` moeten status UP hebben.
+
+2. **Start containers als ze niet draaien**
+   ```bash
+   docker compose up -d
+   ```
+
+3. **Health checks**
+   - Redis: `docker compose exec redis redis-cli ping` → moet `PONG` teruggeven
+   - ClickHouse: `curl -s http://localhost:8123/ping` → moet `Ok.` teruggeven
+   - WireMock A: `curl -s http://localhost:8081/__admin/mappings` → moet JSON teruggeven
+   - WireMock B: `curl -s http://localhost:8082/__admin/mappings` → moet JSON teruggeven
+
+4. **Rapporteer resultaat**
+   Geef een overzicht van welke services draaien en welke niet.

--- a/.claude/skills/openapi-wijziging/SKILL.md
+++ b/.claude/skills/openapi-wijziging/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: openapi-wijziging
+description: Wijzig de OpenAPI spec, genereer code, en pas de Kotlin resource aan
+---
+
+# OpenAPI-wijziging workflow
+
+Bij elke API-wijziging volg je deze stappen in volgorde:
+
+1. **Wijzig de OpenAPI spec**
+   Bewerk `services/berichtensessiecache/src/main/resources/openapi/berichtensessiecache-api.yaml`
+   Dit is de bron van waarheid — alle endpoint-, model- en validatiewijzigingen beginnen hier.
+
+2. **Genereer de interfaces**
+   ```bash
+   ./mvnw compile -pl services/berichtensessiecache
+   ```
+   Controleer dat de gegenereerde interfaces in `target/generated-sources/openapi/` correct zijn.
+   Pas gegenereerde code NOOIT handmatig aan.
+
+3. **Implementeer in Kotlin**
+   Pas de resource-klasse aan zodat deze de nieuwe/gewijzigde interface-methode implementeert.
+   Volg de functionele package-structuur: `berichten/`, `magazijn/`, `notificatie/`.
+
+4. **Tests schrijven**
+   Voeg tests toe voor zowel happy als unhappy paths.
+   ```bash
+   ./mvnw test -pl services/berichtensessiecache
+   ```
+
+5. **Valideer NL API Design Rules**
+   Controleer: `/api/v1` prefix, camelCase JSON, `application/problem+json` fouten, `API-Version` header.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,12 +33,14 @@ Communicatie in het Nederlands. Code en technische termen in het Engels waar gan
 - **GroupId:** `nl.rijksoverheid.moz`
 - **Packages:** `nl.rijksoverheid.moz.berichtensessiecache.*`
 - **Monorepo structuur:** `services/<service-naam>/` als Maven module
+- **Actieve modules:** Alleen `services/berichtensessiecache` is geregistreerd in de parent POM. `services/berichtenlijst/` bestaat als directory maar is niet actief.
 - **Gegenereerde code:** `target/generated-sources/openapi/` — nooit handmatig aanpassen
 - **Tests:** Mock externe clients via `@Mock @ApplicationScoped` CDI beans in test-package
 
 ## Build & test commando's
 
 ```bash
+docker compose up -d                                       # Start Redis, WireMock, ClickHouse
 ./mvnw compile -pl services/berichtensessiecache          # Compileren
 ./mvnw test -pl services/berichtensessiecache              # Tests draaien
 ./mvnw quarkus:dev -pl services/berichtensessiecache       # Dev mode
@@ -46,12 +48,22 @@ Communicatie in het Nederlands. Code en technische termen in het Engels waar gan
 
 ## Belangrijke bestanden
 
-| Pad | Beschrijving |
-|-----|-------------|
-| `pom.xml` | Parent POM (Quarkus BOM, Kotlin plugin config) |
-| `services/berichtensessiecache/pom.xml` | Module POM (OpenAPI generator, dependencies) |
+| Pad                                    | Beschrijving                                                    |
+|----------------------------------------|-----------------------------------------------------------------|
+| `pom.xml`                              | Parent POM (Quarkus BOM, Kotlin plugin config)                  |
+| `services/berichtensessiecache/pom.xml`| Module POM (OpenAPI generator, dependencies)                    |
 | `services/berichtensessiecache/src/main/resources/openapi/berichtensessiecache-api.yaml` | OpenAPI spec (bron van waarheid) |
-| `docs/architecture/` | C4 model (Structurizr DSL) |
+| `docs/architecture/`                   | C4 model (Structurizr DSL)                                      |
+| `compose.yaml`                         | Lokale dev-omgeving (Redis, WireMock, ClickHouse)               |
+| `.github/workflows/`                   | CI: CodeQL security scanning, Scorecard, Architecture validatie |
+| `.github/CODEOWNERS`                   | Code ownership (`@MinBZK/mijnoverheid-zakelijk`)                |
+
+## Omgevingsvariabelen
+
+| Variabele              | Default | Beschrijving                                        |
+|------------------------|---------|-----------------------------------------------------|
+| `CLICKHOUSE_USERNAME`  | `ldv`   | ClickHouse gebruikersnaam (Logboek Dataverwerkingen) |
+| `CLICKHOUSE_PASSWORD`  | `ldv`   | ClickHouse wachtwoord                                |
 
 ## Plannen
 
@@ -60,6 +72,21 @@ Implementatieplannen worden opgeslagen in `docs/plans/` met oplopend nummer:
 - Bevat: context, structuur, stappen, ontwerpkeuzes, verificatie
 - Voeg `**Status:**` toe bovenaan (Concept / Uitgevoerd / Verworpen)
 - Sla elk plan op bij het afronden, zodat beslissingen traceerbaar blijven
+
+## Git-werkwijze
+
+- **Nooit direct pushen naar `main`.** Alle wijzigingen gaan via een feature branch en een Pull Request.
+- Branch naming: `feature/`, `fix/`, `chore/` prefix.
+
+## Teststrategie
+
+Bij elke codewijziging beoordelen of er tests toegevoegd of aangepast moeten worden:
+
+- **Happy én unhappy paths:** Niet alleen het successcenario, maar ook foutgevallen, edge cases en validatiefouten.
+- **Unit tests** zijn de basis (JUnit 5 + REST-assured).
+- **Integratietests** (`@QuarkusTest`) wanneer de wijziging meerdere componenten raakt of externe afhankelijkheden (Redis, REST-clients) betreft.
+- **Fuzzing / property-based tests** overwegen bij input-parsing, validatielogica of security-gevoelige code.
+- Als integratietests of fuzzing een grote toevoeging vormen, dit eerst voorleggen aan de gebruiker voordat je begint.
 
 ## Review-aanpak
 


### PR DESCRIPTION
## Summary

- **CLAUDE.md verbeterd**: git-werkwijze (nooit direct naar main, altijd PR), teststrategie (happy/unhappy paths, integratie- en fuzzing-tests), Docker Compose instructie, omgevingsvariabelen, CI/CD workflows en CODEOWNERS gedocumenteerd, orphaned `berichtenlijst`-module benoemd
- **Hooks**: auto-test na broncode-edits, blokkeer edits aan gegenereerde OpenAPI code
- **Skills**: `openapi-wijziging` (spec → genereer → implementeer → test workflow), `dev-check` (Docker Compose health check)
- **Subagent**: `security-reviewer` voor OWASP Top 10, input validatie en Redis cache poisoning

## Test plan

- [ ] Controleer dat CLAUDE.md correct rendert op GitHub
- [ ] Verifieer dat `settings.local.json` NIET is meegecommit
- [ ] Test hook: edit een bronbestand en controleer dat tests automatisch draaien
- [ ] Test hook: probeer een bestand in `target/generated-sources/` te editen — moet geblokkeerd worden
- [ ] Test skill: `/dev-check` uitvoeren met en zonder draaiende containers
- [ ] MCP servers (context7, github-mcp) worden apart lokaal geconfigureerd en zijn niet in deze PR opgenomen

🤖 Generated with [Claude Code](https://claude.com/claude-code)