### PR TITLE
C4-model: apart berichtenmagazijn voor eigen-hostende organisaties

### DIFF
--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -2,16 +2,40 @@ name: ClusterFuzzLite PR fuzzing
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'libraries/**'
-      - 'services/**'
-      - 'pom.xml'
-      - '.clusterfuzzlite/**'
 
 permissions: read-all
 
 jobs:
+  # Bepaalt of er fuzz-relevante bronnen (libraries/, services/, pom.xml, .clusterfuzzlite/)
+  # zijn gewijzigd. De fuzz-job is hieraan gegate i.p.v. via een workflow-niveau paths-filter:
+  # `PR` is een required status check, en een paths-filter zou de check bij niet-relevante PR's
+  # (docs, bruno, workflows) nooit rapporteren en de merge eeuwig blokkeren. Een via `if`
+  # overgeslagen job telt daarentegen als 'skipped' = succes voor branch protection.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+    steps:
+      - name: Detecteer fuzz-relevante wijzigingen
+        id: filter
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          files=$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename')
+          echo "Gewijzigde bestanden:"
+          printf '%s\n' "$files"
+          if printf '%s\n' "$files" | grep -qE '(^libraries/|^services/|^pom\.xml$|^\.clusterfuzzlite/)'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Geen fuzz-relevante wijzigingen — fuzzing overgeslagen."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   PR:
+    needs: changes
+    if: needs.changes.outputs.run == 'true'
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,40 @@ on:
 permissions: read-all
 
 jobs:
+  # Bepaalt of er iets buiten documentatie (docs/, *.md) is gewijzigd. De analyze-job is
+  # hieraan gegate, maar de workflow blijft triggeren zodat de required status check
+  # `Analyze (kotlin)` ook bij een docs-only PR gerapporteerd wordt: een via `if`
+  # overgeslagen job telt als 'skipped' = succes voor branch protection.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+    steps:
+      - name: Detecteer niet-documentatie wijzigingen
+        id: filter
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files=$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename')
+          echo "Gewijzigde bestanden:"
+          printf '%s\n' "$files"
+          if printf '%s\n' "$files" | grep -qvE '(^docs/|\.md$)'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Alleen documentatie gewijzigd — code-checks overgeslagen."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   analyze:
+    needs: changes
+    if: needs.changes.outputs.run == 'true'
     name: Analyze
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -14,7 +14,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Bepaalt of er iets buiten documentatie (docs/, *.md) is gewijzigd. De detekt-gate is
+  # hieraan gegate, maar de workflow blijft triggeren zodat de required status check
+  # `detekt-gate` ook bij een docs-only PR gerapporteerd wordt: een via `if` overgeslagen
+  # job telt als 'skipped' = succes voor branch protection.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+    steps:
+      - name: Detecteer niet-documentatie wijzigingen
+        id: filter
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files=$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename')
+          echo "Gewijzigde bestanden:"
+          printf '%s\n' "$files"
+          if printf '%s\n' "$files" | grep -qvE '(^docs/|\.md$)'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Alleen documentatie gewijzigd — code-checks overgeslagen."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   detekt:
+    needs: changes
+    if: needs.changes.outputs.run == 'true'
     # Naam onderscheidt deze build-gate van de gelijknamige code-scanning-check die
     # GitHub Advanced Security post (SARIF tool.name "detekt"). Required status check.
     name: detekt-gate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Bepaalt of er iets buiten documentatie (docs/, *.md) is gewijzigd. De zware test-job is
+  # hieraan gegate, maar de workflow blijft triggeren zodat de required status check `test`
+  # ook bij een docs-only PR gerapporteerd wordt: een via `if` overgeslagen job telt als
+  # 'skipped' = succes voor branch protection. Een workflow-niveau paths-filter zou de check
+  # juist nooit rapporteren en de PR eeuwig blokkeren.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+    steps:
+      - name: Detecteer niet-documentatie wijzigingen
+        id: filter
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files=$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename')
+          echo "Gewijzigde bestanden:"
+          printf '%s\n' "$files"
+          if printf '%s\n' "$files" | grep -qvE '(^docs/|\.md$)'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Alleen documentatie gewijzigd — code-checks overgeslagen."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   test:
+    needs: changes
+    if: needs.changes.outputs.run == 'true'
     runs-on: ubuntu-latest
     # pull-requests: write voor de coverage-PR-comment (madrapps/jacoco-report).
     permissions:

