### PR TITLE
chore: voeg Maven en docker-compose toe aan Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,15 @@
 
 version: 2
 updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "docker-compose"
+    directory: "/"
+    schedule:
+      interval: "monthly"
   - package-ecosystem: "github-actions"
-    directory: /
+    directory: "/"
     schedule:
       interval: "monthly"


### PR DESCRIPTION
## Samenvatting
- Dependabot checkte tot nu toe alleen `github-actions`. Maven dependencies in de monorepo en images in `compose.yaml` werden niet automatisch bijgehouden.
- Toegevoegd naar voorbeeld van `moza-profiel-service`:
  - `maven` op `/` — parent POM dekt alle modules (`berichtensessiecache`, `berichtenmagazijn`, `fbs-common`)
  - `docker-compose` op `/` — voor de Redis/WireMock/ClickHouse images in `compose.yaml`
- Alle ecosystems blijven op `interval: monthly`.

Niet overgenomen: `docker` op `/src/main/docker` uit de profiel-service config — dat pad bestaat niet in deze repo. De enige Dockerfile (`.clusterfuzzlite/Dockerfile`) is voor fuzzing-tooling, geen applicatie-image.

## Test plan
- [ ] CI groen op deze PR
- [ ] Na merge: controleer in GitHub → Insights → Dependency graph → Dependabot dat de drie ecosystems verschijnen
- [ ] Wachten op eerste maandelijkse run om te bevestigen dat Maven- en docker-compose-PR's worden geopend

🤖 Generated with [Claude Code](https://claude.com/claude-code)