### PR TITLE
LDV endpoint fail-fast in prod: TLS-eis afdwingen bij boot

### DIFF
--- a/services/berichtenmagazijn/src/main/kotlin/nl/rijksoverheid/moz/berichtenmagazijn/LdvEndpointValidator.kt
+++ b/services/berichtenmagazijn/src/main/kotlin/nl/rijksoverheid/moz/berichtenmagazijn/LdvEndpointValidator.kt
@@ -1,0 +1,32 @@
+package nl.rijksoverheid.moz.berichtenmagazijn
+
+import io.quarkus.runtime.StartupEvent
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
+import org.eclipse.microprofile.config.inject.ConfigProperty
+
+@ApplicationScoped
+class LdvEndpointValidator {
+
+    @ConfigProperty(name = "logboekdataverwerking.clickhouse.endpoint")
+    lateinit var endpoint: String
+
+    @ConfigProperty(name = "quarkus.profile")
+    lateinit var profile: String
+
+    fun onStartup(@Observes event: StartupEvent) {
+        validate(profile, endpoint)
+    }
+
+    companion object {
+        private val PROFIELEN_ZONDER_TLS_EIS = setOf("dev", "test")
+
+        fun validate(profile: String, endpoint: String) {
+            if (profile in PROFIELEN_ZONDER_TLS_EIS) return
+            require(endpoint.startsWith("https://")) {
+                "logboekdataverwerking.clickhouse.endpoint MOET https:// gebruiken in profiel '$profile' " +
+                    "(BIO 13.2.1: persoonsgegevens versleuteld over netwerk). Huidige waarde: '$endpoint'"
+            }
+        }
+    }
+}

--- a/services/berichtenmagazijn/src/main/resources/application.properties
+++ b/services/berichtenmagazijn/src/main/resources/application.properties
@@ -31,19 +31,24 @@ quarkus.hibernate-orm.log.sql=false
 quarkus.fault-tolerance.enabled=true
 
 # Logboek Dataverwerkingen (AVG Art. 30) — geen fallback-defaults voor credentials
-# zodat de service faalt te starten als env-vars ontbreken; anders draait LDV stilletjes
-# op bekende defaults.
+# en endpoint, zodat de service faalt te starten als env-vars ontbreken; anders draait
+# LDV stilletjes op bekende defaults of (erger) een onversleuteld endpoint.
 logboekdataverwerking.enabled=true
 logboekdataverwerking.service-name=berichtenmagazijn
-logboekdataverwerking.clickhouse.endpoint=http://localhost:8123
+logboekdataverwerking.clickhouse.endpoint=${LDV_CLICKHOUSE_ENDPOINT}
 logboekdataverwerking.clickhouse.username=${CLICKHOUSE_USERNAME}
 logboekdataverwerking.clickhouse.password=${CLICKHOUSE_PASSWORD}
 logboekdataverwerking.clickhouse.database=ldv_logging
 logboekdataverwerking.clickhouse.table=logboek_dataverwerkingen
 
-# Voor dev/test: veilige default-credentials zodat lokaal draaien zonder env-vars werkt.
+# Voor dev/test: veilige defaults zodat lokaal draaien zonder env-vars werkt.
+# In %prod blijft de basisproperty `${LDV_CLICKHOUSE_ENDPOINT}` zonder default; operators
+# MOETEN een TLS-endpoint (https://) zetten conform BIO 13.2.1 (persoonsgegevens
+# versleuteld over netwerk).
+%dev.logboekdataverwerking.clickhouse.endpoint=http://localhost:8123
 %dev.logboekdataverwerking.clickhouse.username=ldv
 %dev.logboekdataverwerking.clickhouse.password=ldv
+%test.logboekdataverwerking.clickhouse.endpoint=http://localhost:8123
 %test.logboekdataverwerking.clickhouse.username=ldv
 %test.logboekdataverwerking.clickhouse.password=ldv
 

