### PR TITLE
Vervang blacklist door whitelist voor RediSearch escaping

### DIFF
--- a/services/berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/berichtensessiecache/berichten/BerichtenCache.kt
+++ b/services/berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/berichtensessiecache/berichten/BerichtenCache.kt
@@ -222,13 +222,13 @@ class RedisBerichtenCache(
         private fun statusKey(key: String) = "$key:status"
         private fun lockKey(key: String) = "$key:lock"
 
-        // Escape speciale tekens voor RediSearch full-text queries
-        internal val SEARCH_SPECIAL = Regex("""[,.<>{}\[\]"':;!@#$%^&*()\-+=~\\/|? ]""")
+        // Escape niet-alfanumerieke tekens voor RediSearch full-text queries (whitelist-benadering)
+        internal val SEARCH_SPECIAL = Regex("[^a-zA-Z0-9]")
         internal fun escapeRedisSearch(text: String): String =
             text.replace(SEARCH_SPECIAL) { "\\${it.value}" }
 
-        // Escape speciale tekens voor RediSearch TAG filter-waarden
-        internal val TAG_SPECIAL = Regex("""[,.<>{}\[\]"':;!@#$%^&*()\-+=~\\/|? ]""")
+        // Escape niet-alfanumerieke tekens voor RediSearch TAG filter-waarden (whitelist-benadering)
+        internal val TAG_SPECIAL = Regex("[^a-zA-Z0-9]")
         internal fun escapeTag(value: String): String =
             value.replace(TAG_SPECIAL) { "\\${it.value}" }
     }


### PR DESCRIPTION
## Summary
- Vervangt de blacklist-regex (`[speciale tekens]`) door een whitelist-regex (`[^a-zA-Z0-9]`) in `escapeRedisSearch()` en `escapeTag()`
- Alle niet-alfanumerieke tekens worden nu automatisch ge-escaped, conform OWASP allowlist-aanbeveling
- Toekomstbestendig: nieuwe RediSearch-operators worden automatisch opgevangen zonder handmatige regex-aanpassing

Closes #15

## Test plan
- [x] Bestaande 16 `RedisSearchEscapeTest` tests slagen ongewijzigd
- [ ] Verify in dev mode met Redis dat queries correct blijven werken

🤖 Generated with [Claude Code](https://claude.com/claude-code)