### PR TITLE
docs: review-scope nuanceren — non-testcode reviewen, tests beproeven

### DIFF
--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -4,7 +4,8 @@ Dit project is een **experimentele Proof of Concept (PoC)** voor de Berichtenbox
 binnen het Federatief Berichtenstelsel (FBS). De code is **grotendeels
 gegenereerd met generatieve AI** (Claude Code, Anthropic). Alle **niet-testcode**
 wordt **menselijk gereviewd** voordat die in de hoofdbranch wordt opgenomen;
-testcode wordt functioneel beproefd in plaats van regel voor regel gereviewd.
+testcode wordt niet regel voor regel gereviewd, maar de werking van het geheel
+wordt functioneel beproefd.
 
 ## Geen officiële dienst
 
@@ -17,7 +18,8 @@ rechten worden ontleend.
 Bijdragen die met behulp van generatieve AI tot stand zijn gekomen, zijn
 gemarkeerd via de commit-trailer `Co-Authored-By`. Niet-testcode is door
 ontwikkelaars beoordeeld via de pull-request-workflow voordat die is gemerged;
-testcode wordt functioneel beproefd in plaats van regel voor regel gereviewd.
+testcode is niet regel voor regel gereviewd, maar de werking van het geheel is
+functioneel beproefd.
 
 ## Gebruik van generatieve AI
 

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -2,8 +2,9 @@
 
 Dit project is een **experimentele Proof of Concept (PoC)** voor de Berichtenbox
 binnen het Federatief Berichtenstelsel (FBS). De code is **grotendeels
-gegenereerd met generatieve AI** (Claude Code, Anthropic) en **volledig
-menselijk gereviewd** voordat die in de hoofdbranch is opgenomen.
+gegenereerd met generatieve AI** (Claude Code, Anthropic). Alle **niet-testcode**
+wordt **menselijk gereviewd** voordat die in de hoofdbranch wordt opgenomen;
+testcode wordt functioneel beproefd in plaats van regel voor regel gereviewd.
 
 ## Geen officiële dienst
 
@@ -14,8 +15,9 @@ rechten worden ontleend.
 ## Met AI gegenereerde bijdragen zijn herkenbaar
 
 Bijdragen die met behulp van generatieve AI tot stand zijn gekomen, zijn
-gemarkeerd via de commit-trailer `Co-Authored-By`. Elke bijdrage is door
-ontwikkelaars beoordeeld via de pull-request-workflow voordat die is gemerged.
+gemarkeerd via de commit-trailer `Co-Authored-By`. Niet-testcode is door
+ontwikkelaars beoordeeld via de pull-request-workflow voordat die is gemerged;
+testcode wordt functioneel beproefd in plaats van regel voor regel gereviewd.
 
 ## Gebruik van generatieve AI
 

--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ Dit project is gelicenseerd onder de [EUPL-1.2](LICENSE).
 
 ## AI-verantwoording
 
-De code in deze PoC is grotendeels gegenereerd met generatieve AI (Claude Code)
-en volledig menselijk gereviewd. Zie [DISCLAIMER.md](DISCLAIMER.md) voor de
+De code in deze PoC is grotendeels gegenereerd met generatieve AI (Claude Code);
+alle niet-testcode wordt menselijk gereviewd en testcode wordt functioneel
+beproefd. Zie [DISCLAIMER.md](DISCLAIMER.md) voor de
 disclaimer en [docs/ai-verantwoording.md](docs/ai-verantwoording.md) voor de
 volledige verantwoording, getoetst aan de Overheidsbrede handreiking voor de
 verantwoorde inzet van generatieve AI.

--- a/docs/ai-verantwoording.md
+++ b/docs/ai-verantwoording.md
@@ -86,7 +86,8 @@ Concrete governance-maatregelen:
 - Met AI gegenereerde bijdragen zijn herkenbaar gemarkeerd via de commit-trailer
   `Co-Authored-By`.
 - Niet-testcode wordt menselijk gereviewd via de pull-request-workflow vóór
