### PR TITLE
feat(sessiecache): magazijn-fetch- en robuustheids-hardening (gestackt op #66)

### DIFF
--- a/services/berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtensessiecacheService.kt
+++ b/services/berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtensessiecacheService.kt
@@ -41,8 +41,8 @@ class BerichtensessiecacheService(
     // grootte van de inkomende magazijn-respons wordt alleen begrensd door de read-timeout
     // (leesduur, niet bytes). Een harde outbound byte-cap is bewust niet toegevoegd: magazijn-
     // URLs komen uit eigen, TLS-bewaakte config (geen attacker-endpoints) en realistische
-    // responses zijn enkele KB — conform CLAUDE.md geen speculatieve payload-cap zonder
-    // concrete productieaanleiding. Niet stilzwijgend verhogen zonder load-evidence.
+    // responses zijn enkele KB — geen speculatieve payload-cap zonder concrete
+    // productieaanleiding. Niet stilzwijgend verhogen zonder load-evidence.
     @param:ConfigProperty(name = "berichtensessiecache.max-berichten-per-magazijn", defaultValue = "200")
     private val maxBerichtenPerMagazijn: Int,
     // Per-magazijn query-timeout (Mutiny `ifNoItem`): primaire TIMEOUT-signaalbron richting
@@ -62,8 +62,9 @@ class BerichtensessiecacheService(
     )
     private val magazijnReadTimeoutMs: Long,
     // Max blocking-await op één Redis-commando vanaf de @Blocking worker-thread tijdens
-    // ophaal-orkestratie (lock-acquire, status-updates, cleanup); overschrijding → 503.
-    // Losse knop: geen invariant met de magazijn-/profiel-timeouts, dus geen kruisvalidatie.
+    // ophaal-orkestratie (lock-acquire, status-updates, cleanup). Een overschreden await-deadline
+    // faalt de lopende ophaalstap (await-timeout → 503; het cleanup-pad slikt de fout en leunt
+    // op de Redis-TTL). Losse knop: geen invariant met de magazijn-/profiel-timeouts.
     @param:ConfigProperty(name = "berichtensessiecache.cache-await-timeout-seconds", defaultValue = "5")
     private val cacheAwaitTimeoutSeconds: Long,
 ) {
@@ -86,6 +87,22 @@ class BerichtensessiecacheService(
         require(magazijnReadTimeoutMs > magazijnQueryTimeoutSeconds * 1000) {
             "magazijn-client.read-timeout-ms ($magazijnReadTimeoutMs) moet groter zijn dan " +
                 "berichtensessiecache.magazijn-query-timeout-seconds × 1000 (${magazijnQueryTimeoutSeconds * 1000})"
+        }
+
+        // Ondergrens: een 0/negatieve timeout schakelt de bescherming stil uit. Mutiny's
+        // `await().atMost(ZERO)` wacht onbegrensd (blokkeert de @Blocking thread tot de TTL,
+        // 409 voor de hele sessie) en `ifNoItem().after(ZERO)` vuurt direct. De ordening-checks
+        // hierboven borgen outer>inner>0 en read>query>0 transitief; cache-await staat los.
+        require(innerTimeoutSeconds > 0) {
+            "profiel.resolver.inner-timeout-seconds ($innerTimeoutSeconds) moet groter zijn dan 0"
+        }
+
+        require(magazijnQueryTimeoutSeconds > 0) {
+            "berichtensessiecache.magazijn-query-timeout-seconds ($magazijnQueryTimeoutSeconds) moet groter zijn dan 0"
+        }
+
+        require(cacheAwaitTimeoutSeconds > 0) {
+            "berichtensessiecache.cache-await-timeout-seconds ($cacheAwaitTimeoutSeconds) moet groter zijn dan 0"
         }
 
         log.infof(

--- a/services/berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtensessiecacheService.kt
+++ b/services/berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtensessiecacheService.kt
@@ -1,22 +1,28 @@
 package nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten
 
+import com.fasterxml.jackson.core.JsonProcessingException
 import io.smallrye.mutiny.Multi
+import io.smallrye.mutiny.TimeoutException
 import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.infrastructure.Infrastructure
 import jakarta.annotation.PostConstruct
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.ProcessingException
 import jakarta.ws.rs.WebApplicationException
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.MagazijnClient
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.MagazijnClientFactory
+import nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.MagazijnFault
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.MagazijnResolver
+import nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.MagazijnResponseOverflow
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.MagazijnResult
 import nl.rijksoverheid.moz.fbs.common.identificatie.Identificatienummer
 import nl.rijksoverheid.moz.fbs.common.profiel.ProfielServiceFoutException
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
+import java.net.ConnectException
 import java.time.Duration
+import java.util.Collections
 import java.util.UUID
-import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
 
 @ApplicationScoped
@@ -28,26 +34,72 @@ class BerichtensessiecacheService(
     private val innerTimeoutSeconds: Long,
     @param:ConfigProperty(name = "profiel.resolver.outer-await-seconds", defaultValue = "25")
     private val outerAwaitSeconds: Long,
+    // Heap-bescherming tegen een rogue/defect magazijn: cap op het AANTAL berichten, toegepast
+    // ná deserialisatie (begrenst de cache-groei + verdere verwerking). LET OP: dit is GEEN
+    // byte-cap vóór deserialisatie — `quarkus.http.limits.max-body-size` geldt enkel voor
+    // INKOMENDE requests naar deze service, niet voor deze outbound magazijn-respons. De
+    // grootte van de inkomende magazijn-respons wordt alleen begrensd door de read-timeout
+    // (leesduur, niet bytes). Een harde outbound byte-cap is bewust niet toegevoegd: magazijn-
+    // URLs komen uit eigen, TLS-bewaakte config (geen attacker-endpoints) en realistische
+    // responses zijn enkele KB — conform CLAUDE.md geen speculatieve payload-cap zonder
+    // concrete productieaanleiding. Niet stilzwijgend verhogen zonder load-evidence.
+    @param:ConfigProperty(name = "berichtensessiecache.max-berichten-per-magazijn", defaultValue = "200")
+    private val maxBerichtenPerMagazijn: Int,
+    // Per-magazijn query-timeout (Mutiny `ifNoItem`): primaire TIMEOUT-signaalbron richting
+    // de client. MOET kleiner zijn dan magazijn-client.read-timeout-ms zodat dit als eerste
+    // aanslaat en een TIMEOUT-event oplevert i.p.v. een ruwe client-fout. valideerTimeouts()
+    // dwingt die invariant bij startup af.
+    @param:ConfigProperty(name = "berichtensessiecache.magazijn-query-timeout-seconds", defaultValue = "10")
+    private val magazijnQueryTimeoutSeconds: Long,
+    // Read-timeout van de magazijn-client; MagazijnClientFactory past dezelfde property toe als
+    // socket-timeout. Hier enkel geïnjecteerd om de invariant read-timeout > query-timeout bij
+    // startup te kruisvalideren. Sleutel + default komen uit één gedeelde constante
+    // (MagazijnClientFactory.READ_TIMEOUT_MS_*) zodat de gevalideerde waarde niet kan afwijken
+    // van de toegepaste.
+    @param:ConfigProperty(
+        name = MagazijnClientFactory.READ_TIMEOUT_MS_PROPERTY,
+        defaultValue = MagazijnClientFactory.READ_TIMEOUT_MS_DEFAULT,
+    )
+    private val magazijnReadTimeoutMs: Long,
 ) {
     private val log = Logger.getLogger(BerichtensessiecacheService::class.java)
 
     @PostConstruct
     fun valideerTimeouts() {
         // Outer-budget MOET groter zijn dan inner zodat de inner-timeout altijd eerst
-        // aanslaat; anders verliest de caller de juiste foutclassificatie (Profiel traag
-        // vs resolver hangt).
+        // aanslaat. Anders verliest de caller de juiste foutclassificatie: een outer
+        // j.u.c.TimeoutException wordt nu door het [ProfielServiceFoutException.resolverMislukt]
+        // pad geclassificeerd als "resolver hangt", niet als "Profiel-service traag".
         require(outerAwaitSeconds > innerTimeoutSeconds) {
             "profiel.resolver.outer-await-seconds ($outerAwaitSeconds) moet groter zijn dan " +
                 "profiel.resolver.inner-timeout-seconds ($innerTimeoutSeconds)"
         }
+
+        // De per-magazijn query-timeout (ifNoItem) MOET vóór de socket-read-timeout aanslaan,
+        // anders krijgt de client een ruwe client-fout i.p.v. een net TIMEOUT-event; de
+        // read-timeout blijft het vangnet als de query-timeout om welke reden dan ook niet vuurt.
+        require(magazijnReadTimeoutMs > magazijnQueryTimeoutSeconds * 1000) {
+            "magazijn-client.read-timeout-ms ($magazijnReadTimeoutMs) moet groter zijn dan " +
+                "berichtensessiecache.magazijn-query-timeout-seconds × 1000 (${magazijnQueryTimeoutSeconds * 1000})"
+        }
+
+        log.infof(
+            "Timeouts: profiel inner=%ds outer=%ds; magazijn query-timeout=%ds read-timeout=%dms",
+            innerTimeoutSeconds,
+            outerAwaitSeconds,
+            magazijnQueryTimeoutSeconds,
+            magazijnReadTimeoutMs,
+        )
     }
 
     fun getBerichten(page: Int, pageSize: Int, ontvanger: Identificatienummer, afzender: String?): Uni<BerichtenPage> {
         log.debugf("Ophalen berichten uit cache: page=%d, pageSize=%d", page, pageSize)
         val key = BerichtenCache.cacheKey(ontvanger)
 
-        // Cache-miss (null) en "opgehaald, 0 berichten" collapsen bewust naar dezelfde lege
-        // pagina; het onderscheid loopt via getAggregationStatus.
+        // Cache-miss (null: nog nooit opgehaald óf TTL verlopen) en "opgehaald, 0 berichten"
+        // collapsen bewust naar dezelfde lege pagina. Het onderscheid loopt via een aparte
+        // bron: de caller raadpleegt getAggregationStatus om "nog ophalen / niets in cache"
+        // te onderscheiden van een afgeronde lege ophaling.
         return berichtenCache.getPage(key, page, pageSize, afzender, ontvanger)
             .map { it ?: BerichtenPage(emptyList(), page, pageSize, 0L, 0) }
     }
@@ -66,7 +118,8 @@ class BerichtensessiecacheService(
 
     fun zoekBerichten(q: String, page: Int, pageSize: Int, ontvanger: Identificatienummer, afzender: String?): Uni<BerichtenPage> {
         // q is user-input zonder CRLF-filter op spec-niveau; loggen van q.length voorkomt
-        // log-injectie via newline-payloads.
+        // log-injectie via newline-payloads. Voor diepere debug staat de query elders in
+        // RediSearch-server-log.
         log.debugf("Zoeken berichten via RediSearch: q.length=%d, page=%d, pageSize=%d", q.length, page, pageSize)
 
         return berichtenCache.search(ontvanger, q, page, pageSize, afzender)
@@ -98,12 +151,53 @@ class BerichtensessiecacheService(
             totaalMagazijnen = 0,
         )
 
-        // Atomaire lock (SET NX EX): voorkom concurrent ophalen voor dezelfde ontvanger.
-        // Blokkerende await() is hier bewust: het aanroepende endpoint is @Blocking en de
-        // lock-check moet synchroon af zijn voordat de Multi-stream start, anders is de
-        // 409-response niet meer mogelijk.
-        val wasSet = berichtenCache.trySetAggregationStatus(cacheKey, bezigStatus)
-            .await().atMost(Duration.ofSeconds(5))
+        // Atomaire lock via trySetAggregationStatus (SET NX EX in één commando): voorkom
+        // concurrent ophalen voor dezelfde ontvanger. Blokkerende await() is hier bewust:
+        // het aanroepende endpoint (BerichtenOphalenResource) is @Blocking gemarkeerd. De
+        // lock-check moet synchroon afgerond zijn voordat de Multi-stream gestart wordt,
+        // omdat de 409-response anders niet meer mogelijk is.
+        // Try/catch: bij Redis-fout (timeout, connection drop) kan de lock-set partial
+        // geslaagd zijn (lockKey wel, statusKey niet). De cache-laag compenseert intern,
+        // maar caller-side cleanup als defense-in-depth voor await-level failures.
+        val wasSet = try {
+            berichtenCache.trySetAggregationStatus(cacheKey, bezigStatus)
+                .await().atMost(Duration.ofSeconds(5))
+        } catch (ex: Exception) {
+            // Cause-walking: Mutiny's blocking-await wrapt upstream-failures, dus directe
+            // instanceof matched de echte fout niet.
+            val errorId = UUID.randomUUID()
+            val classification = classifyLockAcquireError(ex)
+
+            when (classification) {
+                LockAcquireError.INTERRUPTED -> {
+                    // Herstel interrupt-flag voor graceful pod-shutdown; 503 (transient), geen eigen-bug.
+                    Thread.currentThread().interrupt()
+                    log.warnf(ex, "(errorId=%s) Lock-acquire onderbroken voor key=%s", errorId, cacheKey)
+                    cleanupLockMetFoutStatus(cacheKey, "lock-acquire interrupted", errorId)
+                    throw WebApplicationException("Service shutdown tijdens ophaalstart", 503)
+                }
+                LockAcquireError.JSON_SERIALIZATION -> {
+                    log.errorf(ex, "(errorId=%s) Lock-acquire JSON-serialisatie-fout voor key=%s", errorId, cacheKey)
+                    cleanupLockMetFoutStatus(cacheKey, "json-serialisatie-fout bij lock-acquire", errorId)
+                    throw WebApplicationException("Interne fout bij serialisatie status", 500)
+                }
+                LockAcquireError.TIMEOUT -> {
+                    log.errorf(ex, "(errorId=%s) Lock-acquire timeout voor key=%s", errorId, cacheKey)
+                    cleanupLockMetFoutStatus(cacheKey, "lock-acquire timeout", errorId)
+                    throw WebApplicationException("Cache niet bereikbaar bij ophaalstart (timeout)", 503)
+                }
+                LockAcquireError.IO_FAULT -> {
+                    log.errorf(ex, "(errorId=%s) Lock-acquire I/O-fout voor key=%s (cause=%s)", errorId, cacheKey, ex.javaClass.simpleName)
+                    cleanupLockMetFoutStatus(cacheKey, "lock-acquire I/O-fout: ${ex.javaClass.simpleName}", errorId)
+                    throw WebApplicationException("Cache niet bereikbaar bij ophaalstart", 503)
+                }
+                LockAcquireError.UNEXPECTED -> {
+                    log.errorf(ex, "(errorId=%s) Lock-acquire onverwachte fout voor key=%s (cause=%s)", errorId, cacheKey, ex.javaClass.simpleName)
+                    cleanupLockMetFoutStatus(cacheKey, "lock-acquire onverwacht: ${ex.javaClass.simpleName}", errorId)
+                    throw WebApplicationException("Interne fout bij ophaalstart", 500)
+                }
+            }
+        }
 
         if (!wasSet) {
             throw WebApplicationException(
@@ -112,18 +206,20 @@ class BerichtensessiecacheService(
             )
         }
 
-        // Resolver bepaalt welke magazijnen relevant zijn. Profiel-fout = fail-closed:
-        // lock vrijgeven; geen "alle magazijnen"-fallback (een Profiel-fout is geen
-        // impliciete toestemming).
         val resolvedIds = try {
+            // Outer-budget = inner-timeout + marge (cross-validatie in valideerTimeouts),
+            // zodat de outer nooit aanslaat vóór de inner — anders verliest de caller
+            // de juiste foutclassificatie (timeout vs onbereikbaar).
             resolver.resolve(ontvanger).await().atMost(Duration.ofSeconds(outerAwaitSeconds))
         } catch (ex: ProfielServiceFoutException) {
-            releaseLockNaFout(cacheKey)
-
-            // CONFIG_DRIFT = eigen-config-fout, niet Profiel-storing: emit een zichtbare
-            // OPHALEN_FOUT zodat de client wéét "geen ophaling mogelijk" i.p.v. een 503 dat
-            // tot zinloze retries leidt op een permanente fout.
+            // ex.errorId doorgeven zodat cleanup-log dezelfde id draagt als mapper-respons.
+            cleanupLockMetFoutStatus(cacheKey, "profiel-service-fout: ${ex.categorie.name}", ex.errorId)
+            // CONFIG_DRIFT: eigen-config-fout, niet Profiel-storing — emit zichtbare
+            // OPHALEN_FOUT i.p.v. 503 zodat client weet "geen ophaling mogelijk", niet
+            // "Profiel offline, retry over 30s". Cache wordt NIET overschreven met empty.
             if (ex.categorie == ProfielServiceFoutException.Categorie.CONFIG_DRIFT) {
+                // Riem-en-bretels: gestructureerd `referentie`-veld + suffix in tekst.
+                // Single source `ref` voorkomt format-drift tussen beide velden.
                 val ref = ex.errorId.toString()
 
                 return Multi.createFrom().item(
@@ -135,44 +231,99 @@ class BerichtensessiecacheService(
                     ),
                 )
             }
-
             throw ex
         } catch (ex: Exception) {
-            releaseLockNaFout(cacheKey)
-            throw ProfielServiceFoutException.resolverMislukt(ex)
+            // Cause-walking via causeChain() (eenmaal materialiseren) — Mutiny wrapt
+            // InterruptedException/TimeoutException, directe instanceof matched niet.
+            // isInterrupted (non-destructive) — Thread.interrupted() zou de flag wissen
+            // ook in niet-interrupt-branches.
+            val chain = ex.causeChain()
+            val wasInterrupted = Thread.currentThread().isInterrupted ||
+                chain.hasCauseOf(InterruptedException::class.java)
+            val isOuterTimeout = chain.hasCauseOf(io.smallrye.mutiny.TimeoutException::class.java) ||
+                chain.hasCauseOf(java.util.concurrent.TimeoutException::class.java)
+
+            when {
+                wasInterrupted -> {
+                    // Interrupt-flag (her)bevestigen voor graceful pod-shutdown; 503 (transient).
+                    Thread.currentThread().interrupt()
+                    val errorId = UUID.randomUUID()
+
+                    log.warnf(ex, "(errorId=%s) Resolver-await onderbroken voor key=%s", errorId, cacheKey)
+                    cleanupLockMetFoutStatus(cacheKey, "resolver-await interrupted", errorId)
+                    throw WebApplicationException("Service shutdown tijdens ophalen", 503)
+                }
+                isOuterTimeout -> {
+                    // Bouw exception eerst zodat errorId via log + cleanup + mapper consistent is.
+                    val foutException = ProfielServiceFoutException.resolverMislukt(ex)
+
+                    log.errorf(ex, "Resolver await overschreed outer-budget (%ds) (errorId=%s) voor key=%s", outerAwaitSeconds, foutException.errorId, cacheKey)
+                    cleanupLockMetFoutStatus(cacheKey, "resolver outer-await timeout", foutException.errorId)
+                    throw foutException
+                }
+                else -> {
+                    // Eigen-code-bug: 500 (geen Retry-After) zodat client niet retry'd.
+                    val errorId = UUID.randomUUID()
+
+                    log.errorf(ex, "(errorId=%s) Onverwachte fout in resolver-await voor key=%s (cause=%s)", errorId, cacheKey, ex.javaClass.simpleName)
+                    cleanupLockMetFoutStatus(cacheKey, "onverwachte resolver-fout: ${ex.javaClass.simpleName}", errorId)
+                    throw WebApplicationException("Interne fout tijdens ophalen", 500)
+                }
+            }
         }
 
-        // De resolver mag alleen magazijn-IDs teruggeven die de factory kent. Een onbekende
-        // ID is config-drift tussen resolver- en magazijn-config en moet hard falen, niet
-        // stil minder magazijnen bevragen. Lock vrijgeven vóór de throw zodat retries na de
-        // fix niet tot TTL blokkeren.
+        // De resolver mag alleen magazijn-IDs teruggeven die de factory kent;
+        // contract van MagazijnResolver. Een onbekende ID is een bug (drift tussen
+        // resolver-config en magazijn-config) en moet hard falen, niet stil leeg-degraderen.
+        // Cleanup vóór de throw: zonder dit blijft de lock tot TTL hangen en blokkeert
+        // legitieme retries na de drift-fix.
         val allClients = clientFactory.getAllClients()
         val onbekend = resolvedIds - allClients.keys
 
         if (onbekend.isNotEmpty()) {
-            log.errorf("Drift: resolver leverde onbekende magazijn-IDs %s voor key=%s", onbekend, cacheKey)
-            releaseLockNaFout(cacheKey)
+            val errorId = UUID.randomUUID()
 
+            log.errorf("(errorId=%s) Drift: resolver leverde onbekende magazijn-IDs %s voor key=%s", errorId, onbekend, cacheKey)
+            cleanupLockMetFoutStatus(cacheKey, "drift: resolver leverde onbekende magazijn-IDs", errorId)
             throw IllegalArgumentException("Resolver leverde onbekende magazijn-IDs: $onbekend")
         }
 
         val clients = allClients.filterKeys { it in resolvedIds }
 
-        // Geen magazijnen → lege resultaten + GEREED.
+        // Geen magazijnen → lege resultaten + GEREED-status.
         if (clients.isEmpty()) {
             return legeResultaten(cacheKey)
         }
 
-        val ontvangerString = ontvanger.toCanonicalString()
-        val alleBerichten = ConcurrentLinkedQueue<Bericht>()
+        // synchronizedList(ArrayList) i.p.v. ConcurrentLinkedQueue: Mutiny's merging-stream
+        // kan callbacks parallel emitten, dus sync is nodig. Geen lock-free CAS per Node
+        // (queue) maar wel goedkoop blocking; payload-size is paar honderd berichten.
+        val alleBerichten: MutableList<Bericht> = Collections.synchronizedList(ArrayList())
         val geslaagd = AtomicInteger(0)
         val mislukt = AtomicInteger(0)
+
+        // Happy: alleen statusKey overschrijven; lockKey blijft tot GEREED/FOUT-schrijfactie.
+        // Fout: cleanupLockMetFoutStatus schrijft FOUT (geeft lock vrij via interne del).
+        try {
+            berichtenCache.updateAggregationStatus(
+                cacheKey,
+                bezigStatus.copy(totaalMagazijnen = clients.size),
+            ).await().atMost(Duration.ofSeconds(5))
+        } catch (ex: Exception) {
+            val errorId = UUID.randomUUID()
+
+            log.errorf(ex, "(errorId=%s) Update aggregatie-status (BEZIG, totaalMagazijnen=%d) mislukt voor key=%s", errorId, clients.size, cacheKey)
+            cleanupLockMetFoutStatus(cacheKey, "update-aggregatie-status mislukt", errorId)
+            throw WebApplicationException("Cache niet bereikbaar tijdens initialisatie ophaalsessie.", 503)
+        }
+
+        val ontvangerString = ontvanger.toCanonicalString()
 
         val magazijnStreams = clients.map { (magazijnId, client) ->
             bouwMagazijnStream(magazijnId, client, ontvangerString, alleBerichten, geslaagd, mislukt)
         }
 
-        // Aggregatie-pipeline draait onafhankelijk van de SSE-client door tot voltooiing.
+        // Aggregatie-pipeline: draait onafhankelijk van de SSE-client door tot voltooiing.
         return Multi.createBy().concatenating().streams(
             Multi.createBy().merging().streams(magazijnStreams),
             aggregeerEnSlaOp(cacheKey, clients.size, alleBerichten, geslaagd, mislukt),
@@ -180,33 +331,73 @@ class BerichtensessiecacheService(
     }
 
     /**
-     * Lege-magazijn-pad: cache overschrijven met lege lijst zodat stale data uit eerdere
-     * sessies niet zichtbaar blijft via GET-endpoints, gevolgd door één OPHALEN_GEREED-event.
+     * Lege-magazijn-pad: cache overschrijven met lege lijst (zodat stale data uit eerdere
+     * sessies niet zichtbaar blijft via GET-endpoints) + GEREED-status, gevolgd door één
+     * OPHALEN_GEREED-event. Bij een store-fout een OPHALEN_FOUT-event i.p.v. mid-stream HTTP-500.
+     *
+     * LET OP (bekende beperking): een lege resolver-set kan ook ontstaan uit een transient
+     * Profiel-404 of base-path-drift (zie ProfielMagazijnResolver 404-tak). In dat geval
+     * overschrijft dit pad geldige eerder-gecachte berichten met een lege lijst — niet te
+     * onderscheiden van een echte opt-out tot de upstream-404-semantiek is aangescherpt;
+     * detectie loopt tot dan via de Profiel-404-rate-alert (docs/operations/profiel-404-alert.md).
      */
-    private fun legeResultaten(cacheKey: String): Multi<MagazijnEvent> =
-        berichtenCache.store(cacheKey, emptyList())
-            .chain { _ -> berichtenCache.storeAggregationStatus(cacheKey, AggregationStatus(status = OphalenStatus.GEREED)) }
-            .map<MagazijnEvent> { _ ->
-                MagazijnEvent(
-                    event = EventType.OPHALEN_GEREED,
-                    totaalBerichten = 0,
-                    geslaagd = 0,
-                    mislukt = 0,
-                    totaalMagazijnen = 0,
+    private fun legeResultaten(cacheKey: String): Multi<MagazijnEvent> {
+        try {
+            // Parallel: spaart 1 RTT op hot-path (nieuwe gebruikers zonder opt-ins).
+            // Per-Uni .onFailure houdt log-context welke faalde.
+            Uni.combine().all()
+                .unis(
+                    berichtenCache.store(cacheKey, emptyList())
+                        .onFailure().invoke { e -> log.errorf(e, "store(empty) mislukt voor lege magazijn-set, key=%s", cacheKey) },
+                    berichtenCache.storeAggregationStatus(cacheKey, AggregationStatus(status = OphalenStatus.GEREED))
+                        .onFailure().invoke { e -> log.errorf(e, "storeAggregationStatus(GEREED) mislukt voor lege magazijn-set, key=%s", cacheKey) },
                 )
-            }
-            .toMulti()
+                .discardItems()
+                .await().atMost(Duration.ofSeconds(5))
+        } catch (ex: Exception) {
+            val errorId = UUID.randomUUID()
+            val ref = errorId.toString()
+
+            log.errorf(ex, "(errorId=%s) Store-fout bij lege magazijn-set voor key=%s", errorId, cacheKey)
+            cleanupLockMetFoutStatus(cacheKey, "store-fout bij lege magazijn-set", errorId)
+            // SSE-stream is al actief op dit punt; OPHALEN_FOUT-event geeft de client
+            // dezelfde UX als het aggregatie-faalpad i.p.v. een mid-stream HTTP-500.
+            // Referentie zowel in foutmelding-tekst ("(ref: ...)") als in het
+            // gestructureerde `referentie`-veld, voor UIs die het veld nog niet renderen.
+            return Multi.createFrom().item(
+                MagazijnEvent(
+                    event = EventType.OPHALEN_FOUT,
+                    totaalMagazijnen = 0,
+                    foutmelding = "Interne fout bij opslaan resultaten (ref: $ref)",
+                    referentie = ref,
+                ),
+            )
+        }
+
+        return Multi.createFrom().item(
+            MagazijnEvent(
+                event = EventType.OPHALEN_GEREED,
+                totaalBerichten = 0,
+                geslaagd = 0,
+                mislukt = 0,
+                totaalMagazijnen = 0,
+            ),
+        )
+    }
 
     /**
      * Bouwt de event-stream voor één magazijn: een GESTART-event gevolgd door het
-     * VOLTOOID-event (OK/TIMEOUT/FOUT). Geslaagde berichten worden in [alleBerichten]
-     * verzameld; [geslaagd]/[mislukt] tellen de uitkomst voor de eind-aggregatie.
+     * VOLTOOID-event (OK/TIMEOUT/FOUT). De per-magazijn query-timeout levert het primaire
+     * TIMEOUT-signaal; de berichten-cap beschermt de heap tegen een rogue magazijn; de
+     * fout-classificatie ([classifyMagazijnFault]) bepaalt log-niveau + eindgebruiker-melding.
+     * Geslaagde berichten worden in [alleBerichten] verzameld; [geslaagd]/[mislukt] tellen
+     * de uitkomst voor de eind-aggregatie.
      */
     private fun bouwMagazijnStream(
         magazijnId: String,
         client: MagazijnClient,
         ontvangerString: String,
-        alleBerichten: ConcurrentLinkedQueue<Bericht>,
+        alleBerichten: MutableList<Bericht>,
         geslaagd: AtomicInteger,
         mislukt: AtomicInteger,
     ): Multi<MagazijnEvent> {
@@ -221,22 +412,26 @@ class BerichtensessiecacheService(
         val resultUni = Uni.createFrom().item { client }
             .onItem().transform { c -> c.getBerichten(ontvangerString, null) }
             .runSubscriptionOn(Infrastructure.getDefaultWorkerPool())
-            .ifNoItem().after(Duration.ofSeconds(10)).fail()
+            .ifNoItem().after(Duration.ofSeconds(magazijnQueryTimeoutSeconds)).fail()
             .map<MagazijnResult> { response ->
-                MagazijnResult.Success(magazijnId, naam, response.berichten)
+                if (response.berichten.size > maxBerichtenPerMagazijn) {
+                    // ErrorF nodig voor Loki-alert-routing; SSE-event alleen gaat niet naar logs.
+                    log.errorf(
+                        "Magazijn %s (%s) overschreed berichten-cap: %d > %d",
+                        magazijnId, naam, response.berichten.size, maxBerichtenPerMagazijn,
+                    )
+                    val foutMessage = "Magazijn leverde meer berichten dan toegestaan (${response.berichten.size} > $maxBerichtenPerMagazijn)"
+
+                    MagazijnResult.Failure(magazijnId, naam, MagazijnResponseOverflow(foutMessage), MagazijnFault.OVERFLOW)
+                } else {
+                    MagazijnResult.Success(magazijnId, naam, response.berichten)
+                }
             }
             .onFailure(Exception::class.java).recoverWithItem { error ->
-                when (error) {
-                    is jakarta.ws.rs.ProcessingException,
-                    is WebApplicationException,
-                    is io.smallrye.mutiny.TimeoutException,
-                    is java.net.ConnectException ->
-                        log.warnf(error, "Magazijn %s (%s) niet bereikbaar", magazijnId, naam)
-                    else ->
-                        log.errorf(error, "Onverwachte fout bij magazijn %s (%s)", magazijnId, naam)
-                }
+                val fault = classifyMagazijnFault(error)
 
-                MagazijnResult.Failure(magazijnId, naam, error)
+                logMagazijnFault(error, magazijnId, naam, fault)
+                MagazijnResult.Failure(magazijnId, naam, error, fault)
             }
 
         val resultStream = resultUni.toMulti().map { result ->
@@ -254,13 +449,21 @@ class BerichtensessiecacheService(
                 }
                 is MagazijnResult.Failure -> {
                     mislukt.incrementAndGet()
-                    val isTimeout = result.error is io.smallrye.mutiny.TimeoutException
+                    val foutmelding = when (result.fault) {
+                        MagazijnFault.TIMEOUT -> "Magazijn reageerde niet binnen de timeout"
+                        MagazijnFault.MALFORMED -> "Magazijn leverde onleesbare respons (mogelijk schema-drift, contact beheerder)"
+                        MagazijnFault.OVERFLOW -> "Magazijn leverde te veel berichten (responsgrootte overschreden, contact beheerder)"
+                        MagazijnFault.HTTP_5XX -> "Magazijn tijdelijk niet bereikbaar"
+                        MagazijnFault.HTTP_4XX -> "Magazijn heeft de aanvraag geweigerd (configuratiefout, contact beheerder)"
+                        // BIO 14.1.3: generiek bericht aan eindgebruiker; technisch onderscheid alleen in log.
+                        MagazijnFault.INTERNAL_BUG, MagazijnFault.NETWORK -> "Magazijn kon niet geraadpleegd worden"
+                    }
                     MagazijnEvent(
                         event = EventType.MAGAZIJN_BEVRAGING_VOLTOOID,
                         magazijnId = magazijnId,
                         naam = naam,
-                        status = if (isTimeout) MagazijnStatus.TIMEOUT else MagazijnStatus.FOUT,
-                        foutmelding = if (isTimeout) "Magazijn reageerde niet binnen de timeout" else "Magazijn tijdelijk niet bereikbaar",
+                        status = if (result.fault == MagazijnFault.TIMEOUT) MagazijnStatus.TIMEOUT else MagazijnStatus.FOUT,
+                        foutmelding = foutmelding,
                     )
                 }
             }
@@ -273,31 +476,38 @@ class BerichtensessiecacheService(
     }
 
     /**
-     * Slaat de verzamelde berichten + GEREED-status op en emit het afsluitende
-     * OPHALEN_GEREED-event. Bij een cache-fout een OPHALEN_FOUT-event i.p.v. een
-     * mid-stream HTTP-500 (de SSE-stream loopt dan al).
+     * Slaat de verzamelde berichten + GEREED-status op (parallel: verschillende keys, geen
+     * ordering-afhankelijkheid → bespaart 1 Redis-RTT) en emit het afsluitende
+     * OPHALEN_GEREED-event. Bij een cache-fout een OPHALEN_FOUT-event i.p.v. een mid-stream
+     * HTTP-500 (de SSE-stream loopt dan al); een dubbele cache-fout krijgt een
+     * `[ALERT cache_doublefail]`-marker voor alert-routing.
      */
     private fun aggregeerEnSlaOp(
         cacheKey: String,
         totaalMagazijnen: Int,
-        alleBerichten: ConcurrentLinkedQueue<Bericht>,
+        alleBerichten: MutableList<Bericht>,
         geslaagd: AtomicInteger,
         mislukt: AtomicInteger,
     ): Multi<MagazijnEvent> =
         Uni.createFrom().voidItem()
             .chain { _ ->
                 val berichten = alleBerichten.toList()
-                berichtenCache.store(cacheKey, berichten)
-                    .chain { _ ->
-                        val status = AggregationStatus(
-                            status = OphalenStatus.GEREED,
-                            totaalMagazijnen = totaalMagazijnen,
-                            geslaagd = geslaagd.get(),
-                            mislukt = mislukt.get(),
-                        )
+                val status = AggregationStatus(
+                    status = OphalenStatus.GEREED,
+                    totaalMagazijnen = totaalMagazijnen,
+                    geslaagd = geslaagd.get(),
+                    mislukt = mislukt.get(),
+                )
 
-                        berichtenCache.storeAggregationStatus(cacheKey, status)
-                    }
+                // Parallel: store(berichten) en storeAggregationStatus(GEREED) hebben
+                // verschillende keys en geen ordering-afhankelijkheid. Bespaart 1 Redis-RTT
+                // t.o.v. sequentiële .chain (consistent met het lege-magazijn-pad).
+                Uni.combine().all()
+                    .unis(
+                        berichtenCache.store(cacheKey, berichten),
+                        berichtenCache.storeAggregationStatus(cacheKey, status),
+                    )
+                    .discardItems()
                     .map { _ ->
                         MagazijnEvent(
                             event = EventType.OPHALEN_GEREED,
@@ -309,40 +519,200 @@ class BerichtensessiecacheService(
                     }
             }
             .onFailure(Exception::class.java).recoverWithUni { error ->
-                log.errorf(error, "Fout bij opslaan in cache na aggregatie (key=%s)", cacheKey)
+                val errorId = UUID.randomUUID()
+                val ref = errorId.toString()
+
+                // Eerste fout = store(berichten) of storeAggregationStatus(GEREED) faalde;
+                // cacheKey + counters + errorId in log zodat ops kan correleren naar
+                // specifieke sessie én naar het MagazijnEvent.referentie veld.
+                log.errorf(
+                    error,
+                    "(errorId=%s) Fout bij opslaan in cache na aggregatie (key=%s, berichten=%d, geslaagd=%d, mislukt=%d)",
+                    errorId, cacheKey, alleBerichten.size, geslaagd.get(), mislukt.get(),
+                )
                 val foutStatus = AggregationStatus(
                     status = OphalenStatus.FOUT,
                     totaalMagazijnen = totaalMagazijnen,
                     geslaagd = geslaagd.get(),
                     mislukt = mislukt.get(),
                 )
-
                 berichtenCache.storeAggregationStatus(cacheKey, foutStatus)
-                    .onFailure().invoke { e -> log.errorf(e, "Best-effort FOUT-status opslaan ook mislukt") }
+                    // FATAL + ALERT-marker: dubbele Redis-fout = cache effectief onbruikbaar
+                    // voor deze sessie. Lock blijft tot Redis-TTL hangen. Het prefix wordt
+                    // door log-aggregator (Loki/CloudWatch) gefilterd richting alert-routing.
+                    .onFailure().invoke { e ->
+                        log.fatalf(
+                            e,
+                            "[ALERT cache_doublefail] (errorId=%s) Cache-write FAIL/FAIL (key=%s, berichten=%d, geslaagd=%d, mislukt=%d): Redis onbruikbaar voor sessie, lock leunt op TTL",
+                            errorId, cacheKey, alleBerichten.size, geslaagd.get(), mislukt.get(),
+                        )
+                    }
                     .onFailure().recoverWithNull()
+                    // Referentie zowel in foutmelding-tekst ("(ref: ...)") als in het
+                    // gestructureerde `referentie`-veld, voor UIs zonder veld-rendering.
+                    // Meld expliciet dat de eerder per-magazijn getoonde resultaten niet
+                    // bewaard zijn: de VOLTOOID-events zijn al geëmit, maar de cache-write
+                    // faalde, dus de client moet opnieuw ophalen i.p.v. te denken dat de
+                    // resultaten beschikbaar zijn via GET /berichten.
                     .replaceWith(
                         MagazijnEvent(
                             event = EventType.OPHALEN_FOUT,
                             geslaagd = geslaagd.get(),
                             mislukt = mislukt.get(),
                             totaalMagazijnen = totaalMagazijnen,
-                            foutmelding = "Interne fout bij opslaan van resultaten",
+                            foutmelding = "Resultaten konden niet worden opgeslagen; haal opnieuw op (ref: $ref)",
+                            referentie = ref,
                         )
                     )
             }
             .toMulti()
 
     /**
-     * Best-effort lock-release na een fout vóór de SSE-stream start: schrijft FOUT-status
-     * (`storeAggregationStatus` doet intern `del(lockKey)`). Cleanup-failure wordt geslikt
-     * — de lock leunt dan op de Redis-TTL.
+     * Best-effort lock-release na fout: schrijft FOUT-status; `storeAggregationStatus`
+     * doet intern `del(lockKey)`. Cleanup-failure geslikt — lock leunt dan op TTL.
+     *
+     * @param errorId caller geeft `ex.errorId` mee (Profiel-pad) zodat de cleanup-log
+     *   dezelfde id draagt als `Problem.instance` voor cross-correlatie; non-Profiel
+     *   paden krijgen een verse id zodat `[ALERT cache_doublefail]`-pad een anker heeft.
      */
-    private fun releaseLockNaFout(cacheKey: String) {
+    private fun cleanupLockMetFoutStatus(
+        cacheKey: String,
+        oorzaak: String,
+        errorId: UUID = UUID.randomUUID(),
+    ) {
         try {
-            berichtenCache.storeAggregationStatus(cacheKey, AggregationStatus(status = OphalenStatus.FOUT))
-                .await().atMost(Duration.ofSeconds(5))
+            berichtenCache.storeAggregationStatus(
+                cacheKey,
+                AggregationStatus(status = OphalenStatus.FOUT),
+            ).await().atMost(Duration.ofSeconds(5))
+
+            log.warnf("Lock vrijgegeven na fout (errorId=%s) voor key=%s: %s", errorId, cacheKey, oorzaak)
         } catch (cleanupEx: Exception) {
-            log.errorf(cleanupEx, "Lock-cleanup na fout mislukt voor key=%s — lock leunt op TTL", cacheKey)
+            // FATAL + ALERT-marker: oorspronkelijke fout PLUS cleanup-fail = lock blijft
+            // tot Redis-TTL hangen, ontvanger 60s onbedienbaar. Zelfde marker als het
+            // aggregatie-pad (`[ALERT cache_doublefail]`) voor uniforme alert-routing
+            // — zonder dit pad zou een Profiel-/resolver-fout + Redis-cleanup-fail
+            // onder de radar blijven van de log-aggregator-rules.
+            log.fatalf(
+                cleanupEx,
+                "[ALERT cache_doublefail] Lock-cleanup na fout mislukt (errorId=%s) voor key=%s: %s — lock leunt op TTL",
+                errorId,
+                cacheKey,
+                oorzaak,
+            )
+        }
+    }
+
+    /**
+     * Materialiseert de cause-chain éénmaal als list (cycle-safe via IdentityHashMap,
+     * depth-cap als defense-in-depth tegen pathologische `cause`-getters). Callers
+     * (classifyMagazijnFault/classifyLockAcquireError) doen meerdere instanceof-checks
+     * tegen dit resultaat i.p.v. meerdere walks → één warnf max bij depth-cap.
+     */
+    private fun Throwable.causeChain(): List<Throwable> {
+        val result = ArrayList<Throwable>(4)
+        val seen = java.util.IdentityHashMap<Throwable, Unit>()
+        var cur: Throwable? = this
+
+        while (cur != null && seen.put(cur, Unit) == null) {
+            result.add(cur)
+            if (result.size >= MAX_CAUSE_DEPTH) {
+                // Chain-namen meeloggen — anders kan on-call niet zien welke wrapper-types
+                // de chain dieper dan depth-cap maakten (misclassificatie als INTERNAL_BUG).
+                log.warnf(
+                    "Cause-chain depth-cap (%d) bereikt in root=%s, chain=%s — classificatie kan onnauwkeurig zijn",
+                    MAX_CAUSE_DEPTH,
+                    this::class.java.simpleName,
+                    result.joinToString(",") { it::class.java.simpleName },
+                )
+                break
+            }
+            cur = cur.cause
+        }
+
+        return result
+    }
+
+    private fun List<Throwable>.findCauseOfClass(cls: Class<*>): Throwable? = firstOrNull { cls.isInstance(it) }
+
+    // Cast safe: findCauseOfClass filtert op cls.isInstance dus result is gegarandeerd T?.
+    @Suppress("UNCHECKED_CAST")
+    private inline fun <reified T : Throwable> List<Throwable>.findCauseOf(): T? =
+        findCauseOfClass(T::class.java) as T?
+
+    private fun List<Throwable>.hasCauseOf(cls: Class<*>): Boolean = findCauseOfClass(cls) != null
+
+    private companion object {
+        private const val MAX_CAUSE_DEPTH = 32
+    }
+
+    internal enum class LockAcquireError { JSON_SERIALIZATION, TIMEOUT, IO_FAULT, INTERRUPTED, UNEXPECTED }
+
+    // Internal voor directe unit-test van classificatie + cycle-/depth-cap-gedrag.
+    internal fun classifyLockAcquireError(ex: Throwable): LockAcquireError {
+        val chain = ex.causeChain()
+
+        return when {
+            chain.hasCauseOf(InterruptedException::class.java) -> LockAcquireError.INTERRUPTED
+            chain.hasCauseOf(JsonProcessingException::class.java) -> LockAcquireError.JSON_SERIALIZATION
+            chain.hasCauseOf(io.smallrye.mutiny.TimeoutException::class.java) ||
+                chain.hasCauseOf(java.util.concurrent.TimeoutException::class.java) -> LockAcquireError.TIMEOUT
+            chain.hasCauseOf(java.io.IOException::class.java) -> LockAcquireError.IO_FAULT
+            else -> LockAcquireError.UNEXPECTED
+        }
+    }
+
+    // Internal voor directe unit-test van de classificatie-tabel (zie service-test).
+    internal fun classifyMagazijnFault(error: Throwable): MagazijnFault {
+        // Cause-walking eenmalig via causeChain(); meerdere instanceof-checks tegen
+        // dezelfde list — voorkomt log-storm van depth-cap warnf bij elke check.
+        val chain = error.causeChain()
+        val webEx = chain.findCauseOf<WebApplicationException>()
+
+        return when {
+            chain.hasCauseOf(MagazijnResponseOverflow::class.java) -> MagazijnFault.OVERFLOW
+            chain.hasCauseOf(TimeoutException::class.java) -> MagazijnFault.TIMEOUT
+            chain.hasCauseOf(JsonProcessingException::class.java) -> MagazijnFault.MALFORMED
+            chain.hasCauseOf(ConnectException::class.java) -> MagazijnFault.NETWORK
+            webEx != null -> {
+                val status = webEx.response?.status ?: 0
+
+                when {
+                    status in 500..599 -> MagazijnFault.HTTP_5XX
+                    status >= 400 -> MagazijnFault.HTTP_4XX
+                    // WAE zonder status = raw WAE("oeps") zonder Response → eigen-bug.
+                    else -> MagazijnFault.INTERNAL_BUG
+                }
+            }
+            chain.hasCauseOf(ProcessingException::class.java) -> MagazijnFault.NETWORK
+            // Annulering (bv. bij pod-shutdown of upstream-cancel) is geen magazijn-bug.
+            // Zonder deze tak valt het in `else -> INTERNAL_BUG` en logt het errorf, wat
+            // vals-positieve alert-ruis geeft. NETWORK logt warnf met een neutrale melding.
+            chain.hasCauseOf(java.util.concurrent.CancellationException::class.java) -> MagazijnFault.NETWORK
+            else -> MagazijnFault.INTERNAL_BUG
+        }
+    }
+
+    /** Log-level differentieert eigen-bug (errorf) van transient upstream (warnf) voor alert-routing. */
+    private fun logMagazijnFault(error: Throwable, magazijnId: String, naam: String?, fault: MagazijnFault) {
+        when (fault) {
+            MagazijnFault.TIMEOUT ->
+                log.warnf(error, "Magazijn %s (%s) timeout", magazijnId, naam)
+            MagazijnFault.MALFORMED ->
+                log.errorf(error, "Magazijn %s (%s) leverde onleesbare JSON-respons (schema-drift?)", magazijnId, naam)
+            // Map-pad logt overflow zelf met counts; warnf hier vangt overflows die
+            // onverwacht via dit pad komen (toekomstige refactor) — warn ipv debug
+            // omdat prod-INFO-niveau anders silent zou maken.
+            MagazijnFault.OVERFLOW ->
+                log.warnf(error, "Magazijn %s (%s) overflow via onFailure-pad — onverwacht, map-pad zou moeten loggen", magazijnId, naam)
+            MagazijnFault.HTTP_5XX ->
+                log.warnf(error, "Magazijn %s (%s) 5xx", magazijnId, naam)
+            MagazijnFault.HTTP_4XX ->
+                log.errorf(error, "Magazijn %s (%s) 4xx — configuratie/auth-fout", magazijnId, naam)
+            MagazijnFault.NETWORK ->
+                log.warnf(error, "Magazijn %s (%s) niet bereikbaar (network/processing)", magazijnId, naam)
+            MagazijnFault.INTERNAL_BUG ->
+                log.errorf(error, "Onverwachte fout bij magazijn %s (%s) (cause=%s)", magazijnId, naam, error.javaClass.simpleName)
         }
     }
 }

--- a/services/berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtensessiecacheService.kt
+++ b/services/berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtensessiecacheService.kt
@@ -61,6 +61,11 @@ class BerichtensessiecacheService(
         defaultValue = MagazijnClientFactory.READ_TIMEOUT_MS_DEFAULT,
     )
     private val magazijnReadTimeoutMs: Long,
+    // Max blocking-await op één Redis-commando vanaf de @Blocking worker-thread tijdens
+    // ophaal-orkestratie (lock-acquire, status-updates, cleanup); overschrijding → 503.
+    // Losse knop: geen invariant met de magazijn-/profiel-timeouts, dus geen kruisvalidatie.
+    @param:ConfigProperty(name = "berichtensessiecache.cache-await-timeout-seconds", defaultValue = "5")
+    private val cacheAwaitTimeoutSeconds: Long,
 ) {
     private val log = Logger.getLogger(BerichtensessiecacheService::class.java)
 
@@ -84,11 +89,12 @@ class BerichtensessiecacheService(
         }
 
         log.infof(
-            "Timeouts: profiel inner=%ds outer=%ds; magazijn query-timeout=%ds read-timeout=%dms",
+            "Timeouts: profiel inner=%ds outer=%ds; magazijn query-timeout=%ds read-timeout=%dms; cache-await=%ds",
             innerTimeoutSeconds,
             outerAwaitSeconds,
             magazijnQueryTimeoutSeconds,
             magazijnReadTimeoutMs,
+            cacheAwaitTimeoutSeconds,
         )
     }
 
@@ -161,7 +167,7 @@ class BerichtensessiecacheService(
         // maar caller-side cleanup als defense-in-depth voor await-level failures.
         val wasSet = try {
             berichtenCache.trySetAggregationStatus(cacheKey, bezigStatus)
-                .await().atMost(Duration.ofSeconds(5))
+                .await().atMost(Duration.ofSeconds(cacheAwaitTimeoutSeconds))
         } catch (ex: Exception) {
             // Cause-walking: Mutiny's blocking-await wrapt upstream-failures, dus directe
             // instanceof matched de echte fout niet.
@@ -308,7 +314,7 @@ class BerichtensessiecacheService(
             berichtenCache.updateAggregationStatus(
                 cacheKey,
                 bezigStatus.copy(totaalMagazijnen = clients.size),
-            ).await().atMost(Duration.ofSeconds(5))
+            ).await().atMost(Duration.ofSeconds(cacheAwaitTimeoutSeconds))
         } catch (ex: Exception) {
             val errorId = UUID.randomUUID()
 
@@ -353,7 +359,7 @@ class BerichtensessiecacheService(
                         .onFailure().invoke { e -> log.errorf(e, "storeAggregationStatus(GEREED) mislukt voor lege magazijn-set, key=%s", cacheKey) },
                 )
                 .discardItems()
-                .await().atMost(Duration.ofSeconds(5))
+                .await().atMost(Duration.ofSeconds(cacheAwaitTimeoutSeconds))
         } catch (ex: Exception) {
             val errorId = UUID.randomUUID()
             val ref = errorId.toString()
@@ -584,7 +590,7 @@ class BerichtensessiecacheService(
             berichtenCache.storeAggregationStatus(
                 cacheKey,
                 AggregationStatus(status = OphalenStatus.FOUT),
-            ).await().atMost(Duration.ofSeconds(5))
+            ).await().atMost(Duration.ofSeconds(cacheAwaitTimeoutSeconds))
 
             log.warnf("Lock vrijgegeven na fout (errorId=%s) voor key=%s: %s", errorId, cacheKey, oorzaak)
         } catch (cleanupEx: Exception) {

--- a/services/berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnClientFactory.kt
+++ b/services/berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnClientFactory.kt
@@ -8,11 +8,22 @@ import nl.rijksoverheid.moz.fbs.common.identificatie.Oin
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
 import java.net.URI
+import java.util.concurrent.TimeUnit
 
 @ApplicationScoped
 class MagazijnClientFactory(
     private val config: MagazijnenConfig,
     @param:ConfigProperty(name = "quarkus.profile") private val profile: String,
+    // Connect/read-timeout op de magazijn-client: zonder read-timeout blokkeert een hangend
+    // magazijn de socket onbegrensd (de Mutiny `ifNoItem` faalt de Uni maar interrupt de
+    // geblokkeerde call niet). De invariant read-timeout > query-timeout wordt afgedwongen in
+    // BerichtensessiecacheService.valideerTimeouts(); rationale + tuning in application.properties.
+    // Eigen prefix (niet `magazijnen.`): SmallRye weigert losse properties onder een
+    // @ConfigMapping-prefix (SRCFG00050).
+    @param:ConfigProperty(name = "magazijn-client.connect-timeout-ms", defaultValue = "2000")
+    private val connectTimeoutMs: Long,
+    @param:ConfigProperty(name = READ_TIMEOUT_MS_PROPERTY, defaultValue = READ_TIMEOUT_MS_DEFAULT)
+    private val readTimeoutMs: Long,
 ) {
     private val log = Logger.getLogger(MagazijnClientFactory::class.java)
     private lateinit var cachedClients: Map<String, MagazijnClient>
@@ -106,6 +117,16 @@ class MagazijnClientFactory(
     protected open fun createClient(instance: MagazijnenConfig.MagazijnInstance): MagazijnClient {
         return QuarkusRestClientBuilder.newBuilder()
             .baseUri(URI.create(instance.url()))
+            .connectTimeout(connectTimeoutMs, TimeUnit.MILLISECONDS)
+            .readTimeout(readTimeoutMs, TimeUnit.MILLISECONDS)
             .build(MagazijnClient::class.java)
+    }
+
+    companion object {
+        // Gedeeld met BerichtensessiecacheService.valideerTimeouts(), dat read > query
+        // kruisvalideert. Eén bron voor sleutel + default zodat de gevalideerde waarde niet
+        // kan afwijken van de waarde die deze factory daadwerkelijk op de socket toepast.
+        const val READ_TIMEOUT_MS_PROPERTY = "magazijn-client.read-timeout-ms"
+        const val READ_TIMEOUT_MS_DEFAULT = "12000"
     }
 }

--- a/services/berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnResult.kt
+++ b/services/berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnResult.kt
@@ -20,9 +20,27 @@ sealed class MagazijnResult {
         override val magazijnId: String,
         override val naam: String?,
         val error: Throwable,
+        // Classificatie eenmaal bepaald in service-laag en hier vastgezet zodat
+        // downstream-mapping niet opnieuw classificeert (voorkomt drift).
+        val fault: MagazijnFault,
     ) : MagazijnResult() {
         init {
             require(magazijnId.isNotBlank()) { "magazijnId mag niet leeg zijn" }
         }
     }
 }
+
+/**
+ * Classificatie van een magazijn-fout. Bepaalt log-niveau (errorf vs warnf voor
+ * alert-routing) en eindgebruiker-foutmelding. Top-level zodat zowel service als
+ * MagazijnResult op één enum kunnen leunen.
+ */
+enum class MagazijnFault { TIMEOUT, MALFORMED, OVERFLOW, HTTP_5XX, HTTP_4XX, NETWORK, INTERNAL_BUG }
+
+/**
+ * Marker-exception voor de availability-cap op magazijn-responses (zie
+ * `berichtensessiecache.max-berichten-per-magazijn`). Geen subclass van
+ * `WebApplicationException`/`ProcessingException` — dit is een interne signalering,
+ * geen upstream-fault, en wordt door de service in een aparte foutmelding gemapt.
+ */
+class MagazijnResponseOverflow(message: String) : RuntimeException(message)

--- a/services/berichtensessiecache/src/main/resources/application.properties
+++ b/services/berichtensessiecache/src/main/resources/application.properties
@@ -31,8 +31,9 @@ quarkus.smallrye-openapi.info-version=0.1.0
 berichtensessiecache.ttl=PT60S
 
 # Max blocking-await op één Redis-commando vanaf de @Blocking worker-thread tijdens
-# ophaal-orkestratie (lock-acquire, status-updates, cleanup); overschrijding → 503.
-# Losse knop: geen invariant met de magazijn-/profiel-timeouts.
+# ophaal-orkestratie (lock-acquire, status-updates, cleanup). Overschreden await-deadline
+# faalt de ophaalstap (await-timeout → 503; cleanup-pad slikt en leunt op de TTL). Moet > 0
+# (afgedwongen in valideerTimeouts). Losse knop: geen invariant met de andere timeouts.
 berichtensessiecache.cache-await-timeout-seconds=5
 %prod.berichtensessiecache.cache-await-timeout-seconds=${CACHE_AWAIT_TIMEOUT_SECONDS:5}
 

--- a/services/berichtensessiecache/src/main/resources/application.properties
+++ b/services/berichtensessiecache/src/main/resources/application.properties
@@ -30,6 +30,12 @@ quarkus.smallrye-openapi.info-version=0.1.0
 # Default 60s modelleert korte inactiviteit binnen een sessie; actieve gebruikers houden hun cache.
 berichtensessiecache.ttl=PT60S
 
+# Max blocking-await op één Redis-commando vanaf de @Blocking worker-thread tijdens
+# ophaal-orkestratie (lock-acquire, status-updates, cleanup); overschrijding → 503.
+# Losse knop: geen invariant met de magazijn-/profiel-timeouts.
+berichtensessiecache.cache-await-timeout-seconds=5
+%prod.berichtensessiecache.cache-await-timeout-seconds=${CACHE_AWAIT_TIMEOUT_SECONDS:5}
+
 # Magazijnen configuratie
 # URLs uit env-vars in prod/staging/acceptatie; MagazijnClientFactory dwingt
 # https:// af via OutboundTlsValidator buiten dev/test (BIO 13.2.1).

--- a/services/berichtensessiecache/src/main/resources/application.properties
+++ b/services/berichtensessiecache/src/main/resources/application.properties
@@ -42,6 +42,19 @@ magazijnen.instances.magazijn-b.naam=Magazijn B
 %test.magazijnen.instances.magazijn-a.url=http://localhost:8081
 %test.magazijnen.instances.magazijn-b.url=http://localhost:8082
 
+# Magazijn-client timeouts (MagazijnClientFactory). Zonder read-timeout blokkeert een
+# hangend magazijn de worker-thread/socket onbegrensd; de Mutiny `ifNoItem`-query-timeout
+# faalt de Uni wel maar interrupt de geblokkeerde call niet. Invariant: read-timeout-ms
+# MOET groter zijn dan berichtensessiecache.magazijn-query-timeout-seconds (×1000), zodat
+# de query-timeout als eerste aanslaat (TIMEOUT-event) en deze timeout de socket alsnog
+# vrijgeeft als vangnet. Deze invariant wordt bij startup afgedwongen in
+# BerichtensessiecacheService.valideerTimeouts() (faalt de boot bij misconfiguratie). Eigen
+# prefix (niet `magazijnen.`): die prefix is een @ConfigMapping-root en SmallRye weigert
+# losse properties eronder (SRCFG00050).
+magazijn-client.connect-timeout-ms=2000
+magazijn-client.read-timeout-ms=12000
+berichtensessiecache.magazijn-query-timeout-seconds=10
+
 # MOZA Profiel Service — gedeelde upstream met berichtenmagazijn.
 # REST-client + DTO's wonen in fbs-common (nl.rijksoverheid.moz.fbs.common.profiel).
 # WireMock-stub op localhost:8089 (zie compose.yaml + wiremock/profiel-service/).

--- a/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtenOphalenResourceTest.kt
+++ b/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtenOphalenResourceTest.kt
@@ -256,7 +256,7 @@ class BerichtenOphalenResourceTest {
     }
 
     @Test
-    fun `GET ophalen met magazijn 4xx toont FOUT`() {
+    fun `GET ophalen met magazijn 4xx toont FOUT met configuratiefout-bericht`() {
         MockMagazijnClientFactory.shouldHttpFailA = 403
         MockMagazijnClientFactory.shouldHttpFailB = 403
 
@@ -268,9 +268,11 @@ class BerichtenOphalenResourceTest {
             .extract().body().asString()
 
         assertTrue(response.contains("\"status\":\"FOUT\""), "Verwacht FOUT status in: $response")
+        // 4xx krijgt aparte foutmelding (configuratie/auth) zodat operator dit niet als
+        // transient verwart. Generieke "kon niet geraadpleegd worden" is voor onbekende fouten.
         assertTrue(
-            response.contains("tijdelijk niet bereikbaar"),
-            "Verwacht generieke FOUT-melding in: $response",
+            response.contains("aanvraag geweigerd") && response.contains("configuratiefout"),
+            "Verwacht 4xx-configuratiefout-bericht in: $response",
         )
     }
 }

--- a/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtensessiecacheServiceTest.kt
+++ b/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtensessiecacheServiceTest.kt
@@ -234,6 +234,55 @@ class BerichtensessiecacheServiceTest {
     }
 
     @Test
+    fun `valideerTimeouts werpt IllegalArgumentException als inner-timeout 0 is`() {
+        // 0/negatief schakelt de bescherming stil uit (Mutiny atMost(ZERO) = onbegrensd wachten).
+        val mis = BerichtensessiecacheService(
+            berichtenCache, clientFactory, resolver,
+            innerTimeoutSeconds = 0L, outerAwaitSeconds = 25L,
+            maxBerichtenPerMagazijn = 1000,
+            magazijnQueryTimeoutSeconds = 10L,
+            magazijnReadTimeoutMs = 12000L,
+            cacheAwaitTimeoutSeconds = 5L,
+        )
+
+        val ex = assertThrows<IllegalArgumentException> { mis.valideerTimeouts() }
+
+        assertTrue(ex.message!!.contains("inner-timeout-seconds"), "Was: ${ex.message}")
+    }
+
+    @Test
+    fun `valideerTimeouts werpt IllegalArgumentException als magazijn-query-timeout 0 is`() {
+        val mis = BerichtensessiecacheService(
+            berichtenCache, clientFactory, resolver,
+            innerTimeoutSeconds = 2L, outerAwaitSeconds = 3L,
+            maxBerichtenPerMagazijn = 1000,
+            magazijnQueryTimeoutSeconds = 0L,
+            magazijnReadTimeoutMs = 12000L,
+            cacheAwaitTimeoutSeconds = 5L,
+        )
+
+        val ex = assertThrows<IllegalArgumentException> { mis.valideerTimeouts() }
+
+        assertTrue(ex.message!!.contains("magazijn-query-timeout-seconds"), "Was: ${ex.message}")
+    }
+
+    @Test
+    fun `valideerTimeouts werpt IllegalArgumentException als cache-await-timeout 0 is`() {
+        val mis = BerichtensessiecacheService(
+            berichtenCache, clientFactory, resolver,
+            innerTimeoutSeconds = 2L, outerAwaitSeconds = 3L,
+            maxBerichtenPerMagazijn = 1000,
+            magazijnQueryTimeoutSeconds = 10L,
+            magazijnReadTimeoutMs = 12000L,
+            cacheAwaitTimeoutSeconds = 0L,
+        )
+
+        val ex = assertThrows<IllegalArgumentException> { mis.valideerTimeouts() }
+
+        assertTrue(ex.message!!.contains("cache-await-timeout-seconds"), "Was: ${ex.message}")
+    }
+
+    @Test
     fun `outer-await-timeout op resolver wrapt naar resolverMislukt en zet FOUT-status`() {
         // Resource-hang vóór subscription: outer-await werpt → resolverMislukt.
         every { berichtenCache.trySetAggregationStatus(cacheKey, any()) } returns Uni.createFrom().item(true)

--- a/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtensessiecacheServiceTest.kt
+++ b/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtensessiecacheServiceTest.kt
@@ -47,6 +47,7 @@ class BerichtensessiecacheServiceTest {
         maxBerichtenPerMagazijn = 1000,
         magazijnQueryTimeoutSeconds = 10L,
         magazijnReadTimeoutMs = 12000L,
+        cacheAwaitTimeoutSeconds = 5L,
     ).also { it.valideerTimeouts() }
 
     private val ontvanger = Bsn("999993653")
@@ -186,6 +187,7 @@ class BerichtensessiecacheServiceTest {
             maxBerichtenPerMagazijn = 1000,
             magazijnQueryTimeoutSeconds = 10L,
             magazijnReadTimeoutMs = 12000L,
+            cacheAwaitTimeoutSeconds = 5L,
         )
 
         val ex = assertThrows<IllegalArgumentException> { mis.valideerTimeouts() }
@@ -202,6 +204,7 @@ class BerichtensessiecacheServiceTest {
             maxBerichtenPerMagazijn = 1000,
             magazijnQueryTimeoutSeconds = 10L,
             magazijnReadTimeoutMs = 12000L,
+            cacheAwaitTimeoutSeconds = 5L,
         )
 
         val ex = assertThrows<IllegalArgumentException> { mis.valideerTimeouts() }
@@ -221,6 +224,7 @@ class BerichtensessiecacheServiceTest {
             maxBerichtenPerMagazijn = 1000,
             magazijnQueryTimeoutSeconds = 10L,
             magazijnReadTimeoutMs = 10_000L,
+            cacheAwaitTimeoutSeconds = 5L,
         )
 
         val ex = assertThrows<IllegalArgumentException> { mis.valideerTimeouts() }
@@ -497,6 +501,7 @@ class BerichtensessiecacheServiceTest {
             maxBerichtenPerMagazijn = 2,
             magazijnQueryTimeoutSeconds = 10L,
             magazijnReadTimeoutMs = 12000L,
+            cacheAwaitTimeoutSeconds = 5L,
         ).also { it.valideerTimeouts() }
 
         val client = mockk<MagazijnClient>()
@@ -558,6 +563,7 @@ class BerichtensessiecacheServiceTest {
             maxBerichtenPerMagazijn = 2,
             magazijnQueryTimeoutSeconds = 10L,
             magazijnReadTimeoutMs = 12000L,
+            cacheAwaitTimeoutSeconds = 5L,
         ).also { it.valideerTimeouts() }
 
         val client = mockk<MagazijnClient>()

--- a/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtensessiecacheServiceTest.kt
+++ b/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtensessiecacheServiceTest.kt
@@ -1,12 +1,16 @@
 package nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten
 
+import com.fasterxml.jackson.core.JsonParseException
+import com.fasterxml.jackson.core.JsonProcessingException
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.quarkus.test.junit.QuarkusTest
 import io.quarkus.test.junit.TestProfile
 import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.ProcessingException
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.MagazijnBerichtenResponse
+import nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.MagazijnFault
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.MagazijnClient
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.MagazijnClientFactory
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.MagazijnResolver
@@ -40,6 +44,9 @@ class BerichtensessiecacheServiceTest {
         resolver,
         innerTimeoutSeconds = 2L,
         outerAwaitSeconds = 3L,
+        maxBerichtenPerMagazijn = 1000,
+        magazijnQueryTimeoutSeconds = 10L,
+        magazijnReadTimeoutMs = 12000L,
     ).also { it.valideerTimeouts() }
 
     private val ontvanger = Bsn("999993653")
@@ -130,8 +137,7 @@ class BerichtensessiecacheServiceTest {
 
     @Test
     fun `resolver levert onbekende magazijn-ID werpt IllegalArgumentException en zet FOUT-status`() {
-        // Drift tussen resolver- en magazijn-config: hard falen i.p.v. stil minder magazijnen
-        // bevragen; lock vrijgeven vóór throw voorkomt TTL-hang.
+        // Hard falen ipv stil leeg-degraderen; cleanup vóór throw voorkomt lock-TTL-hang.
         every { berichtenCache.trySetAggregationStatus(cacheKey, any()) } returns Uni.createFrom().item(true)
         every { resolver.resolve(ontvanger) } returns Uni.createFrom().item(setOf("ghost-magazijn"))
         every { clientFactory.getAllClients() } returns emptyMap()
@@ -151,11 +157,35 @@ class BerichtensessiecacheServiceTest {
     }
 
     @Test
+    fun `onverwachte RuntimeException uit resolver levert 500 (niet 503) en zet FOUT-status`() {
+        // Eigen-bug → 500 (geen Retry-After); 503 zou client onnodig laten retryen.
+        every { berichtenCache.trySetAggregationStatus(cacheKey, any()) } returns Uni.createFrom().item(true)
+        every { resolver.resolve(ontvanger) } returns
+            Uni.createFrom().failure(IllegalStateException("interne bug"))
+        every { berichtenCache.storeAggregationStatus(cacheKey, any()) } returns Uni.createFrom().voidItem()
+
+        val ex = assertThrows<WebApplicationException> {
+            service.haalBerichtenOp(ontvanger)
+        }
+
+        assertEquals(500, ex.response.status)
+        verify {
+            berichtenCache.storeAggregationStatus(
+                cacheKey,
+                match { it.status == OphalenStatus.FOUT },
+            )
+        }
+    }
+
+    @Test
     fun `valideerTimeouts werpt IllegalArgumentException als outer gelijk is aan inner`() {
         // Outer == inner = race → niet-deterministische fout-classificatie. Fail-fast in startup.
         val mis = BerichtensessiecacheService(
             berichtenCache, clientFactory, resolver,
             innerTimeoutSeconds = 2L, outerAwaitSeconds = 2L,
+            maxBerichtenPerMagazijn = 1000,
+            magazijnQueryTimeoutSeconds = 10L,
+            magazijnReadTimeoutMs = 12000L,
         )
 
         val ex = assertThrows<IllegalArgumentException> { mis.valideerTimeouts() }
@@ -169,11 +199,34 @@ class BerichtensessiecacheServiceTest {
         val mis = BerichtensessiecacheService(
             berichtenCache, clientFactory, resolver,
             innerTimeoutSeconds = 5L, outerAwaitSeconds = 2L,
+            maxBerichtenPerMagazijn = 1000,
+            magazijnQueryTimeoutSeconds = 10L,
+            magazijnReadTimeoutMs = 12000L,
         )
 
         val ex = assertThrows<IllegalArgumentException> { mis.valideerTimeouts() }
 
         assertTrue(ex.message!!.contains("outer-await-seconds"), "Was: ${ex.message}")
+    }
+
+    @Test
+    fun `valideerTimeouts werpt IllegalArgumentException als read-timeout niet strikt groter is dan query-timeout`() {
+        // De socket-read-timeout MOET het query-timeout-budget overschrijden, anders kapt de
+        // socket een nog-lopende magazijn-call af vóór de Mutiny ifNoItem en krijgt de client
+        // een ruwe client-fout i.p.v. een TIMEOUT-event. read=10000ms == query=10s×1000 is niet
+        // strikt groter en moet de boot laten falen (pin op de `>`-grens, geen `>=`).
+        val mis = BerichtensessiecacheService(
+            berichtenCache, clientFactory, resolver,
+            innerTimeoutSeconds = 2L, outerAwaitSeconds = 3L,
+            maxBerichtenPerMagazijn = 1000,
+            magazijnQueryTimeoutSeconds = 10L,
+            magazijnReadTimeoutMs = 10_000L,
+        )
+
+        val ex = assertThrows<IllegalArgumentException> { mis.valideerTimeouts() }
+
+        assertTrue(ex.message!!.contains("read-timeout-ms"), "Was: ${ex.message}")
+        assertTrue(ex.message!!.contains("magazijn-query-timeout-seconds"), "Was: ${ex.message}")
     }
 
     @Test
@@ -204,7 +257,7 @@ class BerichtensessiecacheServiceTest {
 
     @Test
     fun `cleanup-fail tijdens Profiel-fout laat oorspronkelijke ProfielServiceFoutException winnen`() {
-        // Cleanup-fail mag oorspronkelijke ProfielServiceFoutException niet overschrijven.
+        // Cleanup-fail mag oorspronkelijke ProfielServiceFoutException niet overschrijven (zou 500 → 503-misclassificatie geven).
         val origineel = ProfielServiceFoutException.upstreamError(503)
 
         every { berichtenCache.trySetAggregationStatus(cacheKey, any()) } returns Uni.createFrom().item(true)
@@ -217,6 +270,122 @@ class BerichtensessiecacheServiceTest {
         }
 
         assertSame(origineel, ex, "Oorspronkelijke exception moet winnen, niet cleanup-fout")
+    }
+
+    @Test
+    fun `lege resolver-set met store-failure emit OPHALEN_FOUT-event met referentie en zet FOUT-status`() {
+        // SSE-stream is al gestart bij empty-resolver-set; client krijgt OPHALEN_FOUT-event
+        // i.p.v. mid-stream HTTP-500. Referentie verbindt event naar cleanup-log.
+        every { berichtenCache.trySetAggregationStatus(cacheKey, any()) } returns Uni.createFrom().item(true)
+        every { resolver.resolve(ontvanger) } returns Uni.createFrom().item(emptySet<String>())
+        every { clientFactory.getAllClients() } returns emptyMap()
+        every { berichtenCache.store(cacheKey, emptyList()) } returns
+            Uni.createFrom().failure(RuntimeException("Redis store down"))
+        every { berichtenCache.storeAggregationStatus(cacheKey, any()) } returns Uni.createFrom().voidItem()
+
+        val events = service.haalBerichtenOp(ontvanger).collect().asList()
+            .await().atMost(Duration.ofSeconds(5))
+
+        assertEquals(1, events.size)
+        assertEquals(EventType.OPHALEN_FOUT, events[0].event)
+        assertEquals(0, events[0].totaalMagazijnen)
+        assertNotNull(events[0].referentie)
+        org.junit.jupiter.api.Assertions.assertDoesNotThrow {
+            UUID.fromString(events[0].referentie!!)
+        }
+        assertTrue(
+            events[0].foutmelding!!.contains("(ref: ${events[0].referentie})"),
+            "Foutmelding moet de (ref: <UUID>)-suffix dragen die het referentie-veld spiegelt; was: ${events[0].foutmelding}",
+        )
+        verify {
+            berichtenCache.storeAggregationStatus(
+                cacheKey,
+                match { it.status == OphalenStatus.FOUT },
+            )
+        }
+    }
+
+    @Test
+    fun `lock-acquire-fout (Redis I-O onbereikbaar) levert 503 en doet best-effort cleanup`() {
+        // Cause-walking detecteert IOException ook als Mutiny 'm wrapt.
+        every { berichtenCache.trySetAggregationStatus(cacheKey, any()) } returns
+            Uni.createFrom().failure(java.io.IOException("Redis connection lost"))
+        every { berichtenCache.storeAggregationStatus(cacheKey, any()) } returns Uni.createFrom().voidItem()
+
+        val ex = assertThrows<WebApplicationException> {
+            service.haalBerichtenOp(ontvanger)
+        }
+
+        assertEquals(503, ex.response.status)
+        verify {
+            berichtenCache.storeAggregationStatus(
+                cacheKey,
+                match { it.status == OphalenStatus.FOUT },
+            )
+        }
+    }
+
+    @Test
+    fun `lock-acquire-fout (onverwachte RuntimeException, geen IO of timeout) levert 500`() {
+        // Eigen-code-bug → 500, geen 503: client retry'd niet op niet-transient fout.
+        every { berichtenCache.trySetAggregationStatus(cacheKey, any()) } returns
+            Uni.createFrom().failure(NullPointerException("interne bug"))
+        every { berichtenCache.storeAggregationStatus(cacheKey, any()) } returns Uni.createFrom().voidItem()
+
+        val ex = assertThrows<WebApplicationException> {
+            service.haalBerichtenOp(ontvanger)
+        }
+
+        assertEquals(500, ex.response.status)
+        verify {
+            berichtenCache.storeAggregationStatus(
+                cacheKey,
+                match { it.status == OphalenStatus.FOUT },
+            )
+        }
+    }
+
+    @Test
+    fun `lock-acquire JSON-serialisatie-fout (cause-gewrapt) levert 500 niet 503`() {
+        // Cause-walking moet JPE-cause door Mutiny-wrap heen alsnog naar 500 routeren.
+        val jpe = com.fasterxml.jackson.core.JsonParseException(null, "Onleesbare status")
+        every { berichtenCache.trySetAggregationStatus(cacheKey, any()) } returns
+            Uni.createFrom().failure(RuntimeException("wrapper", jpe))
+        every { berichtenCache.storeAggregationStatus(cacheKey, any()) } returns Uni.createFrom().voidItem()
+
+        val ex = assertThrows<WebApplicationException> {
+            service.haalBerichtenOp(ontvanger)
+        }
+
+        assertEquals(500, ex.response.status)
+    }
+
+    @Test
+    fun `magazijn JsonProcessingException levert schema-drift foutmelding in MagazijnEvent`() {
+        // Schema-drift moet eigen-foutmelding krijgen, niet als generieke netwerkfout maskeren.
+        val client = mockk<MagazijnClient>()
+        val parseFout = JsonParseException(null, "Unexpected token at position 42")
+
+        every { berichtenCache.trySetAggregationStatus(cacheKey, any()) } returns Uni.createFrom().item(true)
+        every { resolver.resolve(ontvanger) } returns Uni.createFrom().item(setOf("magazijn-a"))
+        every { clientFactory.getAllClients() } returns mapOf("magazijn-a" to client)
+        every { clientFactory.getNaam("magazijn-a") } returns "Test magazijn A"
+        every { client.getBerichten(any(), any()) } throws ProcessingException(parseFout)
+        every { berichtenCache.updateAggregationStatus(cacheKey, any()) } returns Uni.createFrom().voidItem()
+        every { berichtenCache.store(cacheKey, any()) } returns Uni.createFrom().voidItem()
+        every { berichtenCache.storeAggregationStatus(cacheKey, any()) } returns Uni.createFrom().voidItem()
+
+        val events = service.haalBerichtenOp(ontvanger).collect().asList()
+            .await().atMost(Duration.ofSeconds(15))
+
+        val voltooidEvent = events.first { it.event == EventType.MAGAZIJN_BEVRAGING_VOLTOOID }
+
+        assertEquals(MagazijnStatus.FOUT, voltooidEvent.status)
+        assertNotNull(voltooidEvent.foutmelding)
+        assertTrue(
+            voltooidEvent.foutmelding!!.contains("schema-drift"),
+            "Foutmelding moet schema-drift signaleren, niet generieke netwerk-fout: ${voltooidEvent.foutmelding}",
+        )
     }
 
     @Test
@@ -254,9 +423,35 @@ class BerichtensessiecacheServiceTest {
     }
 
     @Test
-    fun `cache-fout na aggregatie produceert OPHALEN_FOUT-event`() {
-        // store + status-write falen: pipeline moet een OPHALEN_FOUT-event emitten i.p.v.
-        // mid-stream te 500-throwen naar de SSE-client.
+    fun `updateAggregationStatus(BEZIG, totaalMagazijnen) fail levert 503 en FOUT-cleanup`() {
+        // Tweede status-write na geslaagde lock; cleanup moet lock vrijgeven, anders 60s hang.
+        val client = mockk<MagazijnClient>(relaxed = true)
+
+        every { berichtenCache.trySetAggregationStatus(cacheKey, any()) } returns Uni.createFrom().item(true)
+        every { resolver.resolve(ontvanger) } returns Uni.createFrom().item(setOf("magazijn-a"))
+        every { clientFactory.getAllClients() } returns mapOf("magazijn-a" to client)
+        every { clientFactory.getNaam("magazijn-a") } returns "Magazijn A"
+        every { berichtenCache.updateAggregationStatus(cacheKey, any()) } returns
+            Uni.createFrom().failure(RuntimeException("Redis update faalde"))
+        every { berichtenCache.storeAggregationStatus(cacheKey, any()) } returns Uni.createFrom().voidItem()
+
+        val ex = assertThrows<WebApplicationException> {
+            service.haalBerichtenOp(ontvanger)
+        }
+
+        assertEquals(503, ex.response.status)
+        verify {
+            berichtenCache.storeAggregationStatus(
+                cacheKey,
+                match { it.status == OphalenStatus.FOUT },
+            )
+        }
+    }
+
+    @Test
+    fun `cache double-fail (store + status fail) produceert OPHALEN_FOUT event`() {
+        // Pipeline moet event emitten (niet hangen, niet 500-throwen naar SSE).
+        // Lock leunt dan op Redis-TTL — geaccepteerd, beter dan oneindig vasthouden.
         val client = mockk<MagazijnClient>()
 
         every { berichtenCache.trySetAggregationStatus(cacheKey, any()) } returns Uni.createFrom().item(true)
@@ -264,6 +459,7 @@ class BerichtensessiecacheServiceTest {
         every { clientFactory.getAllClients() } returns mapOf("magazijn-a" to client)
         every { clientFactory.getNaam("magazijn-a") } returns "Magazijn A"
         every { client.getBerichten(any(), any()) } returns MagazijnBerichtenResponse(emptyList())
+        every { berichtenCache.updateAggregationStatus(cacheKey, any()) } returns Uni.createFrom().voidItem()
         every { berichtenCache.store(cacheKey, any()) } returns
             Uni.createFrom().failure(RuntimeException("Redis store down"))
         every { berichtenCache.storeAggregationStatus(cacheKey, any()) } returns
@@ -275,7 +471,59 @@ class BerichtensessiecacheServiceTest {
         val fouten = events.filter { it.event == EventType.OPHALEN_FOUT }
 
         assertEquals(1, fouten.size, "Verwacht 1 OPHALEN_FOUT-event in: $events")
-        assertNotNull(fouten[0].foutmelding)
+        assertNotNull(fouten[0].referentie, "OPHALEN_FOUT moet referentie dragen voor support-correlatie")
+        org.junit.jupiter.api.Assertions.assertDoesNotThrow {
+            UUID.fromString(fouten[0].referentie!!)
+        }
+        // De referentie staat zowel in de foutmelding-tekst ("(ref: ...)") als in het
+        // gestructureerde referentie-veld; de tekst meldt expliciet dat eerder getoonde
+        // per-magazijn-resultaten niet bewaard zijn.
+        assertTrue(
+            fouten[0].foutmelding!!.startsWith("Resultaten konden niet worden opgeslagen"),
+            "Foutmelding moet melden dat resultaten niet bewaard zijn; was: ${fouten[0].foutmelding}",
+        )
+        assertTrue(
+            fouten[0].foutmelding!!.contains("(ref: ${fouten[0].referentie})"),
+            "Foutmelding moet (ref: <UUID>)-suffix dragen; was: ${fouten[0].foutmelding}",
+        )
+    }
+
+    @Test
+    fun `magazijn-response boven size-cap wordt geweigerd met overflow-foutmelding`() {
+        // cap=2, magazijn levert 3 → FOUT + overflow-foutmelding.
+        val serviceMetLageCap = BerichtensessiecacheService(
+            berichtenCache, clientFactory, resolver,
+            innerTimeoutSeconds = 2L, outerAwaitSeconds = 3L,
+            maxBerichtenPerMagazijn = 2,
+            magazijnQueryTimeoutSeconds = 10L,
+            magazijnReadTimeoutMs = 12000L,
+        ).also { it.valideerTimeouts() }
+
+        val client = mockk<MagazijnClient>()
+        val drieBerichten = (1..3).map { i ->
+            testBericht().copy(berichtId = UUID.fromString("00000000-0000-0000-0000-00000000000$i"))
+        }
+
+        every { berichtenCache.trySetAggregationStatus(cacheKey, any()) } returns Uni.createFrom().item(true)
+        every { resolver.resolve(ontvanger) } returns Uni.createFrom().item(setOf("magazijn-a"))
+        every { clientFactory.getAllClients() } returns mapOf("magazijn-a" to client)
+        every { clientFactory.getNaam("magazijn-a") } returns "Magazijn A"
+        every { client.getBerichten(any(), any()) } returns MagazijnBerichtenResponse(drieBerichten)
+        every { berichtenCache.updateAggregationStatus(cacheKey, any()) } returns Uni.createFrom().voidItem()
+        every { berichtenCache.store(cacheKey, any()) } returns Uni.createFrom().voidItem()
+        every { berichtenCache.storeAggregationStatus(cacheKey, any()) } returns Uni.createFrom().voidItem()
+
+        val events = serviceMetLageCap.haalBerichtenOp(ontvanger).collect().asList()
+            .await().atMost(Duration.ofSeconds(15))
+
+        val voltooid = events.first { it.event == EventType.MAGAZIJN_BEVRAGING_VOLTOOID }
+
+        assertEquals(MagazijnStatus.FOUT, voltooid.status)
+        assertNotNull(voltooid.foutmelding)
+        assertTrue(
+            voltooid.foutmelding!!.contains("te veel berichten"),
+            "Foutmelding moet overflow signaleren: ${voltooid.foutmelding}",
+        )
     }
 
     @Test
@@ -288,6 +536,7 @@ class BerichtensessiecacheServiceTest {
         every { clientFactory.getAllClients() } returns mapOf("magazijn-a" to client)
         every { clientFactory.getNaam("magazijn-a") } returns "Magazijn A"
         every { client.getBerichten(any(), any()) } throws NullPointerException("gegenereerde client NPE")
+        every { berichtenCache.updateAggregationStatus(cacheKey, any()) } returns Uni.createFrom().voidItem()
         every { berichtenCache.store(cacheKey, any()) } returns Uni.createFrom().voidItem()
         every { berichtenCache.storeAggregationStatus(cacheKey, any()) } returns Uni.createFrom().voidItem()
 
@@ -297,11 +546,98 @@ class BerichtensessiecacheServiceTest {
         val voltooid = events.first { it.event == EventType.MAGAZIJN_BEVRAGING_VOLTOOID }
 
         assertEquals(MagazijnStatus.FOUT, voltooid.status)
-        assertEquals("Magazijn tijdelijk niet bereikbaar", voltooid.foutmelding)
+        assertEquals("Magazijn kon niet geraadpleegd worden", voltooid.foutmelding)
     }
 
     @Test
-    fun `ConnectException uit MagazijnClient levert FOUT met generieke foutmelding`() {
+    fun `boundary - response exact op max-berichten-cap is succesvol (cap is strikt groter dan)`() {
+        // Pinned off-by-one: cap-check is `>` (strikt), niet `>=`.
+        val serviceMetLageCap = BerichtensessiecacheService(
+            berichtenCache, clientFactory, resolver,
+            innerTimeoutSeconds = 2L, outerAwaitSeconds = 3L,
+            maxBerichtenPerMagazijn = 2,
+            magazijnQueryTimeoutSeconds = 10L,
+            magazijnReadTimeoutMs = 12000L,
+        ).also { it.valideerTimeouts() }
+
+        val client = mockk<MagazijnClient>()
+        val tweeBerichten = (1..2).map { i ->
+            testBericht().copy(berichtId = UUID.fromString("00000000-0000-0000-0000-00000000000$i"))
+        }
+
+        every { berichtenCache.trySetAggregationStatus(cacheKey, any()) } returns Uni.createFrom().item(true)
+        every { resolver.resolve(ontvanger) } returns Uni.createFrom().item(setOf("magazijn-a"))
+        every { clientFactory.getAllClients() } returns mapOf("magazijn-a" to client)
+        every { clientFactory.getNaam("magazijn-a") } returns "Magazijn A"
+        every { client.getBerichten(any(), any()) } returns MagazijnBerichtenResponse(tweeBerichten)
+        every { berichtenCache.updateAggregationStatus(cacheKey, any()) } returns Uni.createFrom().voidItem()
+        every { berichtenCache.store(cacheKey, any()) } returns Uni.createFrom().voidItem()
+        every { berichtenCache.storeAggregationStatus(cacheKey, any()) } returns Uni.createFrom().voidItem()
+
+        val events = serviceMetLageCap.haalBerichtenOp(ontvanger).collect().asList()
+            .await().atMost(Duration.ofSeconds(15))
+
+        val voltooid = events.first { it.event == EventType.MAGAZIJN_BEVRAGING_VOLTOOID }
+
+        assertEquals(MagazijnStatus.OK, voltooid.status)
+        assertEquals(2, voltooid.aantalBerichten)
+    }
+
+    @Test
+    fun `lock-acquire JSON-fout via 2-niveau cause-wrap classificeert nog steeds als 500`() {
+        // Productie-pad is CompletionException → SyncFailure → JPE (>=2 niveaus).
+        // Pinned dat hasCauseOf de volledige chain afloopt (geen 1-niveau-shortcut).
+        val jpe = com.fasterxml.jackson.core.JsonParseException(null, "diep genest")
+        val gewrapt = RuntimeException("outer", RuntimeException("middle", jpe))
+
+        every { berichtenCache.trySetAggregationStatus(cacheKey, any()) } returns
+            Uni.createFrom().failure(gewrapt)
+        every { berichtenCache.storeAggregationStatus(cacheKey, any()) } returns Uni.createFrom().voidItem()
+
+        val ex = assertThrows<WebApplicationException> {
+            service.haalBerichtenOp(ontvanger)
+        }
+
+        assertEquals(500, ex.response.status)
+    }
+
+    @Test
+    fun `lock-acquire-fout (cause-gewrapt InterruptedException) levert 503 en herstelt interrupt-flag`() {
+        // Pod-shutdown tijdens lock-acquire: classifier moet INTERRUPTED detecteren en de
+        // interrupt-flag herstellen voor bovenliggende graceful-shutdown.
+        val gewrapt = RuntimeException("wrap", InterruptedException("pod-shutdown"))
+        every { berichtenCache.trySetAggregationStatus(cacheKey, any()) } returns
+            Uni.createFrom().failure(gewrapt)
+        every { berichtenCache.storeAggregationStatus(cacheKey, any()) } returns Uni.createFrom().voidItem()
+
+        val ex = assertThrows<WebApplicationException> {
+            service.haalBerichtenOp(ontvanger)
+        }
+
+        assertEquals(503, ex.response.status)
+        assertTrue(Thread.interrupted(), "Interrupt-flag moet zijn hersteld na catch")
+    }
+
+    @Test
+    fun `lock-acquire-fout (TimeoutException-cause) levert 503 met timeout-melding`() {
+        val gewrapt = RuntimeException("wrap", java.util.concurrent.TimeoutException("await overschreden"))
+        every { berichtenCache.trySetAggregationStatus(cacheKey, any()) } returns
+            Uni.createFrom().failure(gewrapt)
+        every { berichtenCache.storeAggregationStatus(cacheKey, any()) } returns Uni.createFrom().voidItem()
+
+        val ex = assertThrows<WebApplicationException> {
+            service.haalBerichtenOp(ontvanger)
+        }
+
+        assertEquals(503, ex.response.status)
+        assertTrue(
+            ex.message!!.contains("timeout", ignoreCase = true),
+            "Foutmelding moet timeout-specifiek zijn: ${ex.message}",
+        )
+    }
+
+    @Test
+    fun `ConnectException uit MagazijnClient classificeert als NETWORK met generieke foutmelding`() {
         val client = mockk<MagazijnClient>()
 
         every { berichtenCache.trySetAggregationStatus(cacheKey, any()) } returns Uni.createFrom().item(true)
@@ -309,6 +645,7 @@ class BerichtensessiecacheServiceTest {
         every { clientFactory.getAllClients() } returns mapOf("magazijn-a" to client)
         every { clientFactory.getNaam("magazijn-a") } returns "Magazijn A"
         every { client.getBerichten(any(), any()) } throws java.net.ConnectException("connection refused")
+        every { berichtenCache.updateAggregationStatus(cacheKey, any()) } returns Uni.createFrom().voidItem()
         every { berichtenCache.store(cacheKey, any()) } returns Uni.createFrom().voidItem()
         every { berichtenCache.storeAggregationStatus(cacheKey, any()) } returns Uni.createFrom().voidItem()
 
@@ -318,7 +655,7 @@ class BerichtensessiecacheServiceTest {
         val voltooid = events.first { it.event == EventType.MAGAZIJN_BEVRAGING_VOLTOOID }
 
         assertEquals(MagazijnStatus.FOUT, voltooid.status)
-        assertEquals("Magazijn tijdelijk niet bereikbaar", voltooid.foutmelding)
+        assertEquals("Magazijn kon niet geraadpleegd worden", voltooid.foutmelding)
     }
 
     @Test
@@ -330,6 +667,7 @@ class BerichtensessiecacheServiceTest {
         every { clientFactory.getAllClients() } returns mapOf("magazijn-a" to client)
         every { clientFactory.getNaam("magazijn-a") } returns "Magazijn A"
         every { client.getBerichten(any(), any()) } returns MagazijnBerichtenResponse(emptyList())
+        every { berichtenCache.updateAggregationStatus(cacheKey, any()) } returns Uni.createFrom().voidItem()
         every { berichtenCache.store(cacheKey, any()) } returns Uni.createFrom().voidItem()
         every { berichtenCache.storeAggregationStatus(cacheKey, any()) } returns Uni.createFrom().voidItem()
 
@@ -344,9 +682,10 @@ class BerichtensessiecacheServiceTest {
 
     @Test
     fun `CONFIG_DRIFT exception uit resolver emit OPHALEN_FOUT-event ipv 503 en geeft lock vrij`() {
-        // Resolver gooit configDrift wanneer alle opt-in OINs onbekend zijn. Service mag NIET
-        // 503 throwen (Profiel werkt prima); moet zichtbaar OPHALEN_FOUT emitten + lock vrijgeven
-        // via storeAggregationStatus(FOUT), anders blijft een volgende request 60s vastlopen.
+        // Resolver gooit configDrift wanneer alle opt-in OINs onbekend zijn. Service
+        // mag NIET 503 throwen (Profiel werkt prima); moet zichtbaar OPHALEN_FOUT-
+        // event emitten + lock vrijgeven via storeAggregationStatus(FOUT), anders
+        // blijft een volgende request 60s vastlopen op de lock.
         every { berichtenCache.trySetAggregationStatus(cacheKey, any()) } returns Uni.createFrom().item(true)
         every { resolver.resolve(ontvanger) } returns
             Uni.createFrom().failure(ProfielServiceFoutException.configDrift())
@@ -361,10 +700,14 @@ class BerichtensessiecacheServiceTest {
             events[0].foutmelding!!.contains("configuratie"),
             "Foutmelding moet config-mismatch noemen: ${events[0].foutmelding}",
         )
+        // referentie-veld voor support-correlatie moet geldige UUID-string zijn,
+        // én moet als substring in foutmelding voorkomen (riem-en-bretels invariant).
         assertNotNull(events[0].referentie)
         org.junit.jupiter.api.Assertions.assertDoesNotThrow {
             UUID.fromString(events[0].referentie!!)
         }
+        // Strakker dan contains() — pint de "(ref: <id>)"-suffix-conventie vast die
+        // de service-comment expliciet belooft; voorkomt stille refactor naar prefix/midden.
         assertTrue(
             events[0].foutmelding!!.endsWith("(ref: ${events[0].referentie})"),
             "foutmelding moet '(ref: <id>)'-suffix hebben: ${events[0].foutmelding}",
@@ -374,6 +717,97 @@ class BerichtensessiecacheServiceTest {
                 cacheKey,
                 match { it.status == OphalenStatus.FOUT },
             )
+        }
+    }
+
+    @Test
+    fun `classifyMagazijnFault termineert op steeds-nieuwe-wrapper cause-getter (depth-cap)`() {
+        // IdentityHashMap helpt niet als elke cause-call een NIEUW object van dezelfde
+        // overridden-cause-subklasse retourneert. Pathologische chain groeit anders
+        // onbegrensd; depth-cap moet afkappen.
+        class GrowingThrowable : Throwable("growing") {
+            override val cause: Throwable get() = GrowingThrowable()
+        }
+
+        org.junit.jupiter.api.Assertions.assertTimeoutPreemptively(Duration.ofSeconds(1)) {
+            service.classifyMagazijnFault(GrowingThrowable())
+        }
+    }
+
+    @Test
+    fun `classifyMagazijnFault termineert binnen 1s op circular cause-chain`() {
+        // Zonder seen-set zou cause-walk oneindig loopen → SSE-stream vast.
+        // Twee cycle-varianten: self-cycle (test-mock) + mutual cycle (proxy-wrap).
+        val selfCycle = object : Throwable("self") {
+            override val cause: Throwable get() = this
+        }
+
+        val e1 = RuntimeException("first")
+        val e2 = RuntimeException("second")
+        e1.initCause(e2)
+        e2.initCause(e1)
+
+        org.junit.jupiter.api.Assertions.assertTimeoutPreemptively(Duration.ofSeconds(1)) {
+            service.classifyMagazijnFault(selfCycle)
+        }
+        org.junit.jupiter.api.Assertions.assertTimeoutPreemptively(Duration.ofSeconds(1)) {
+            service.classifyMagazijnFault(e1)
+        }
+    }
+
+    @Test
+    fun `classifyMagazijnFault matched root-class (cause==null edge)`() {
+        // causeChain() includes ex zelf als chain[0]; chain.hasCauseOf(X) moet dus
+        // matchen wanneer root direct van type X is en cause==null. Eerdere refactor
+        // verwijderde `ex is X` directe checks; deze test borgt dat causeChain dat dekt.
+        assertEquals(MagazijnFault.TIMEOUT, service.classifyMagazijnFault(io.smallrye.mutiny.TimeoutException()))
+        assertEquals(MagazijnFault.MALFORMED, service.classifyMagazijnFault(JsonParseException(null, "bare")))
+        assertEquals(MagazijnFault.INTERNAL_BUG, service.classifyMagazijnFault(RuntimeException("bare")))
+    }
+
+    @Test
+    fun `classifyMagazijnFault doorloopt cause-chain exact EEN keer per call`() {
+        // Regressie-guard: P3-refactor verving N losse hasCauseOf-walks (elk depth-cap-warnf
+        // kandidaat → Loki-storm) door één causeChain()-materialisatie + N instanceof-checks
+        // tegen de cached list. Counting-Throwable telt cause-accesses; één walk ≈ MAX_CAUSE_DEPTH,
+        // een refactor terug naar per-check-walks zou een veelvoud opleveren.
+        val counter = java.util.concurrent.atomic.AtomicInteger()
+
+        class CountingGrowingThrowable : Throwable("counting") {
+            override val cause: Throwable get() {
+                counter.incrementAndGet()
+                return CountingGrowingThrowable()
+            }
+        }
+
+        service.classifyMagazijnFault(CountingGrowingThrowable())
+
+        // Eén walk hoogstens MAX_CAUSE_DEPTH (32) cause-accesses; ruime bovengrens 50
+        // dekt eventuele toekomstige cap-verhoging, maar vlagt ≥2 walks (>=64).
+        assertTrue(
+            counter.get() < 50,
+            "Verwacht 1 causeChain-walk (≈32 cause-accesses), maar telde ${counter.get()} — refactor terug naar per-check-walks?",
+        )
+    }
+
+    @Test
+    fun `classifyLockAcquireError termineert binnen 1s op circular cause-chain`() {
+        // classifyLockAcquireError deelt causeChain() met classifyMagazijnFault;
+        // symmetrische cycle-test voorkomt regressie bij toekomstige divergentie.
+        val selfCycle = object : Throwable("self") {
+            override val cause: Throwable get() = this
+        }
+
+        val e1 = RuntimeException("first")
+        val e2 = RuntimeException("second")
+        e1.initCause(e2)
+        e2.initCause(e1)
+
+        org.junit.jupiter.api.Assertions.assertTimeoutPreemptively(Duration.ofSeconds(1)) {
+            service.classifyLockAcquireError(selfCycle)
+        }
+        org.junit.jupiter.api.Assertions.assertTimeoutPreemptively(Duration.ofSeconds(1)) {
+            service.classifyLockAcquireError(e1)
         }
     }
 

--- a/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/CacheAwaitTimeoutWiringTest.kt
+++ b/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/CacheAwaitTimeoutWiringTest.kt
@@ -1,0 +1,74 @@
+package nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten
+
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import io.smallrye.mutiny.Uni
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Alternative
+import jakarta.inject.Inject
+import jakarta.ws.rs.WebApplicationException
+import nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.MagazijnResolver
+import nl.rijksoverheid.moz.fbs.common.identificatie.Bsn
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+/**
+ * Pin dat `berichtensessiecache.cache-await-timeout-seconds` daadwerkelijk de
+ * Redis-await-grens in [BerichtensessiecacheService.haalBerichtenOp] bedient. Een
+ * verkeerd gespelde property-naam of ontbrekende `@ConfigProperty` zou compileren én
+ * alle unit-tests halen (die de waarde als literal doorgeven) en daarna stil
+ * terugvallen op de default in productie.
+ *
+ * De lock-acquire wordt 3s vertraagd; de override zet de grens op 1s. 3s ligt tússen
+ * de geconfigureerde 1s en de default 5s: alleen als de property gelezen wordt slaat
+ * de await-timeout aan (→ 503). Bij een losgekoppelde property zou de default 5s de
+ * 3s-delay opvangen en zou er geen fout volgen.
+ */
+@QuarkusTest
+@TestProfile(CacheAwaitTimeoutTestProfile::class)
+class CacheAwaitTimeoutWiringTest {
+
+    @Inject
+    lateinit var service: BerichtensessiecacheService
+
+    @Test
+    fun `cache-await-timeout uit config bedient de Redis-await-grens`() {
+        val ex = assertThrows(WebApplicationException::class.java) {
+            service.haalBerichtenOp(Bsn("999993653"))
+        }
+
+        assertEquals(503, ex.response.status)
+        assertTrue(ex.message!!.contains("timeout", ignoreCase = true), "Was: ${ex.message}")
+    }
+}
+
+/**
+ * Vertraagt uitsluitend de lock-acquire zodat de await-timeout meetbaar wordt; alle
+ * overige cache-operaties erven het directe in-memory-gedrag van [MockBerichtenCache].
+ */
+@Alternative
+@ApplicationScoped
+class TraagLockBerichtenCache : MockBerichtenCache() {
+
+    override fun trySetAggregationStatus(key: String, status: AggregationStatus): Uni<Boolean> =
+        super.trySetAggregationStatus(key, status).onItem().delayIt().by(Duration.ofSeconds(3))
+}
+
+class CacheAwaitTimeoutTestProfile : QuarkusTestProfile {
+
+    override fun getEnabledAlternatives(): Set<Class<*>> = setOf(
+        TraagLockBerichtenCache::class.java,
+        MockMagazijnClientFactory::class.java,
+        MockMagazijnResolver::class.java,
+    )
+
+    override fun getConfigOverrides(): Map<String, String> = mapOf(
+        "quarkus.redis.devservices.enabled" to "false",
+        "quarkus.redis.hosts" to "redis://localhost:6379",
+        "berichtensessiecache.cache-await-timeout-seconds" to "1",
+    )
+}

--- a/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/ClassifyMagazijnFaultTest.kt
+++ b/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/ClassifyMagazijnFaultTest.kt
@@ -1,0 +1,136 @@
+package nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten
+
+import com.fasterxml.jackson.core.JsonParseException
+import io.mockk.mockk
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.TestProfile
+import io.smallrye.mutiny.TimeoutException
+import jakarta.ws.rs.ProcessingException
+import jakarta.ws.rs.WebApplicationException
+import jakarta.ws.rs.core.Response
+import nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.MagazijnClientFactory
+import nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.MagazijnFault
+import nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.MagazijnResolver
+import nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.MagazijnResponseOverflow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Direct-tests op `classifyMagazijnFault` — buiten de end-to-end SSE-pipeline om.
+ * Pinned alle enum-takken inclusief edge-cases (WAE met null Response, status=0,
+ * status=399) en cause-walking via geneste exceptions.
+ */
+@QuarkusTest
+@TestProfile(MockedDependenciesProfile::class)
+class ClassifyMagazijnFaultTest {
+
+    private val service = BerichtensessiecacheService(
+        mockk<BerichtenCache>(),
+        mockk<MagazijnClientFactory>(),
+        mockk<MagazijnResolver>(relaxed = true),
+        innerTimeoutSeconds = 2L,
+        outerAwaitSeconds = 3L,
+        maxBerichtenPerMagazijn = 1000,
+        magazijnQueryTimeoutSeconds = 10L,
+        magazijnReadTimeoutMs = 12000L,
+    ).also { it.valideerTimeouts() }
+
+    @Test
+    fun `TimeoutException direct = TIMEOUT`() {
+        assertEquals(MagazijnFault.TIMEOUT, service.classifyMagazijnFault(TimeoutException()))
+    }
+
+    @Test
+    fun `MagazijnResponseOverflow direct = OVERFLOW`() {
+        assertEquals(MagazijnFault.OVERFLOW, service.classifyMagazijnFault(MagazijnResponseOverflow("te veel")))
+    }
+
+    @Test
+    fun `JsonProcessingException direct = MALFORMED`() {
+        assertEquals(MagazijnFault.MALFORMED, service.classifyMagazijnFault(JsonParseException(null, "oeps")))
+    }
+
+    @Test
+    fun `ProcessingException met JPE-cause = MALFORMED`() {
+        assertEquals(
+            MagazijnFault.MALFORMED,
+            service.classifyMagazijnFault(ProcessingException(JsonParseException(null, "oeps"))),
+        )
+    }
+
+    @Test
+    fun `diep-geneste JPE (CompletionException-achtige wrap) = MALFORMED`() {
+        val diep = RuntimeException("outer", RuntimeException("middle", JsonParseException(null, "diep")))
+        assertEquals(MagazijnFault.MALFORMED, service.classifyMagazijnFault(diep))
+    }
+
+    @Test
+    fun `ConnectException direct = NETWORK`() {
+        assertEquals(MagazijnFault.NETWORK, service.classifyMagazijnFault(java.net.ConnectException("refused")))
+    }
+
+    @Test
+    fun `ProcessingException zonder cause = NETWORK`() {
+        assertEquals(MagazijnFault.NETWORK, service.classifyMagazijnFault(ProcessingException("net")))
+    }
+
+    @Test
+    fun `CancellationException = NETWORK (annulering is geen INTERNAL_BUG)`() {
+        assertEquals(
+            MagazijnFault.NETWORK,
+            service.classifyMagazijnFault(java.util.concurrent.CancellationException("cancelled")),
+        )
+    }
+
+    @Test
+    fun `WebApplicationException 500 = HTTP_5XX`() {
+        assertEquals(
+            MagazijnFault.HTTP_5XX,
+            service.classifyMagazijnFault(WebApplicationException(Response.status(500).build())),
+        )
+    }
+
+    @Test
+    fun `WebApplicationException 403 = HTTP_4XX`() {
+        assertEquals(
+            MagazijnFault.HTTP_4XX,
+            service.classifyMagazijnFault(WebApplicationException(Response.status(403).build())),
+        )
+    }
+
+    @Test
+    fun `WebApplicationException zonder bruikbare status = INTERNAL_BUG`() {
+        // Raw WAE("oeps") zonder Response heeft status=500 (default), valt onder HTTP_5XX.
+        // Maar handmatig-geconstrueerde WAE met null response geeft status=0 → INTERNAL_BUG.
+        val wae = object : WebApplicationException("raw") {
+            override fun getResponse(): Response? = null
+        }
+        assertEquals(MagazijnFault.INTERNAL_BUG, service.classifyMagazijnFault(wae))
+    }
+
+    @Test
+    fun `WebApplicationException status 399 (geen 4xx, geen 5xx) = INTERNAL_BUG`() {
+        // Edge: 399 valt buiten beide HTTP-bereiken → eigen-bug.
+        assertEquals(
+            MagazijnFault.INTERNAL_BUG,
+            service.classifyMagazijnFault(WebApplicationException(Response.status(399).build())),
+        )
+    }
+
+    @Test
+    fun `NullPointerException = INTERNAL_BUG`() {
+        assertEquals(MagazijnFault.INTERNAL_BUG, service.classifyMagazijnFault(NullPointerException("npe")))
+    }
+
+    @Test
+    fun `IllegalStateException = INTERNAL_BUG`() {
+        assertEquals(MagazijnFault.INTERNAL_BUG, service.classifyMagazijnFault(IllegalStateException("oeps")))
+    }
+
+    @Test
+    fun `WAE met 500-status diep gewrapt = HTTP_5XX (cause-walking)`() {
+        val wae = WebApplicationException(Response.status(500).build())
+        val diep = RuntimeException("outer", wae)
+        assertEquals(MagazijnFault.HTTP_5XX, service.classifyMagazijnFault(diep))
+    }
+}

--- a/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/ClassifyMagazijnFaultTest.kt
+++ b/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/ClassifyMagazijnFaultTest.kt
@@ -33,6 +33,7 @@ class ClassifyMagazijnFaultTest {
         maxBerichtenPerMagazijn = 1000,
         magazijnQueryTimeoutSeconds = 10L,
         magazijnReadTimeoutMs = 12000L,
+        cacheAwaitTimeoutSeconds = 5L,
     ).also { it.valideerTimeouts() }
 
     @Test

--- a/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/MockMagazijnClientFactory.kt
+++ b/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/MockMagazijnClientFactory.kt
@@ -19,6 +19,8 @@ import java.util.UUID
 class MockMagazijnClientFactory : MagazijnClientFactory(
     MockMagazijnenConfig(),
     profile = "test",
+    connectTimeoutMs = 2000L,
+    readTimeoutMs = 12000L,
 ) {
 
     companion object {

--- a/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnClientFactoryInitTest.kt
+++ b/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnClientFactoryInitTest.kt
@@ -32,7 +32,7 @@ class MagazijnClientFactoryInitTest {
 
     @Test
     fun `init met lege instances faalt met 'Geen magazijnen geconfigureerd'`() {
-        val factory = MagazijnClientFactory(makeConfig(emptyMap()), profile = "test")
+        val factory = MagazijnClientFactory(makeConfig(emptyMap()), profile = "test", connectTimeoutMs = 2000L, readTimeoutMs = 12000L)
 
         val ex = assertThrows<IllegalArgumentException> { factory.init() }
 
@@ -47,6 +47,8 @@ class MagazijnClientFactoryInitTest {
                 mapOf("mag-a" to makeInstance(url = "http://host met spaties/pad", afzenders = listOf("00000001003214345000"))),
             ),
             profile = "test",
+            connectTimeoutMs = 2000L,
+            readTimeoutMs = 12000L,
         )
 
         val ex = assertThrows<IllegalStateException> { factory.init() }
@@ -61,6 +63,8 @@ class MagazijnClientFactoryInitTest {
                 mapOf("mag-a" to makeInstance(url = "http://localhost:8081", afzenders = emptyList())),
             ),
             profile = "test",
+            connectTimeoutMs = 2000L,
+            readTimeoutMs = 12000L,
         )
 
         val ex = assertThrows<IllegalArgumentException> { factory.init() }
@@ -75,6 +79,8 @@ class MagazijnClientFactoryInitTest {
                 mapOf("mag-a" to makeInstance(url = "http://localhost:8081", afzenders = listOf("12345"))),
             ),
             profile = "test",
+            connectTimeoutMs = 2000L,
+            readTimeoutMs = 12000L,
         )
 
         val ex = assertThrows<IllegalStateException> { factory.init() }
@@ -89,6 +95,8 @@ class MagazijnClientFactoryInitTest {
                 mapOf("mag-a" to makeInstance(url = "http://magazijn-a.prod.local", afzenders = listOf("00000001003214345000"))),
             ),
             profile = "prod",
+            connectTimeoutMs = 2000L,
+            readTimeoutMs = 12000L,
         )
 
         val ex = assertThrows<IllegalArgumentException> { factory.init() }
@@ -107,6 +115,8 @@ class MagazijnClientFactoryInitTest {
                 mapOf("mag-a" to makeInstance(url = "http://localhost:8081", afzenders = listOf(oinA, oinB))),
             ),
             profile = "test",
+            connectTimeoutMs = 2000L,
+            readTimeoutMs = 12000L,
         )
 
         factory.init()
@@ -128,6 +138,8 @@ class MagazijnClientFactoryInitTest {
                 ),
             ),
             profile = "test",
+            connectTimeoutMs = 2000L,
+            readTimeoutMs = 12000L,
         )
 
         factory.init()
@@ -142,6 +154,8 @@ class MagazijnClientFactoryInitTest {
                 mapOf("mag-a" to makeInstance(url = "http://localhost:8081", afzenders = listOf("00000000000000000000"))),
             ),
             profile = "test",
+            connectTimeoutMs = 2000L,
+            readTimeoutMs = 12000L,
         )
 
         val ex = assertThrows<IllegalStateException> { factory.init() }

--- a/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnClientWireMockTest.kt
+++ b/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnClientWireMockTest.kt
@@ -11,6 +11,8 @@ import io.restassured.RestAssured.given
 import jakarta.inject.Inject
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.MockBerichtenCache
 import org.hamcrest.CoreMatchers.`is`
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -36,6 +38,11 @@ class MagazijnClientWireMockTest {
     // zodat GET /berichten-asserts niet op state van een vorige test leunen.
     @Inject
     lateinit var cache: MockBerichtenCache
+
+    // Echte factory (geen mock onder dit profiel): levert de REST-clients die met de
+    // geconfigureerde read-timeout naar de WireMock-magazijns wijzen.
+    @Inject
+    lateinit var clientFactory: MagazijnClientFactory
 
     @BeforeEach
     fun setUp() {
@@ -103,10 +110,68 @@ class MagazijnClientWireMockTest {
     }
 
     @Test
+    fun `query-timeout op de geconfigureerde grens levert TIMEOUT (niet de prod-default)`() {
+        // De delay (3s) ligt boven de in WireMockTestProfile geconfigureerde query-timeout (2s)
+        // maar onder de prod-default (10s). Zou de service de property negeren en de default
+        // gebruiken, dan zou magazijn-a binnen 3s succesvol antwoorden en GEEN TIMEOUT geven.
+        // Het verschijnen van TIMEOUT bewijst dus dat de geconfigureerde waarde gehonoreerd
+        // wordt. TIMEOUT i.p.v. FOUT: FOUT is voorbehouden aan HTTP-errors / malformed responses.
+        WireMockMagazijnResource.serverA!!.stubFor(
+            get(urlPathEqualTo("/api/v1/berichten"))
+                .willReturn(aResponse().withFixedDelay(3_000).withStatus(200).withBody("""{"berichten":[]}"""))
+        )
+        stubMagazijnSuccess(WireMockMagazijnResource.serverB!!, "magazijn-b")
+
+        val response = given()
+            .header("X-Ontvanger", ontvanger)
+            .`when`().get("/api/v1/berichten/_ophalen")
+            .then().statusCode(200)
+            .extract().body().asString()
+
+        assertTrue(
+            response.contains("TIMEOUT"),
+            "Verwacht TIMEOUT-event op de geconfigureerde 2s-grens maar stream bevatte: $response",
+        )
+    }
+
+    @Test
+    fun `read-timeout op de REST-client kapt een hangende magazijn-call af (socket-vangnet)`() {
+        // Backstop-pad: de read-timeout (4000ms in profile) moet de socket vrijgeven als een
+        // magazijn-call langer hangt dan de timeout, óók buiten de Mutiny ifNoItem om. We roepen
+        // de client daarom DIRECT aan (geen query-timeout in dit pad) tegen een 6s-delay die de
+        // read-timeout overschrijdt. Bewijst dat MagazijnClientFactory de timeout aandraait.
+        WireMockMagazijnResource.serverA!!.stubFor(
+            get(urlPathEqualTo("/api/v1/berichten"))
+                .willReturn(aResponse().withFixedDelay(6_000).withStatus(200).withBody("""{"berichten":[]}"""))
+        )
+
+        val client = clientFactory.getAllClients()["magazijn-a"]
+
+        assertNotNull(client, "magazijn-a client moet geconfigureerd zijn")
+
+        val startNanos = System.nanoTime()
+
+        val fout = assertThrows(Exception::class.java) {
+            client!!.getBerichten(ontvanger, null)
+        }
+
+        val elapsedMs = (System.nanoTime() - startNanos) / 1_000_000
+
+        // Tijdvenster i.p.v. exception-type-match (het concrete type verschilt per client-stack):
+        // de ~4s read-timeout valt binnen [3000, 5500]. Een instant connect-fout (<100ms) of een
+        // geslaagde call op de 6s-delay valt erbuiten, zodat de test alleen groen wordt als juist
+        // de read-timeout vuurde — niet bij een willekeurige andere fout.
+        assertTrue(
+            elapsedMs in 3_000..5_500,
+            "Read-timeout (4s) moet de call afkappen vóór de 6s-delay; duurde ${elapsedMs}ms, fout=${fout.javaClass.simpleName}",
+        )
+    }
+
+    @Test
     fun `client-disconnect tijdens aggregatie stopt de cache-vulling niet`() {
         // De aggregatie loopt bewust door na een client-disconnect zodat de cache alsnog gevuld
         // raakt (een retry wordt dan een cache-hit). Magazijns antwoorden vertraagd (800ms, ruim
-        // onder de per-magazijn-timeout) zodat er een venster is om te disconnecten vóór completion;
+        // onder de 2s query-timeout) zodat er een venster is om te disconnecten vóór completion;
         // daarna pollen we GET /berichten tot de cache gevuld is.
         stubMagazijnSuccessDelayed(WireMockMagazijnResource.serverA!!, "magazijn-a", 800)
         stubMagazijnSuccessDelayed(WireMockMagazijnResource.serverB!!, "magazijn-b", 800)

--- a/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnResultTest.kt
+++ b/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnResultTest.kt
@@ -1,0 +1,102 @@
+package nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn
+
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.TestProfile
+import nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.Bericht
+import nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.MockedDependenciesProfile
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+@QuarkusTest
+@TestProfile(MockedDependenciesProfile::class)
+class MagazijnResultTest {
+
+    private val bericht = Bericht(
+        berichtId = UUID.fromString("11111111-1111-1111-1111-111111111111"),
+        afzender = "00000001234567890000",
+        ontvanger = "999993653",
+        onderwerp = "test",
+        tijdstip = Instant.parse("2026-03-10T10:00:00Z"),
+        magazijnId = "magazijn-a",
+    )
+
+    @Test
+    fun `Success bevat magazijn-id naam en berichten`() {
+        val success = MagazijnResult.Success("magazijn-a", "Magazijn A", listOf(bericht))
+
+        assertEquals("magazijn-a", success.magazijnId)
+        assertEquals("Magazijn A", success.naam)
+        assertEquals(1, success.berichten.size)
+    }
+
+    @Test
+    fun `Failure bevat magazijn-id naam error en fault`() {
+        val ex = RuntimeException("test")
+        val failure = MagazijnResult.Failure("magazijn-b", "Magazijn B", ex, MagazijnFault.INTERNAL_BUG)
+
+        assertEquals("magazijn-b", failure.magazijnId)
+        assertEquals("Magazijn B", failure.naam)
+        assertEquals(ex, failure.error)
+        assertEquals(MagazijnFault.INTERNAL_BUG, failure.fault)
+    }
+
+    @Test
+    fun `data class equals en hashCode werken`() {
+        val a1 = MagazijnResult.Success("id", "n", listOf(bericht))
+        val a2 = MagazijnResult.Success("id", "n", listOf(bericht))
+        val b = MagazijnResult.Success("id", "andere", listOf(bericht))
+
+        assertEquals(a1, a2)
+        assertEquals(a1.hashCode(), a2.hashCode())
+        assertNotEquals(a1, b)
+        assertNotNull(a1.toString())
+    }
+
+    @Test
+    fun `Success en Failure zijn niet gelijk`() {
+        val success: MagazijnResult = MagazijnResult.Success("id", "n", emptyList())
+        val failure: MagazijnResult = MagazijnResult.Failure("id", "n", RuntimeException(), MagazijnFault.INTERNAL_BUG)
+
+        assertNotEquals(success, failure)
+    }
+
+    @Test
+    fun `Success met lege magazijn-id gooit IllegalArgumentException`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            MagazijnResult.Success("", "Magazijn", listOf(bericht))
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            MagazijnResult.Success("   ", "Magazijn", listOf(bericht))
+        }
+    }
+
+    @Test
+    fun `Failure met lege magazijn-id gooit IllegalArgumentException`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            MagazijnResult.Failure("", "Magazijn", RuntimeException(), MagazijnFault.INTERNAL_BUG)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            MagazijnResult.Failure("   ", "Magazijn", RuntimeException(), MagazijnFault.INTERNAL_BUG)
+        }
+    }
+
+    @Test
+    fun `MagazijnBerichtenResponse default is leeg`() {
+        val response = MagazijnBerichtenResponse()
+
+        assertEquals(emptyList<Bericht>(), response.berichten)
+    }
+
+    @Test
+    fun `MagazijnBerichtenResponse met berichten`() {
+        val response = MagazijnBerichtenResponse(listOf(bericht))
+
+        assertEquals(1, response.berichten.size)
+        assertNotNull(response.toString())
+    }
+}

--- a/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/ProfielMagazijnResolverTest.kt
+++ b/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/ProfielMagazijnResolverTest.kt
@@ -49,6 +49,8 @@ class ProfielMagazijnResolverTest {
             )
         },
         profile = "test",
+        connectTimeoutMs = 2000L,
+        readTimeoutMs = 12000L,
     ) {
         override fun createClient(instance: MagazijnenConfig.MagazijnInstance): MagazijnClient = mockk()
     }.also { it.init() }
@@ -355,6 +357,8 @@ class ProfielMagazijnResolverTest {
                 )
             },
             profile = "test",
+            connectTimeoutMs = 2000L,
+            readTimeoutMs = 12000L,
         ) {
             override fun createClient(instance: MagazijnenConfig.MagazijnInstance): MagazijnClient = mockk()
         }.also { it.init() }

--- a/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/WireMockTestProfile.kt
+++ b/services/berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/WireMockTestProfile.kt
@@ -14,5 +14,10 @@ class WireMockTestProfile : QuarkusTestProfile {
     override fun getConfigOverrides(): Map<String, String> = mapOf(
         "quarkus.redis.devservices.enabled" to "false",
         "quarkus.redis.hosts" to "redis://localhost:6379",
+        // Niet-default timeouts zodat de tests bewijzen dat de geconfigureerde waarden
+        // gehonoreerd worden (niet de prod-defaults 10s/12000ms) én de suite snel blijft.
+        // Invariant read-timeout (4000ms) > query-timeout (2s × 1000) blijft gerespecteerd.
+        "berichtensessiecache.magazijn-query-timeout-seconds" to "2",
+        "magazijn-client.read-timeout-ms" to "4000",
     )
 }


### PR DESCRIPTION
## Aanleiding

Tijdens de review van #66 (MagazijnResolver) bleek dat er via opeenvolgende review-rondes
fetch- en robuustheids-hardening in die PR was geslopen die functioneel niet bij de resolver
hoort. Om #66 behapbaar en gefocust te houden is die hardening hieruit gesplitst naar deze PR.

## Wat zit hierin

Deze PR is **gestackt op #66** (`feature/magazijn-resolver-416`); de diff bevat dus puur de
magazijn-omgang- en robuustheids-hardening boven op de resolver-fetch-loop:

- **Magazijn-fout-taxonomie:** `MagazijnFault`-classificatie + `MagazijnResult.fault` +
  `MagazijnResponseOverflow` + `classifyMagazijnFault`/`logMagazijnFault` (granulaire
  eindgebruiker-foutmeldingen + alert-log-niveau-differentiatie).
- **Berichten-cap:** `max-berichten-per-magazijn` + overflow-afhandeling (heap-bescherming
  tegen een rogue magazijn).
- **Timeouts:** per-magazijn query-timeout + magazijn-client connect/read-timeout +
  startup-invariant (`read-timeout > query-timeout`) in `valideerTimeouts`.
- **Lock/cache-robuustheid:** lock-acquire-foutclassificatie + cause-chain-walking +
  parallel cache-store + `[ALERT cache_doublefail]`-logrouting.
- **Tests:** `ClassifyMagazijnFaultTest`, `MagazijnResultTest`, timeout-scenario's in
  `MagazijnClientWireMockTest`, en de hardening-paden in `BerichtensessiecacheServiceTest`.

## Volgorde

Mergen **na** #66. Base staat nu op de resolver-branch zodat de diff schoon is; na merge van
#66 retargeten naar `main`.

Onderdeel van het MagazijnResolver-werk (#416). Tegenhanger van #66.