--- a/services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/berichtenmagazijn/LdvEndpointValidatorTest.kt
+++ b/services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/berichtenmagazijn/LdvEndpointValidatorTest.kt
@@ -1,0 +1,52 @@
+package nl.rijksoverheid.moz.berichtenmagazijn
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+
+class LdvEndpointValidatorTest {
+
+    @Test
+    fun `dev-profiel laat http-endpoint toe`() {
+        assertDoesNotThrow { LdvEndpointValidator.validate("dev", "http://localhost:8123") }
+    }
+
+    @Test
+    fun `test-profiel laat http-endpoint toe`() {
+        assertDoesNotThrow { LdvEndpointValidator.validate("test", "http://localhost:8123") }
+    }
+
+    @Test
+    fun `prod-profiel met http-endpoint faalt fail-fast`() {
+        val ex = assertThrows<IllegalArgumentException> {
+            LdvEndpointValidator.validate("prod", "http://insecure:8123")
+        }
+        assertTrue(ex.message!!.contains("BIO 13.2.1"), "foutmelding moet naar BIO 13.2.1 verwijzen")
+        assertTrue(ex.message!!.contains("https://"), "foutmelding moet https:// noemen")
+        assertTrue(
+            ex.message!!.contains("http://insecure:8123"),
+            "foutmelding moet de huidige (foutieve) waarde tonen voor diagnose",
+        )
+    }
+
+    @Test
+    fun `prod-profiel met https-endpoint slaagt`() {
+        assertDoesNotThrow { LdvEndpointValidator.validate("prod", "https://clickhouse.intern:8443") }
+    }
+
+    @Test
+    fun `niet-dev-test profielen vallen onder de TLS-eis`() {
+        assertThrows<IllegalArgumentException> {
+            LdvEndpointValidator.validate("staging", "http://x:8123")
+        }
+        assertThrows<IllegalArgumentException> {
+            LdvEndpointValidator.validate("acceptatie", "http://x:8123")
+        }
+    }
+
+    @Test
+    fun `lege endpoint-waarde faalt buiten dev-test`() {
+        assertThrows<IllegalArgumentException> { LdvEndpointValidator.validate("prod", "") }
+    }
+}


### PR DESCRIPTION
## Samenvatting

Pakt **stap B** op uit `docs/plans/2026-04-23-berichtenmagazijn-review-fixes-restant.md` (oorspronkelijke bevinding 3 uit het review-fixes-plan).

In productie MOET het ClickHouse-endpoint van Logboek Dataverwerkingen versleuteld zijn (BIO 13.2.1: persoonsgegevens versleuteld over netwerk). Voorheen had `logboekdataverwerking.clickhouse.endpoint` een hardcoded `http://localhost:8123`-default — een prod-deploy zonder override draaide stilletjes onversleuteld.

## Twee lagen verdediging

1. **`application.properties`** — geen hardcoded fallback meer voor het endpoint. In `%prod` resolveert SmallRye `${LDV_CLICKHOUSE_ENDPOINT}` zonder default, wat de boot al breekt als de env-var ontbreekt. Dev/test krijgen expliciet `http://localhost:8123` zodat lokaal draaien blijft werken.
2. **`LdvEndpointValidator`** — Quarkus `StartupEvent`-observer die in elk profiel buiten dev/test eist dat het endpoint met `https://` begint. Dekt het geval waarin een operator wél een endpoint zet maar (per ongeluk) http.

## Test plan

- [x] `./mvnw -B clean test -pl services/berichtenmagazijn -am` — 83 tests groen, JaCoCo ≥ 90%.
- [x] Prod zonder env-vars: `./mvnw quarkus:dev -Dquarkus.profile=prod` → SmallRye Config faalt op `${LDV_CLICKHOUSE_ENDPOINT}`-resolve.
- [x] Prod met http-endpoint: `…-DLDV_CLICKHOUSE_ENDPOINT=http://insecure:8123 …` → `IllegalArgumentException: logboekdataverwerking.clickhouse.endpoint MOET https:// gebruiken in profiel 'prod' (BIO 13.2.1: persoonsgegevens versleuteld over netwerk). Huidige waarde: 'http://insecure:8123'`.
- [x] Prod met https-endpoint: `…-DLDV_CLICKHOUSE_ENDPOINT=https://clickhouse.intern:8443 …` → boot slaagt.

## Stack-volgorde

Base = `feature/berichtenmagazijn-aanlever-api` (PR #31), parallel aan PR #36 (log-hygiëne, stap A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)