### PR TITLE
Verwijder CODEOWNERS om auto-review-request op PR's te voorkomen

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @MinBZK/mijnoverheid-zakelijk


### PR DESCRIPTION
## Samenvatting

Verwijdert `.github/CODEOWNERS` (alleen regel: `* @MinBZK/mijnoverheid-zakelijk`). Elke PR kreeg daardoor automatisch het hele team als reviewer aangewezen — ook op triviale of work-in-progress PR's die geen team-review nodig hebben. De mail/notificatie ging naar iedereen in het team zodra de PR opende; achteraf de reviewer verwijderen is te laat want de notificatie is dan al uit.

## Impact

`main`-branch-protection heeft `require_code_owner_reviews=false` en vereist 1 approving review (ongeacht wie). Geen merge-gevolgen:

```
$ gh api repos/MinBZK/moza-poc-fbs-berichtenbox/branches/main/protection --jq .required_pull_request_reviews.require_code_owner_reviews
false
```

Wie specifiek een team-review wil kan die per PR handmatig aanvragen (via de GitHub-UI of `gh pr edit --add-reviewer`).

## Draft

Deze PR is als draft aangemaakt zodat het aanmaken zelf nog geen laatste auto-request richting het team triggert. Markeer als "Ready for review" zodra de wijziging gereviewd en gemerged mag worden.

## Test plan

- [x] Branch-protection vereist geen code-owner-reviews (geverifieerd via API)
- [ ] Na merge: open een test-PR en controleer dat `reviewRequests` leeg blijft

🤖 Generated with [Claude Code](https://claude.com/claude-code)