### PR TITLE
test(magazijn): CASCADE-regressietest + planNieuwe-invariant (#56 follow-up)

### DIFF
--- a/services/berichtenmagazijn/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/PublicatieClaimVerwerker.kt
+++ b/services/berichtenmagazijn/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/PublicatieClaimVerwerker.kt
@@ -86,8 +86,10 @@ class PublicatieClaimVerwerker(
         try {
             val bericht = berichten.findByBerichtId(claim.berichtId)
             if (bericht == null) {
-                // Bericht weg tussen plan en verwerking. CASCADE op bericht_db_id maakt dit in
-                // praktijk onbereikbaar; vangnet voor handmatige DB-mutaties/soft-delete.
+                // Bericht weg tussen plan en verwerking. Een hard-delete neemt via
+                // CASCADE op bericht_db_id ook de delivery-rij mee, dus die orphan-claim
+                // is onbereikbaar. Het live pad hierheen is soft-delete: findByBerichtId
+                // filtert verwijderdOp IS NULL, terwijl de delivery-rij blijft bestaan.
                 // dataSubject = berichtId (ontvanger ontbreekt) zodat het LDV-record
                 // auditbaar blijft zonder lege subject-velden.
                 ldvContext.dataSubjectId = claim.berichtId.toString()

--- a/services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/PublicatieDeliveryRepositoryTest.kt
+++ b/services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/PublicatieDeliveryRepositoryTest.kt
@@ -1,0 +1,41 @@
+package nl.rijksoverheid.moz.fbs.berichtenmagazijn.publicatie
+
+import io.mockk.every
+import io.mockk.mockk
+import nl.rijksoverheid.moz.fbs.berichtenmagazijn.opslag.BerichtRepository
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Borgt dat [PublicatieDeliveryRepository.planNieuwe] luid faalt als het parent-bericht
+ * ontbreekt — geen stille no-op die een phantom-delivery (zonder parent) zou verbergen.
+ * Pure unit test: de [IllegalStateException] valt vóór `persist()`, dus geen CDI/EM nodig.
+ */
+class PublicatieDeliveryRepositoryTest {
+
+    private val berichtRepository = mockk<BerichtRepository>()
+    private val repository = PublicatieDeliveryRepository(berichtRepository)
+
+    @Test
+    fun `planNieuwe gooit ISE met berichtId wanneer parent-bericht ontbreekt`() {
+        val berichtId = UUID.randomUUID()
+        every { berichtRepository.findEntityByBerichtId(berichtId) } returns null
+        val nu = Instant.parse("2026-05-12T10:00:00Z")
+
+        val ex = assertThrows(IllegalStateException::class.java) {
+            repository.planNieuwe(
+                berichtId = berichtId,
+                doel = Publicatiedoel("aanmeld"),
+                volgendePoging = nu,
+                aangemaaktOp = nu,
+            )
+        }
+        assertTrue(
+            ex.message?.contains(berichtId.toString()) == true,
+            "fout-message moet berichtId noemen voor correlatie, kreeg: ${ex.message}",
+        )
+    }
+}

--- a/services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/PublicatieOutboxIntegrationTest.kt
+++ b/services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/PublicatieOutboxIntegrationTest.kt
@@ -90,6 +90,40 @@ class PublicatieOutboxIntegrationTest {
         assertTrue(rijen.all { it.volgendePoging == toekomst })
     }
 
+    @Test
+    @Transactional
+    fun `hard-delete van bericht cascade-verwijdert de delivery-rijen`() {
+        // Borgt de load-bearing ON DELETE CASCADE: de retentie-job (HardDeleteTransactionalOps)
+        // ruimt bijlagen/status expliciet op maar NIET de deliveries — die verdwijnen alleen
+        // via de FK-CASCADE. Een regressie naar RESTRICT zou hard-delete laten falen voor elk
+        // bericht met (terminale) delivery-rijen.
+        val tijdstip = Instant.parse("2026-05-12T10:00:00Z")
+        val bericht = Bericht(
+            berichtId = UUID.randomUUID(),
+            afzender = Oin("00000001003214345000"),
+            ontvanger = Bsn("999993653"),
+            onderwerp = "Cascade",
+            inhoud = "Inhoud",
+            tijdstipOntvangst = tijdstip,
+            publicatiedatum = tijdstip,
+        )
+        berichten.save(bericht)
+        outbox.planDeliveries(bericht.berichtId, tijdstip)
+        val dbId = berichten.findDbIdByBerichtId(bericht.berichtId)
+            ?: error("db-id niet gevonden voor zojuist opgeslagen bericht")
+        assertTrue(
+            deliveries.findByBerichtId(bericht.berichtId).isNotEmpty(),
+            "voorwaarde: er moeten delivery-rijen gepland zijn",
+        )
+
+        berichten.hardDeleteByDbId(dbId)
+
+        assertTrue(
+            deliveries.findByBerichtId(bericht.berichtId).isEmpty(),
+            "ON DELETE CASCADE moet de delivery-rijen meenemen bij hard-delete van het bericht",
+        )
+    }
+
     class TweeDownstreamsProfile : QuarkusTestProfile {
         override fun getConfigOverrides(): Map<String, String> = mapOf(
             "magazijn.publicatie.downstreams.aanmeld.url" to "http://localhost:1/events",


### PR DESCRIPTION
Volgt op de squash-merge van #56: die nam de FK-fix (`bericht_db_id` → `berichten.id`) mee, maar niet de review-fix-commit die er net na kwam. Deze PR brengt die wijzigingen alsnog op `main`.

## Wat
- **`PublicatieDeliveryRepositoryTest`** (nieuw): `planNieuwe` gooit `IllegalStateException` (met `berichtId`) als het parent-bericht ontbreekt — borgt de no-phantom-delivery-invariant. Pure unit test (throw vóór `persist()`).
- **`PublicatieOutboxIntegrationTest`**: hard-delete van een bericht cascade-verwijdert de delivery-rijen. Borgt het **load-bearing** `ON DELETE CASCADE` waar de retentie-job op leunt — `HardDeleteTransactionalOps.deleteOne` ruimt `bijlagen`/`status` expliciet op maar **niet** `publicatie_deliveries`. Een regressie naar RESTRICT zou hard-delete laten falen voor elk bericht met (terminale) delivery-rijen.
- **`PublicatieClaimVerwerker`**: comment gecorrigeerd — CASCADE dekt het hard-delete-pad; het live null-pad is soft-delete (`findByBerichtId` filtert `verwijderdOp IS NULL`).

Geen productie-logica gewijzigd: 2 tests + 1 comment.

## Test
`mvn clean test -pl services/berichtenmagazijn -am` (Testcontainers): groen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)