-  merge; testcode wordt functioneel beproefd (zie "Menselijke review" hierboven).
+  merge; de werking van het geheel wordt functioneel beproefd (zie "Menselijke
+  review" hierboven).
 - Voor maximale transparantie is de repository openbaar en onder een open
   licentie ([EUPL-1.2](../LICENSE)); reageren kan via GitHub-issues.
 

--- a/docs/ai-verantwoording.md
+++ b/docs/ai-verantwoording.md
@@ -17,11 +17,20 @@ Claude Code (Anthropic). AI is ingezet voor codegeneratie en voor ondersteuning
 bij refactoring en review. Architectuur- en ontwerpbeslissingen zijn vastgelegd
 in [`docs/plans/`](plans/).
 
-**Menselijke review.** Alle met AI gegenereerde bijdragen worden volledig door
-ontwikkelaars beoordeeld voordat ze worden opgenomen in de hoofdbranch. Dit
-gebeurt via de pull-request-workflow met code-eigenaarschap (`CODEOWNERS`) en een
-CI-pijplijn met onder andere CodeQL-securityscanning en OpenSSF Scorecard. De
-mens blijft eindverantwoordelijk; de AI is een hulpmiddel.
+**Menselijke review.** De review richt zich op de onderdelen die het gedrag en de
+kwaliteit van de PoC bepalen: de OpenAPI-specificaties en het ontwerp (het
+C4-model en de plannen in [`docs/plans/`](plans/)) worden inhoudelijk beoordeeld,
+en alle niet-testcode wordt door ontwikkelaars gereviewd voordat die in de
+hoofdbranch wordt opgenomen. Testcode wordt niet regel voor regel gereviewd; de
+werking wordt in plaats daarvan functioneel beproefd (met Bruno-requests en een
+demo-applicatie). Dit gebeurt via de pull-request-workflow met code-eigenaarschap
+(`CODEOWNERS`) en een CI-pijplijn met onder andere CodeQL-securityscanning en
+OpenSSF Scorecard. De mens blijft eindverantwoordelijk; de AI is een hulpmiddel.
+
+Deze afbakening is een bewust onderdeel van de beproeving: we onderzoeken hoeveel
+en hoe nauwkeurig menselijke review nodig én haalbaar is. De aanname die we
+daarbij toetsen, is dat codegeneratie door de OpenAPI-tooling correct verloopt en
+dat de AI met voldoende review-stappen code van voldoende kwaliteit oplevert.
 
 **Gegevens.** De PoC verwerkt geen persoonsgegevens. Er wordt uitsluitend
 gewerkt met fictieve en testgegevens.
@@ -76,8 +85,8 @@ Concrete governance-maatregelen:
 
 - Met AI gegenereerde bijdragen zijn herkenbaar gemarkeerd via de commit-trailer
   `Co-Authored-By`.
-- Alle bijdragen worden volledig menselijk gereviewd via de
-  pull-request-workflow vóór merge.
+- Niet-testcode wordt menselijk gereviewd via de pull-request-workflow vóór
+  merge; testcode wordt functioneel beproefd (zie "Menselijke review" hierboven).
 - Voor maximale transparantie is de repository openbaar en onder een open
   licentie ([EUPL-1.2](../LICENSE)); reageren kan via GitHub-issues.
 
@@ -130,10 +139,10 @@ en richtlijnen. AI is slechts een hulpmiddel.
 
 #### f. Kwaliteitsrisico: onjuiste of onveilige gegenereerde code
 
-De kwaliteit wordt op meerdere niveaus geborgd: volledige menselijke
-code-review, een teststrategie met onder meer ≥90% line coverage (JaCoCo), een
-spec-driven OpenAPI-first-aanpak (compilatie faalt bij afwijking van de spec) en
-geautomatiseerde CI-controles.
+De kwaliteit wordt op meerdere niveaus geborgd: menselijke review van de
+niet-testcode (zie "Menselijke review" hierboven), een teststrategie met onder
+meer ≥90% line coverage (JaCoCo), een spec-driven OpenAPI-first-aanpak
+(compilatie faalt bij afwijking van de spec) en geautomatiseerde CI-controles.
 
 #### g. Auteursrecht op brondocumenten als input
 


### PR DESCRIPTION
## Waarom

Voortschrijdend inzicht uit overleg (Eric ↔ Mark): we reviewen testcode niet regel voor regel. De huidige verantwoording claimde dat **alle** bijdragen volledig menselijk gereviewd worden — dat is te breed en niet wat we feitelijk doen.

## Wat we wél doen

- OpenAPI-spec en ontwerp (C4-model, plannen) inhoudelijk reviewen
- Alle **niet-testcode** reviewen vóór merge
- Testcode **functioneel beproeven** (Bruno-requests, straks demo-applicatie) i.p.v. line-by-line review

Dit is een bewust onderdeel van onze beproeving van AI: hoeveel en hoe nauwkeurig menselijke review is nodig én haalbaar. De getoetste aanname — codegeneratie via OpenAPI-tooling verloopt correct en AI levert met voldoende review-stappen code van voldoende kwaliteit — is nu expliciet opgenomen.

## Wijzigingen

- `DISCLAIMER.md` — twee claims genuanceerd
- `README.md` — AI-verantwoording-paragraaf genuanceerd
- `docs/ai-verantwoording.md` — "Menselijke review" herschreven met review-scope + getoetste aanname; governance-bullet en kwaliteitsrisico #f consistent gemaakt

Alleen documentatie; geen codewijziging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)