### PR TITLE
Centraliseer dependency- en pluginversies in de parent-pom

### DIFF
--- a/libraries/fbs-berichtensessiecache/pom.xml
+++ b/libraries/fbs-berichtensessiecache/pom.xml
@@ -54,7 +54,6 @@
         <dependency>
             <groupId>nl.mijnoverheidzakelijk.ldv</groupId>
             <artifactId>logboekdataverwerking-wrapper</artifactId>
-            <version>1.2.1-SNAPSHOT</version>
         </dependency>
 
         <!-- Test -->
@@ -71,7 +70,6 @@
         <dependency>
             <groupId>com.code-intelligence</groupId>
             <artifactId>jazzer-api</artifactId>
-            <version>0.30.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -85,15 +83,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.mockk</groupId>
-            <artifactId>mockk-jvm</artifactId>
-            <version>1.14.11</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
-            <version>3.13.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -147,7 +138,6 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>3.5.3</version>
                 <executions>
                     <execution>
                         <id>make-index</id>
@@ -161,7 +151,6 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.14</version>
                 <configuration>
                     <!-- Whitelist: alleen library-eigen klassen meten. fbs-common heeft een
                          eigen JaCoCo-gate; Quarkus-instrumented dep-classes verschijnen

--- a/libraries/fbs-common/pom.xml
+++ b/libraries/fbs-common/pom.xml
@@ -83,14 +83,7 @@
         <dependency>
             <groupId>nl.mijnoverheidzakelijk.ldv</groupId>
             <artifactId>logboekdataverwerking-wrapper</artifactId>
-            <version>1.2.1-SNAPSHOT</version>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.mockk</groupId>
-            <artifactId>mockk-jvm</artifactId>
-            <version>1.14.11</version>
-            <scope>test</scope>
         </dependency>
         <!-- RuntimeDelegate-implementatie voor JAX-RS `Response.status(...)` in mapper-tests. -->
         <dependency>
@@ -126,7 +119,6 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>3.5.3</version>
                 <executions>
                     <execution>
                         <id>make-index</id>
@@ -139,7 +131,6 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.14</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,17 @@
              zelf, java-compile draait alleen op gegenereerde sources). Zonder beheerde versie
              waarschuwt Maven 'build.plugins.plugin.version is missing'. -->
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+        <!-- Niet-BOM-beheerde dependencies en plugins: één versie hier zodat de modules
+             niet uiteenlopen (drift). -->
+        <jandex-maven-plugin.version>3.5.3</jandex-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
+        <logboekdataverwerking-wrapper.version>1.2.1-SNAPSHOT</logboekdataverwerking-wrapper.version>
+        <mockk.version>1.14.11</mockk.version>
+        <jazzer-api.version>0.30.0</jazzer-api.version>
+        <wiremock.version>3.13.0</wiremock.version>
+        <openapi-request-validator.version>3.0.0</openapi-request-validator.version>
+        <json-schema-validator.version>2.0.1</json-schema-validator.version>
+        <awaitility.version>4.3.0</awaitility.version>
     </properties>
 
     <repositories>
@@ -66,6 +77,39 @@
                 <artifactId>fbs-berichtensessiecache</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <!-- Niet-BOM-beheerde deps: versie centraal zodat modules niet uiteenlopen.