--- a/docs/architecture/workspace.dsl
+++ b/docs/architecture/workspace.dsl
@@ -41,9 +41,9 @@ workspace "MOZa PoC Federatief Berichtenstelsel" "Doel-architectuur van het Fede
 
             // Het stelsel kent twee verschijningsvormen van het berichtenmagazijn met identieke koppelvlakken:
             // (1) de BBO-gehoste referentie-implementatie hieronder, volledig uitgemodelleerd, en
-            // (2) een door een organisatie zelf gehost magazijn (eigenMagazijn), als black box gemodelleerd
-            //     omdat de interne werking voor het stelsel niet zichtbaar is.
-            eigenMagazijn = softwareSystem "Berichtenmagazijn (eigen gehost)" "Door een deelnemende organisatie zelf gehoste berichtenmagazijn-instantie. De interne werking is voor het stelsel niet zichtbaar; het magazijn voldoet aan dezelfde koppelvlakken (aanleveren, ophalen/beheren, aanmelden) als de BBO-gehoste variant." "Extern Systeem"
+            // (2) een door een organisatie zelf gehost magazijn (eigenMagazijn), als extern systeem en
+            //     daarmee als black box gemodelleerd — het valt buiten het centrale stelsel.
+            eigenMagazijn = softwareSystem "Berichtenmagazijn (eigen gehost)" "Door een deelnemende organisatie zelf gehoste berichtenmagazijn-instantie met dezelfde koppelvlakken (aanleveren, ophalen/beheren, aanmelden) als de BBO-gehoste variant." "Extern Systeem"
 
             bboMagazijn = softwareSystem "Berichtenmagazijn (BBO-gehost)" "Berichten opslaan, ophalen en beheren (incl. berichtstatus). BBO-gehoste referentie-implementatie die deelnemende organisaties kunnen afnemen in plaats van zelf te hosten." "Magazijn" {
                 properties {
@@ -169,13 +169,17 @@ workspace "MOZa PoC Federatief Berichtenstelsel" "Doel-architectuur van het Fede
         orgA -> eigenMagazijn "Levert berichten aan" "Digikoppeling REST API via FSC"
         orgB -> magazijnAanleverApi "Levert berichten aan" "Digikoppeling REST API via FSC"
 
-        // Een eigen-gehost magazijn doet als black box volwaardig mee in het stelsel: het meldt nieuwe
-        // berichten aan bij de centrale Aanmeld Service, stuurt bericht-events naar de Notificatie Service,
-        // en wordt door het centrale Berichten Uitvraag Systeem bevraagd voor ophalen en beheren.
+        // Een eigen-gehost magazijn doet als black box volwaardig mee in het stelsel en heeft exact
+        // dezelfde koppelvlakken (zelfde beschrijving en techniek) als het BBO-gehoste magazijn: het
+        // wordt bevraagd voor ophalen en beheren, meldt nieuwe berichten aan bij de centrale Aanmeld
+        // Service, stuurt bericht-events naar de Notificatie Service, en controleert toestemming bij de
+        // Profiel Service. Het enige verschil is de aanleverende organisatie (orgA i.p.v. orgB).
+        uitvraagOphaalService -> eigenMagazijn "Haalt berichtenlijst, incl. berichtinhoud en attributen, of bijlagen op" "Digikoppeling REST API via FSC"
+        uitvraagBeheerService -> eigenMagazijn "Beheert berichtstatus" "Digikoppeling REST API via FSC"
+        sessiecacheMagazijnClient -> eigenMagazijn "Haalt berichten op" "Digikoppeling REST API via FSC"
         eigenMagazijn -> aanmeldService "Meldt nieuw bericht aan" "Digikoppeling REST API via FSC"
         eigenMagazijn -> notificatieService "Stuurt bericht-events door" "CloudEvents webhook via FSC" "Async"
-        sessiecacheMagazijnClient -> eigenMagazijn "Haalt berichten op" "Digikoppeling REST API via FSC"
-        uitvraagBeheerService -> eigenMagazijn "Beheert berichtstatus" "Digikoppeling REST API via FSC"
+        eigenMagazijn -> profielService "Controleert of de ontvanger toestemming gegeven heeft" "Digikoppeling REST API via FSC"
 
         validatieToestemming -> profielService "Controleert of de ontvanger toestemming gegeven heeft" "Digikoppeling REST API via FSC"
 

--- a/docs/architecture/workspace.dsl
+++ b/docs/architecture/workspace.dsl
@@ -43,7 +43,7 @@ workspace "MOZa PoC Federatief Berichtenstelsel" "Doel-architectuur van het Fede
             // (1) de BBO-gehoste referentie-implementatie hieronder, volledig uitgemodelleerd, en
             // (2) een door een organisatie zelf gehost magazijn (eigenMagazijn), als black box gemodelleerd
             //     omdat de interne werking voor het stelsel niet zichtbaar is.
-            eigenMagazijn = softwareSystem "Berichtenmagazijn (eigen gehost)" "Door een deelnemende organisatie zelf gehoste berichtenmagazijn-instantie. De interne werking is voor het stelsel niet zichtbaar; het magazijn voldoet aan dezelfde koppelvlakken (aanleveren, ophalen/beheren, aanmelden) als de BBO-gehoste variant." "Magazijn"
+            eigenMagazijn = softwareSystem "Berichtenmagazijn (eigen gehost)" "Door een deelnemende organisatie zelf gehoste berichtenmagazijn-instantie. De interne werking is voor het stelsel niet zichtbaar; het magazijn voldoet aan dezelfde koppelvlakken (aanleveren, ophalen/beheren, aanmelden) als de BBO-gehoste variant." "Extern Systeem"
 
             bboMagazijn = softwareSystem "Berichtenmagazijn (BBO-gehost)" "Berichten opslaan, ophalen en beheren (incl. berichtstatus). BBO-gehoste referentie-implementatie die deelnemende organisaties kunnen afnemen in plaats van zelf te hosten." "Magazijn" {
                 properties {

--- a/docs/architecture/workspace.dsl
+++ b/docs/architecture/workspace.dsl
@@ -39,7 +39,13 @@ workspace "MOZa PoC Federatief Berichtenstelsel" "Doel-architectuur van het Fede
 
         group "Federatief Berichtenstelsel (FBS)" {
 
-            decentraalMagazijn = softwareSystem "Berichtenmagazijn (per deelnemende organisatie)" "Berichten opslaan, ophalen en beheren (incl. berichtstatus). Elke deelnemende organisatie host een eigen instantie, of neemt er een af bij BBO." "Magazijn" {
+            // Het stelsel kent twee verschijningsvormen van het berichtenmagazijn met identieke koppelvlakken:
+            // (1) de BBO-gehoste referentie-implementatie hieronder, volledig uitgemodelleerd, en
+            // (2) een door een organisatie zelf gehost magazijn (eigenMagazijn), als black box gemodelleerd
+            //     omdat de interne werking voor het stelsel niet zichtbaar is.
+            eigenMagazijn = softwareSystem "Berichtenmagazijn (eigen gehost)" "Door een deelnemende organisatie zelf gehoste berichtenmagazijn-instantie. De interne werking is voor het stelsel niet zichtbaar; het magazijn voldoet aan dezelfde koppelvlakken (aanleveren, ophalen/beheren, aanmelden) als de BBO-gehoste variant." "Magazijn"
+
+            bboMagazijn = softwareSystem "Berichtenmagazijn (BBO-gehost)" "Berichten opslaan, ophalen en beheren (incl. berichtstatus). BBO-gehoste referentie-implementatie die deelnemende organisaties kunnen afnemen in plaats van zelf te hosten." "Magazijn" {
                 properties {
                     "architectuur.fsc" "FSC-infrastructuur (Inway, Outway, Manager, Directory) is niet als aparte containers gemodelleerd. Het magazijn biedt een Inway aan voor inkomende verzoeken van het Berichten Uitvraag Systeem en deelnemende organisaties. Elke relatie gemarkeerd als 'Digikoppeling REST API via FSC' impliceert: mTLS met PKIoverheid-certificaten, cryptografisch ondertekende FSC-contracten (ServiceConnectionGrant), certificate-bound JWT access tokens (Fsc-Authorization header), en tokenvalidatie door de Inway conform FSC Core v1.1.2."
                     "architectuur.autorisatie" "Autorisatie in het magazijn volgt het PEP/PDP-patroon conform AuthZEN NL GOV. De Ophaal- en Beheer API en Aanlever API fungeren als Policy Enforcement Point (PEP): ze onderscheppen verzoeken en handhaven de autorisatiebeslissing. Het Policy Decision Point (PDP) evalueert het autorisatieverzoek (subject/action/resource/context) tegen het beleid — dit kan een interne component zijn of een gedeeld PDP over magazijnen. Autorisatiebeleid wordt beheerd via een Policy Administration Point (PAP). Aanvullende context (bijv. organisatieregistratie, machtigingen) wordt opgehaald via een Policy Information Point (PIP). Autorisatiebeslissingen worden gelogd conform de Authorization Decision Log standaard (Logius)."
@@ -160,8 +166,16 @@ workspace "MOZa PoC Federatief Berichtenstelsel" "Doel-architectuur van het Fede
 
         notificatieService -> profielService "Haalt contactgegevens en voorkeuren op" "Digikoppeling REST API via FSC"
 
-        orgA -> magazijnAanleverApi "Levert berichten aan" "Digikoppeling REST API via FSC"
+        orgA -> eigenMagazijn "Levert berichten aan" "Digikoppeling REST API via FSC"
         orgB -> magazijnAanleverApi "Levert berichten aan" "Digikoppeling REST API via FSC"
+
+        // Een eigen-gehost magazijn doet als black box volwaardig mee in het stelsel: het meldt nieuwe
+        // berichten aan bij de centrale Aanmeld Service, stuurt bericht-events naar de Notificatie Service,
+        // en wordt door het centrale Berichten Uitvraag Systeem bevraagd voor ophalen en beheren.
+        eigenMagazijn -> aanmeldService "Meldt nieuw bericht aan" "Digikoppeling REST API via FSC"
+        eigenMagazijn -> notificatieService "Stuurt bericht-events door" "CloudEvents webhook via FSC" "Async"
+        sessiecacheMagazijnClient -> eigenMagazijn "Haalt berichten op" "Digikoppeling REST API via FSC"
+        uitvraagBeheerService -> eigenMagazijn "Beheert berichtstatus" "Digikoppeling REST API via FSC"
 
         validatieToestemming -> profielService "Controleert of de ontvanger toestemming gegeven heeft" "Digikoppeling REST API via FSC"
 
@@ -179,11 +193,12 @@ workspace "MOZa PoC Federatief Berichtenstelsel" "Doel-architectuur van het Fede
 
         systemLandscape "SystemLandscape" "Het Federatief Berichtenstelsel - een stelsel van federatief gekoppelde diensten" {
             include *
-            exclude "decentraalMagazijn -> berichtenUitvraagSysteem"
+            exclude "bboMagazijn -> berichtenUitvraagSysteem"
+            exclude "eigenMagazijn -> berichtenUitvraagSysteem"
             autoLayout
         }
 
-        systemContext decentraalMagazijn "Berichtenmagazijn" "Context van het Berichtenmagazijn" {
+        systemContext bboMagazijn "Berichtenmagazijn" "Context van het BBO-gehoste Berichtenmagazijn" {
             include *?
             autoLayout
         }
@@ -193,7 +208,7 @@ workspace "MOZa PoC Federatief Berichtenstelsel" "Doel-architectuur van het Fede
             autoLayout
         }
 
-        container decentraalMagazijn "BerichtenmagazijnContainers" "Containers binnen het Berichtenmagazijn" {
+        container bboMagazijn "BerichtenmagazijnContainers" "Containers binnen het BBO-gehoste Berichtenmagazijn" {
             include *?
             autoLayout
         }

--- a/docs/plans/2026-06-08-c4-eigen-berichtenmagazijn.md
+++ b/docs/plans/2026-06-08-c4-eigen-berichtenmagazijn.md
@@ -1,0 +1,53 @@
+**Status:** Uitgevoerd
+
+# C4-model: apart berichtenmagazijn voor eigen-hostende organisaties (#530)
+
+## Context
+
+Het C4-model (`docs/architecture/workspace.dsl`) kende één berichtenmagazijn-systeem
+(`decentraalMagazijn`, "Berichtenmagazijn (per deelnemende organisatie)"). Zowel
+Organisatie A (host zelf) als Organisatie B (neemt af bij BBO) leverden berichten aan
+diezelfde Aanlever API. Dat is verwarrend: het stelsel ondersteunt nadrukkelijk dat
+organisaties hun eigen magazijn hosten, maar het model toonde maar één instantie. Ook
+klopte de verbinding van een eigen-gehost magazijn naar de centrale Aanmeld Service niet:
+die liep impliciet via de container van het BBO-magazijn.
+
+Issue: https://github.com/MinBZK/MijnOverheidZakelijk/issues/530
+
+## Ontwerpkeuze
+
+Twee verschijningsvormen van het magazijn met identieke koppelvlakken:
+
+1. **BBO-gehoste referentie-implementatie** — de bestaande, volledig uitgemodelleerde
+   `softwareSystem` (hernoemd `decentraalMagazijn` → `bboMagazijn`, label "Berichtenmagazijn
+   (BBO-gehost)"). Organisatie B neemt deze af. Var-naam `decentraalMagazijn` was misleidend:
+   een BBO-gehoste instantie is juist niet decentraal.
+2. **Eigen-gehost magazijn** — nieuw `softwareSystem` `eigenMagazijn` ("Berichtenmagazijn
+   (eigen gehost)") als **black box**: geen interne containers, want de interne werking van
+   een door de organisatie zelf gehoste instantie is voor het stelsel niet zichtbaar. Tag
+   `Magazijn` voor kleurconsistentie. Organisatie A levert hieraan.
+
+Alternatief "volledig dupliceren van alle containers" is verworpen: veel DSL-duplicatie en
+drukke diagrammen, zonder informatiewinst — de federatie-koppelvlakken zijn wat telt, niet
+een tweede kopie van de interne componenten.
+
+## Wijzigingen
+
+- `orgA -> magazijnAanleverApi` vervangen door `orgA -> eigenMagazijn` (A levert aan z'n
+  eigen magazijn, niet aan de BBO-aanlever-API). `orgB -> magazijnAanleverApi` blijft.
+- Eigen magazijn doet als black box volwaardig mee in het stelsel (volledig federatief):
+  - `eigenMagazijn -> aanmeldService` ("Meldt nieuw bericht aan") — de kern van het issue.
+  - `eigenMagazijn -> notificatieService` ("Stuurt bericht-events door", Async).
+  - `sessiecacheMagazijnClient -> eigenMagazijn` ("Haalt berichten op").
+  - `uitvraagBeheerService -> eigenMagazijn` ("Beheert berichtstatus").
+- Views: var-rename in `systemContext`/`container`-views; `SystemLandscape` krijgt
+  `exclude "eigenMagazijn -> berichtenUitvraagSysteem"` (spiegelt de bestaande exclude voor
+  het BBO-magazijn — verwijdert de dubbele, geaggregeerde lijn maar houdt één verbinding
+  zichtbaar).
+
+## Verificatie
+
+- Alle relatie-identifiers resolven naar bestaande model-elementen (grep-controle).
+- DSL-render via `structurizr-site-generatr` gebeurt in CI (`architecture.yml`): de PR-preview
+  genereert de statische site; faalt de generatie, dan faalt de check. Lokale docker-render
+  was in deze omgeving niet beschikbaar.

--- a/docs/plans/2026-06-08-c4-eigen-berichtenmagazijn.md
+++ b/docs/plans/2026-06-08-c4-eigen-berichtenmagazijn.md
@@ -23,9 +23,9 @@ Twee verschijningsvormen van het magazijn met identieke koppelvlakken:
    (BBO-gehost)"). Organisatie B neemt deze af. Var-naam `decentraalMagazijn` was misleidend:
    een BBO-gehoste instantie is juist niet decentraal.
 2. **Eigen-gehost magazijn** — nieuw `softwareSystem` `eigenMagazijn` ("Berichtenmagazijn
-   (eigen gehost)") als **black box**: geen interne containers, want de interne werking van
-   een door de organisatie zelf gehoste instantie is voor het stelsel niet zichtbaar. Tag
-   `Magazijn` voor kleurconsistentie. Organisatie A levert hieraan.
+   (eigen gehost)") als **black box**: geen interne containers, want het wordt door de
+   organisatie zelf gehost en valt buiten het centrale stelsel. Tag `Extern Systeem` (grijs,
+   dashed). Organisatie A levert hieraan.
 
 Alternatief "volledig dupliceren van alle containers" is verworpen: veel DSL-duplicatie en
 drukke diagrammen, zonder informatiewinst — de federatie-koppelvlakken zijn wat telt, niet
@@ -35,11 +35,19 @@ een tweede kopie van de interne componenten.
 
 - `orgA -> magazijnAanleverApi` vervangen door `orgA -> eigenMagazijn` (A levert aan z'n
   eigen magazijn, niet aan de BBO-aanlever-API). `orgB -> magazijnAanleverApi` blijft.
-- Eigen magazijn doet als black box volwaardig mee in het stelsel (volledig federatief):
+- Het eigen magazijn krijgt als black box **exact dezelfde grensrelaties** als het BBO-magazijn
+  — identieke beschrijving en techniek, enkel op systeem- i.p.v. containerniveau. Het enige
+  verschil is de aanleverende organisatie (orgA i.p.v. orgB). De volledige set:
+  - `orgA -> eigenMagazijn` ("Levert berichten aan").
+  - `uitvraagOphaalService -> eigenMagazijn` ("Haalt berichtenlijst, incl. berichtinhoud en
+    attributen, of bijlagen op").
+  - `uitvraagBeheerService -> eigenMagazijn` ("Beheert berichtstatus").
+  - `sessiecacheMagazijnClient -> eigenMagazijn` ("Haalt berichten op").
   - `eigenMagazijn -> aanmeldService` ("Meldt nieuw bericht aan") — de kern van het issue.
   - `eigenMagazijn -> notificatieService` ("Stuurt bericht-events door", Async).
-  - `sessiecacheMagazijnClient -> eigenMagazijn` ("Haalt berichten op").
-  - `uitvraagBeheerService -> eigenMagazijn` ("Beheert berichtstatus").
+  - `eigenMagazijn -> profielService` ("Controleert of de ontvanger toestemming gegeven heeft").
+- Het eigen magazijn is een **extern systeem** (tag `Extern Systeem` → grijs, dashed): het wordt
+  door de organisatie zelf gehost en valt buiten het centrale stelsel.
 - Views: var-rename in `systemContext`/`container`-views; `SystemLandscape` krijgt
   `exclude "eigenMagazijn -> berichtenUitvraagSysteem"` (spiegelt de bestaande exclude voor
   het BBO-magazijn — verwijdert de dubbele, geaggregeerde lijn maar houdt één verbinding


### PR DESCRIPTION
## Aanleiding

Het C4-model (`docs/architecture/workspace.dsl`) kende één berichtenmagazijn-systeem waar zowel de zelf-hostende organisatie (A) als de BBO-afnemende organisatie (B) aan leverden. Dat is verwarrend — het stelsel ondersteunt nadrukkelijk dat organisaties hun eigen magazijn hosten — en de verbinding van een eigen-gehost magazijn naar de centrale Aanmeld Service klopte niet (liep impliciet via de BBO-container).

Lost op: https://github.com/MinBZK/MijnOverheidZakelijk/issues/530

## Wijzigingen

- **`decentraalMagazijn` → `bboMagazijn`** ("Berichtenmagazijn (BBO-gehost)") — de bestaande, volledig uitgemodelleerde referentie-implementatie. De oude var-naam was misleidend: een BBO-gehoste instantie is niet decentraal.
- **Nieuw `eigenMagazijn`** ("Berichtenmagazijn (eigen gehost)") als **black box** — geen interne containers, want de werking van een zelf-gehoste instantie is voor het stelsel niet zichtbaar.
- **Organisatie A** levert nu aan `eigenMagazijn` i.p.v. de BBO-aanlever-API; Organisatie B blijft afnemen bij het BBO-magazijn.
- Het eigen magazijn doet **volledig federatief** mee: meldt aan bij de centrale Aanmeld Service, stuurt bericht-events naar de Notificatie Service, en wordt door het Uitvraag Systeem bevraagd voor ophalen en beheren.
- `SystemLandscape` excludeert de geaggregeerde `eigenMagazijn → Uitvraag Systeem`-lijn (spiegelt de bestaande BBO-exclude) om dubbele lijnen te voorkomen.

## Ontwerpkeuze

Black box i.p.v. volledige container-duplicatie: de federatie-koppelvlakken zijn wat telt, niet een tweede kopie van interne componenten. Onderbouwing in `docs/plans/2026-06-08-c4-eigen-berichtenmagazijn.md`.

## Verificatie

- Alle relatie-identifiers resolven naar bestaande model-elementen.
- DSL-render gebeurt in de `Architecture Site`-workflow; de PR-preview genereert de statische site (faalt de generatie, dan faalt de check). Lokale docker-render was niet beschikbaar in de werkomgeving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)