+                 Scope laten de modules zelf bepalen (provided in de library, compile/test
+                 in de services). -->
+            <dependency>
+                <groupId>nl.mijnoverheidzakelijk.ldv</groupId>
+                <artifactId>logboekdataverwerking-wrapper</artifactId>
+                <version>${logboekdataverwerking-wrapper.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.code-intelligence</groupId>
+                <artifactId>jazzer-api</artifactId>
+                <version>${jazzer-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wiremock</groupId>
+                <artifactId>wiremock</artifactId>
+                <version>${wiremock.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.atlassian.oai</groupId>
+                <artifactId>openapi-request-validator-restassured</artifactId>
+                <version>${openapi-request-validator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.networknt</groupId>
+                <artifactId>json-schema-validator</artifactId>
+                <version>${json-schema-validator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>${awaitility.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -79,6 +123,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- MockK in elke module gebruikt; versie via mockk.version. -->
+        <dependency>
+            <groupId>io.mockk</groupId>
+            <artifactId>mockk-jvm</artifactId>
+            <version>${mockk.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -100,6 +151,16 @@
                     <groupId>org.openapitools</groupId>
                     <artifactId>openapi-generator-maven-plugin</artifactId>
                     <version>${openapi-generator.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>io.smallrye</groupId>
+                    <artifactId>jandex-maven-plugin</artifactId>
+                    <version>${jandex-maven-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${jacoco-maven-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jetbrains.kotlin</groupId>

--- a/services/berichtenmagazijn/pom.xml
+++ b/services/berichtenmagazijn/pom.xml
@@ -69,7 +69,6 @@
         <dependency>
             <groupId>nl.mijnoverheidzakelijk.ldv</groupId>
             <artifactId>logboekdataverwerking-wrapper</artifactId>
-            <version>1.2.1-SNAPSHOT</version>
         </dependency>
 
         <!-- Test -->
@@ -84,21 +83,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.mockk</groupId>
-            <artifactId>mockk-jvm</artifactId>
-            <version>1.14.11</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.atlassian.oai</groupId>
             <artifactId>openapi-request-validator-restassured</artifactId>
-            <version>3.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
-            <version>3.13.0</version>
             <scope>test</scope>
         </dependency>
         <!-- openapi-request-validator-core 3.0.0 vereist json-schema-validator 2.0.1
@@ -107,13 +98,11 @@
         <dependency>
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
-            <version>2.0.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -304,7 +293,6 @@ public final class ApiInfo {
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.14</version>
                 <configuration>
                     <excludes>
                         <exclude>nl/rijksoverheid/moz/fbs/berichtenmagazijn/api/**</exclude>

--- a/services/berichtenuitvraag/pom.xml
+++ b/services/berichtenuitvraag/pom.xml
@@ -44,7 +44,6 @@
         <dependency>
             <groupId>nl.mijnoverheidzakelijk.ldv</groupId>
             <artifactId>logboekdataverwerking-wrapper</artifactId>
-            <version>1.2.1-SNAPSHOT</version>
         </dependency>
 
         <!-- Bean Validation for generated OpenAPI interface annotations -->
@@ -66,7 +65,6 @@
         <dependency>
             <groupId>com.code-intelligence</groupId>
             <artifactId>jazzer-api</artifactId>
-            <version>0.22.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -80,21 +78,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.mockk</groupId>
-            <artifactId>mockk-jvm</artifactId>
-            <version>1.14.9</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.atlassian.oai</groupId>
             <artifactId>openapi-request-validator-restassured</artifactId>
-            <version>3.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
-            <version>3.13.0</version>
             <scope>test</scope>
         </dependency>
         <!-- openapi-request-validator-core 3.0.0 vereist json-schema-validator 2.0.1
@@ -103,7 +93,6 @@
         <dependency>
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
-            <version>2.0.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -263,7 +252,6 @@ public final class ApiInfo {
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.13</version>
                 <configuration>
                     <excludes>
                         <!-- Gegenereerde OpenAPI model-klassen -->


### PR DESCRIPTION
## Aanleiding

Versies van niet-BOM-beheerde dependencies en build-plugins stonden per module hardgecodeerd. Daardoor waren ze stilletjes uiteengelopen tussen de modules — een bron van moeilijk te vinden gedragsverschillen tussen services.

Gevonden drift:

| Artifact | Was | Nu |
|---|---|---|
| `mockk-jvm` (test) | uitvraag **1.14.9**, rest 1.14.11 | 1.14.11 |
| `jazzer-api` (test) | uitvraag **0.22.1**, sessiecache 0.30.0 | 0.30.0 |
| `jacoco-maven-plugin` | uitvraag **0.8.13**, rest 0.8.14 | 0.8.14 |

## Wijziging

Eén bron van waarheid in de parent-pom:

1. **`dependencyManagement` + version-properties** voor `logboekdataverwerking-wrapper`, `jazzer-api`, `wiremock`, `openapi-request-validator-restassured`, `json-schema-validator` en `awaitility`. Scope blijven de modules zelf bepalen (`provided` in de library, `compile`/`test` in de services).
2. **`pluginManagement`** voor `jandex-maven-plugin` en `jacoco-maven-plugin`.
3. **`mockk-jvm`** (in elke module test-scoped) verhuisd naar parent `<dependencies>`, net als `kotlin-stdlib` en `junit-jupiter`.

Canonieke versie = hoogste reeds aanwezige (`mockk 1.14.11`, `jazzer 0.30.0`, `jacoco 0.8.14`).

## Bewust niet gehoist

Quarkus-extensies (`quarkus-kotlin`, `quarkus-rest-*`, `quarkus-smallrye-openapi`, `quarkus-hibernate-validator`, `quarkus-junit`, `rest-assured`) zijn gedeeld door de drie Quarkus-modules maar **niet** door `fbs-common` — een pure-JVM library die bewust Quarkus-vrij is (`provided` `quarkus-core`). Hoisten naar parent `<dependencies>` zou de Quarkus-runtime op die library forceren. Versies zijn al BOM-beheerd, dus geen drift-risico.

## Verificatie

`./mvnw clean test-compile` — alle 5 modules `SUCCESS`, inclusief de `jazzer-api`-bump 0.22.1 → 0.30.0 in `berichtenuitvraag`.

> Stacked op `fix/quarkus-dev-en-bouwconfig-aanvullingen` (PR #92); GitHub retarget automatisch naar `main` zodra die merget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)