### PR TITLE
Cache-foutafhandeling expliciet en afdwingbaar via sealed SessiecacheException (#623)

### DIFF
--- a/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/BlockingSessiecache.kt
+++ b/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/BlockingSessiecache.kt
@@ -118,7 +118,9 @@ internal class BlockingSessiecache(
     /**
      * Lees- en zoekpaden vereisen een afgeronde ophaling: zonder status is de cache
      * (mogelijk) leeg of verouderd en zou een lege lijst onterecht "geen berichten"
-     * suggereren. De caller krijgt 409 om eerst [Sessiecache.ophalen] aan te roepen.
+     * suggereren. De caller krijgt [SessiecacheException.NogNietGevuld] (nog niet gestart)
+     * resp. [SessiecacheException.OphalenBezig] (loopt nog) en moet eerst [Sessiecache.ophalen]
+     * aanroepen; een mislukte ophaling levert [SessiecacheException.OphalenMislukt].
      */
     private fun requireGereedStatus(ontvanger: Identificatienummer): AggregationStatus {
         val aggregation = awaitOrServiceUnavailable { service.getAggregationStatus(ontvanger) }

--- a/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/BlockingSessiecache.kt
+++ b/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/BlockingSessiecache.kt
@@ -3,8 +3,6 @@ package nl.rijksoverheid.moz.fbs.berichtensessiecache
 import io.smallrye.mutiny.Multi
 import io.smallrye.mutiny.Uni
 import jakarta.enterprise.context.ApplicationScoped
-import jakarta.ws.rs.WebApplicationException
-import jakarta.ws.rs.core.Response
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.AggregationStatus
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.Bericht
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.BerichtenPagina
@@ -22,8 +20,8 @@ import java.util.UUID
 /**
  * Synchrone facade over de reactieve [BerichtensessiecacheService]: blokkeert
  * begrensd ([TIMEOUT]) op de Mutiny-pijplijn en vertaalt infrastructuurfouten
- * naar de statuscodes uit het [Sessiecache]-contract. Houdt zelf géén staat —
- * alle sessiestaat (cache, aggregatie-status, lock) leeft in Redis.
+ * naar de gesloten [SessiecacheException]-hiërarchie uit het [Sessiecache]-contract.
+ * Houdt zelf géén staat — alle sessiestaat (cache, aggregatie-status, lock) leeft in Redis.
  */
 @ApplicationScoped
 internal class BlockingSessiecache(
@@ -76,9 +74,8 @@ internal class BlockingSessiecache(
         // Een lege patch zou als no-op-succes ogen; expliciet afwijzen zodat de
         // caller (en diens client) weet dat er niets gewijzigd is.
         if (status == null && map == null) {
-            throw WebApplicationException(
+            throw SessiecacheException.OngeldigeInvoer(
                 "Minimaal één van 'status' of 'map' is vereist (geen geldige waarde meegegeven).",
-                Response.Status.BAD_REQUEST,
             )
         }
 
@@ -97,18 +94,16 @@ internal class BlockingSessiecache(
         // Vergelijk op .waarde: Bericht.ontvanger slaat de raw identificatiewaarde op
         // (geen type-prefix), zodat JSON-serialisatie en upstream-contracten ongewijzigd blijven.
         if (bericht.ontvanger != ontvanger.waarde) {
-            throw WebApplicationException(
+            throw SessiecacheException.OngeldigeInvoer(
                 "Ontvanger in bericht komt niet overeen met de opgegeven ontvanger.",
-                Response.Status.BAD_REQUEST,
             )
         }
 
         // Aanmeld-pad mag alleen bestaande, actieve sessies bijwerken: als er geen
         // aggregatie heeft plaatsgevonden voor deze ontvanger, hoort er ook geen cache te zijn.
         awaitOrServiceUnavailable { service.getAggregationStatus(ontvanger) }
-            ?: throw WebApplicationException(
+            ?: throw SessiecacheException.GeenActieveSessie(
                 "Geen actieve sessie voor deze ontvanger; bericht niet toegevoegd.",
-                Response.Status.NOT_FOUND,
             )
 
         return try {
@@ -116,7 +111,7 @@ internal class BlockingSessiecache(
         } catch (e: IllegalArgumentException) {
             // Defensieve limiet overschreden (BerichtValidator): invoerfout van de
             // aanleverende caller, geen infrastructuurfout.
-            throw WebApplicationException(e.message, e, Response.Status.BAD_REQUEST)
+            throw SessiecacheException.OngeldigeInvoer(e.message ?: "Ongeldig bericht.", e)
         }
     }
 
@@ -127,20 +122,17 @@ internal class BlockingSessiecache(
      */
     private fun requireGereedStatus(ontvanger: Identificatienummer): AggregationStatus {
         val aggregation = awaitOrServiceUnavailable { service.getAggregationStatus(ontvanger) }
-            ?: throw WebApplicationException(
+            ?: throw SessiecacheException.NogNietGevuld(
                 "Berichten zijn nog niet opgehaald. Start eerst het ophalen van berichten.",
-                Response.Status.CONFLICT,
             )
 
         return when (aggregation.status) {
             OphalenStatus.GEREED -> aggregation
-            OphalenStatus.BEZIG -> throw WebApplicationException(
+            OphalenStatus.BEZIG -> throw SessiecacheException.OphalenBezig(
                 "Berichten worden momenteel opgehaald. Wacht tot het ophalen is afgerond.",
-                Response.Status.CONFLICT,
             )
-            OphalenStatus.FOUT -> throw WebApplicationException(
+            OphalenStatus.FOUT -> throw SessiecacheException.OphalenMislukt(
                 "Het ophalen van berichten is mislukt. Start het ophalen van berichten opnieuw.",
-                Response.Status.INTERNAL_SERVER_ERROR,
             )
         }
     }
@@ -162,34 +154,33 @@ internal class BlockingSessiecache(
 
     private fun vertaalCacheFout(e: Throwable): Exception = when (e) {
         // Cache-operatie hing langer dan TIMEOUT — log warn met cause zodat operations
-        // niet alleen het 503-pad ziet maar ook welke await het was. Silent discard
-        // verbergt prestatie-regressies in Redis.
+        // niet alleen het onbereikbaar-pad ziet maar ook welke await het was. Silent
+        // discard verbergt prestatie-regressies in Redis.
         is java.util.concurrent.TimeoutException -> {
-            log.warnf(e, "Cache-operatie overschreed timeout van %s; 503 naar caller", TIMEOUT)
-            WebApplicationException("Cache niet bereikbaar. Probeer het later opnieuw", 503)
+            log.warnf(e, "Cache-operatie overschreed timeout van %s; onbereikbaar naar caller", TIMEOUT)
+            SessiecacheException.Onbereikbaar("Cache niet bereikbaar. Probeer het later opnieuw", e)
         }
-        // Transiente schrijf-contentie: bron logt al op warn. Retriable 503
-        // i.p.v. de misleidende 404 die een null-resultaat zou opleveren.
+        // Transiente schrijf-contentie: bron logt al op warn. Retriable onbereikbaar
+        // i.p.v. de misleidende not-found die een null-resultaat zou opleveren.
         is CacheContentieException ->
-            WebApplicationException("Cache tijdelijk niet bij te werken. Probeer het later opnieuw", 503)
-        is WebApplicationException -> e
+            SessiecacheException.Onbereikbaar("Cache tijdelijk niet bij te werken. Probeer het later opnieuw", e)
         // Invoervalidatie (BerichtValidator, Leesstatus.fromWire): caller-fout,
-        // geen infrastructuurfout — laat de caller dit naar 400 vertalen.
+        // geen infrastructuurfout — laat schrijfBericht dit naar OngeldigeInvoer vertalen.
         is IllegalArgumentException -> e
         // Cache-deserialisatie-fout = data-integriteit-issue (verkeerde versie, corrupte hash),
-        // niet "Redis onbereikbaar". 500 zonder de verkeerde infrastructuur-diagnose te suggereren.
+        // niet "Redis onbereikbaar". Onleesbaar zonder de verkeerde infrastructuur-diagnose.
         is com.fasterxml.jackson.core.JsonProcessingException -> {
             log.errorf(e, "Cache-data niet deserialiseerbaar (corruptie of schema-drift)")
-            WebApplicationException("Cache-data niet leesbaar.", 500)
+            SessiecacheException.Onleesbaar("Cache-data niet leesbaar.", e)
         }
         // Hash-velden ontbreken of onleesbaar → eigen data-issue, niet bereikbaarheids-issue.
         is CacheCorruptedException -> {
             log.errorf(e, "Cache-hash corrupt")
-            WebApplicationException("Cache-data niet leesbaar.", 500)
+            SessiecacheException.Onleesbaar("Cache-data niet leesbaar.", e)
         }
         else -> {
             log.errorf(e, "Cache-operatie mislukt")
-            WebApplicationException("Cache niet bereikbaar.", 503)
+            SessiecacheException.Onbereikbaar("Cache niet bereikbaar.", e)
         }
     }
 

--- a/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/Sessiecache.kt
+++ b/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/Sessiecache.kt
@@ -16,7 +16,7 @@ import java.util.UUID
  *
  * Foutsemantiek: de synchrone lees-/schrijfmethoden gooien een [SessiecacheException]
  * (gesloten hiërarchie, geen HTTP-transport-type) zodat de consumer elk geval
- * exhaustief naar zijn eigen transport vertaalt; een nieuw foutscenario dwingt daar
+ * naar zijn eigen transport vertaalt; een nieuw foutscenario dwingt daar
  * een bouwfout af. De gevallen:
  * - cache nog niet gevuld → [SessiecacheException.NogNietGevuld]
  * - ophalen bezig → [SessiecacheException.OphalenBezig]

--- a/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/Sessiecache.kt
+++ b/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/Sessiecache.kt
@@ -14,12 +14,20 @@ import java.util.UUID
  * aggregatie, Profiel-resolver) is `internal` en alle sessiestaat leeft in Redis —
  * de facade-impl is stateless zodat meerdere pods dezelfde sessies kunnen bedienen.
  *
- * Foutsemantiek (gespiegeld aan het vroegere REST-contract van de sessiecache-
- * service, zodat de Problem-mapping bij de consumer ongewijzigd blijft):
- * - cache nog niet gevuld of ophalen bezig → [jakarta.ws.rs.WebApplicationException] 409
- * - laatste ophaling mislukt → 500 (client moet `ophalen` opnieuw aanroepen)
- * - Redis onbereikbaar / schrijf-contentie → 503 (retriable)
- * - cache-corruptie (onleesbare entry) → 500
+ * Foutsemantiek: de synchrone lees-/schrijfmethoden gooien een [SessiecacheException]
+ * (gesloten hiërarchie, geen HTTP-transport-type) zodat de consumer elk geval
+ * exhaustief naar zijn eigen transport vertaalt; een nieuw foutscenario dwingt daar
+ * een bouwfout af. De gevallen:
+ * - cache nog niet gevuld → [SessiecacheException.NogNietGevuld]
+ * - ophalen bezig → [SessiecacheException.OphalenBezig]
+ * - laatste ophaling mislukt → [SessiecacheException.OphalenMislukt] (client moet `ophalen` herhalen)
+ * - opslag onbereikbaar / schrijf-contentie → [SessiecacheException.Onbereikbaar] (retriable)
+ * - cache-data onleesbaar (corruptie) → [SessiecacheException.Onleesbaar]
+ * - ongeldige invoer → [SessiecacheException.OngeldigeInvoer]
+ * - geen actieve sessie (schrijfpad) → [SessiecacheException.GeenActieveSessie]
+ *
+ * Het streaming [ophalen] heeft een eigen asynchroon foutkanaal (`Multi`-failure) en
+ * valt buiten deze hiërarchie.
  */
 interface Sessiecache {
 

--- a/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/Sessiecache.kt
+++ b/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/Sessiecache.kt
@@ -15,16 +15,9 @@ import java.util.UUID
  * de facade-impl is stateless zodat meerdere pods dezelfde sessies kunnen bedienen.
  *
  * Foutsemantiek: de synchrone lees-/schrijfmethoden gooien een [SessiecacheException]
- * (gesloten hiërarchie, geen HTTP-transport-type) zodat de consumer elk geval
- * naar zijn eigen transport vertaalt; een nieuw foutscenario dwingt daar
- * een bouwfout af. De gevallen:
- * - cache nog niet gevuld → [SessiecacheException.NogNietGevuld]
- * - ophalen bezig → [SessiecacheException.OphalenBezig]
- * - laatste ophaling mislukt → [SessiecacheException.OphalenMislukt] (client moet `ophalen` herhalen)
- * - opslag onbereikbaar / schrijf-contentie → [SessiecacheException.Onbereikbaar] (retriable)
- * - cache-data onleesbaar (corruptie) → [SessiecacheException.Onleesbaar]
- * - ongeldige invoer → [SessiecacheException.OngeldigeInvoer]
- * - geen actieve sessie (schrijfpad) → [SessiecacheException.GeenActieveSessie]
+ * (gesloten hiërarchie) zodat de consumer elk geval naar zijn eigen transport vertaalt;
+ * een nieuw foutscenario dwingt daar een bouwfout af. Zie [SessiecacheException] voor de
+ * afzonderlijke foutgevallen.
  *
  * Het streaming [ophalen] heeft een eigen asynchroon foutkanaal (`Multi`-failure) en
  * valt buiten deze hiërarchie.

--- a/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/SessiecacheException.kt
+++ b/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/SessiecacheException.kt
@@ -3,12 +3,12 @@ package nl.rijksoverheid.moz.fbs.berichtensessiecache
 /**
  * Foutsemantiek van de synchrone [Sessiecache]-facade als gesloten hiërarchie.
  *
- * De library heeft geen HTTP-laag, dus draagt zij haar fouten niet langer via een
- * transport-type ([jakarta.ws.rs.WebApplicationException] + statuscode): consumers
- * vertalen elk geval naar hun eigen transport. Doordat de hiërarchie
- * `sealed` is, dwingt een nieuw foutscenario een bouwfout af bij de consumer (de
- * `when` dekt niet langer alle gevallen) i.p.v. een runtime-verrassing waarbij een
- * onbedoeld foutgeval verkeerd bij de gebruiker terechtkomt. Vgl. het bestaande
+ * De library draagt haar fouten als domein-type (deze gesloten hiërarchie) en niet als
+ * transport-type met statuscode: elke consumer vertaalt zelf elk geval naar zijn eigen
+ * transport. Doordat de hiërarchie `sealed` is, dwingt een nieuw foutscenario een bouwfout
+ * af bij de consumer (de `when` dekt dan niet meer alle gevallen) i.p.v. een
+ * runtime-verrassing waarbij een onbedoeld foutgeval verkeerd bij de gebruiker terechtkomt.
+ * Vgl. het bestaande
  * [nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.MagazijnResult].
  *
  * Het streaming-ophaalpad ([Sessiecache.ophalen]) heeft een eigen, asynchroon

--- a/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/SessiecacheException.kt
+++ b/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/SessiecacheException.kt
@@ -1,0 +1,39 @@
+package nl.rijksoverheid.moz.fbs.berichtensessiecache
+
+/**
+ * Foutsemantiek van de synchrone [Sessiecache]-facade als gesloten hiërarchie.
+ *
+ * De library heeft geen HTTP-laag, dus draagt zij haar fouten niet langer via een
+ * transport-type ([jakarta.ws.rs.WebApplicationException] + statuscode): consumers
+ * vertalen elk geval exhaustief naar hun eigen transport. Doordat de hiërarchie
+ * `sealed` is, dwingt een nieuw foutscenario een bouwfout af bij de consumer (de
+ * `when` is niet langer exhaustief) i.p.v. een runtime-verrassing waarbij een
+ * onbedoeld foutgeval verkeerd bij de gebruiker terechtkomt. Vgl. het bestaande
+ * [nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.MagazijnResult].
+ *
+ * Het streaming-ophaalpad ([Sessiecache.ophalen]) heeft een eigen, asynchroon
+ * foutkanaal (de `Multi`-failure) en valt buiten deze hiërarchie.
+ */
+sealed class SessiecacheException(message: String, cause: Throwable? = null) : RuntimeException(message, cause) {
+
+    /** Nog geen ophaling gestart voor deze ontvanger: de cache is (nog) leeg. */
+    class NogNietGevuld(message: String) : SessiecacheException(message)
+
+    /** Een ophaling loopt; de cache is mogelijk nog incompleet. */
+    class OphalenBezig(message: String) : SessiecacheException(message)
+
+    /** De laatste ophaling is mislukt; de ontvanger moet het ophalen opnieuw starten. */
+    class OphalenMislukt(message: String) : SessiecacheException(message)
+
+    /** Cache-opslag tijdelijk onbereikbaar of schrijf-contentie; retriable. */
+    class Onbereikbaar(message: String, cause: Throwable? = null) : SessiecacheException(message, cause)
+
+    /** Cache-data onleesbaar (deserialisatiefout of corruptie); niet retriable. */
+    class Onleesbaar(message: String, cause: Throwable? = null) : SessiecacheException(message, cause)
+
+    /** Ongeldige invoer in een facade-call (lege patch, ontvanger-mismatch, limiet-overschrijding). */
+    class OngeldigeInvoer(message: String, cause: Throwable? = null) : SessiecacheException(message, cause)
+
+    /** Geen actieve sessie voor de ontvanger (aanmeld-schrijfpad). */
+    class GeenActieveSessie(message: String) : SessiecacheException(message)
+}

--- a/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/SessiecacheException.kt
+++ b/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/SessiecacheException.kt
@@ -5,9 +5,9 @@ package nl.rijksoverheid.moz.fbs.berichtensessiecache
  *
  * De library heeft geen HTTP-laag, dus draagt zij haar fouten niet langer via een
  * transport-type ([jakarta.ws.rs.WebApplicationException] + statuscode): consumers
- * vertalen elk geval exhaustief naar hun eigen transport. Doordat de hiërarchie
+ * vertalen elk geval naar hun eigen transport. Doordat de hiërarchie
  * `sealed` is, dwingt een nieuw foutscenario een bouwfout af bij de consumer (de
- * `when` is niet langer exhaustief) i.p.v. een runtime-verrassing waarbij een
+ * `when` dekt niet langer alle gevallen) i.p.v. een runtime-verrassing waarbij een
  * onbedoeld foutgeval verkeerd bij de gebruiker terechtkomt. Vgl. het bestaande
  * [nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.MagazijnResult].
  *

--- a/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/BlockingSessiecacheTest.kt
+++ b/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/BlockingSessiecacheTest.kt
@@ -28,10 +28,11 @@ import java.util.UUID
 
 /**
  * Pin het facade-contract van [BlockingSessiecache]: de gereed-status-gating op
- * leespaden, de vertaling van infrastructuurfouten naar de gedocumenteerde
- * statuscodes en de invoervalidatie op de schrijfpaden. Dit gedrag zat eerder
- * in de REST-resource van de sessiecache-deployable; de facade is nu het
- * contractuele seam voor consumers.
+ * leespaden, de vertaling van infrastructuurfouten naar de gesloten
+ * [SessiecacheException]-hiërarchie en de invoervalidatie op de schrijfpaden. Dit
+ * gedrag zat eerder in de REST-resource van de sessiecache-deployable; de facade is
+ * nu het contractuele seam voor consumers. De facade draagt géén HTTP-transport-type
+ * meer — de vertaling naar statuscodes leeft bij de consumer (zie de uitvraag-service).
  */
 class BlockingSessiecacheTest {
 
@@ -60,30 +61,24 @@ class BlockingSessiecacheTest {
     // --- gereed-status-gating op leespaden ---
 
     @Test
-    fun `lijst zonder aggregatie-status geeft 409`() {
+    fun `lijst zonder aggregatie-status geeft NogNietGevuld`() {
         stubStatus(null)
 
-        val ex = assertThrows<WebApplicationException> { facade.lijst(ontvanger) }
-
-        assertEquals(409, ex.response.status)
+        assertThrows<SessiecacheException.NogNietGevuld> { facade.lijst(ontvanger) }
     }
 
     @Test
-    fun `lijst met BEZIG-status geeft 409`() {
+    fun `lijst met BEZIG-status geeft OphalenBezig`() {
         stubStatus(AggregationStatus(status = OphalenStatus.BEZIG, totaalMagazijnen = 2))
 
-        val ex = assertThrows<WebApplicationException> { facade.lijst(ontvanger) }
-
-        assertEquals(409, ex.response.status)
+        assertThrows<SessiecacheException.OphalenBezig> { facade.lijst(ontvanger) }
     }
 
     @Test
-    fun `lijst met FOUT-status geeft 500`() {
+    fun `lijst met FOUT-status geeft OphalenMislukt`() {
         stubStatus(AggregationStatus(status = OphalenStatus.FOUT))
 
-        val ex = assertThrows<WebApplicationException> { facade.lijst(ontvanger) }
-
-        assertEquals(500, ex.response.status)
+        assertThrows<SessiecacheException.OphalenMislukt> { facade.lijst(ontvanger) }
     }
 
     @Test
@@ -103,7 +98,7 @@ class BlockingSessiecacheTest {
     fun `zoek kent dezelfde gating en geeft q door`() {
         stubStatus(null)
 
-        assertThrows<WebApplicationException> { facade.zoek(ontvanger, "factuur") }
+        assertThrows<SessiecacheException.NogNietGevuld> { facade.zoek(ontvanger, "factuur") }
 
         stubStatus(gereed)
         every { service.zoekBerichten("factuur", 0, 20, ontvanger, null, null) } returns Uni.createFrom().item(legePagina)
@@ -124,12 +119,10 @@ class BlockingSessiecacheTest {
     // --- werkBerichtBij ---
 
     @Test
-    fun `werkBerichtBij zonder status en map geeft 400`() {
-        val ex = assertThrows<WebApplicationException> {
+    fun `werkBerichtBij zonder status en map geeft OngeldigeInvoer`() {
+        assertThrows<SessiecacheException.OngeldigeInvoer> {
             facade.werkBerichtBij(ontvanger, UUID.randomUUID(), status = null, map = null)
         }
-
-        assertEquals(400, ex.response.status)
     }
 
     @Test
@@ -143,23 +136,21 @@ class BlockingSessiecacheTest {
     }
 
     @Test
-    fun `werkBerichtBij vertaalt schrijf-contentie naar 503`() {
+    fun `werkBerichtBij vertaalt schrijf-contentie naar Onbereikbaar`() {
         val id = UUID.randomUUID()
 
         every { service.updateBerichtMetadata(id, ontvanger, null, "archief") } returns
             Uni.createFrom().failure(CacheContentieException(id))
 
-        val ex = assertThrows<WebApplicationException> {
+        assertThrows<SessiecacheException.Onbereikbaar> {
             facade.werkBerichtBij(ontvanger, id, status = null, map = "archief")
         }
-
-        assertEquals(503, ex.response.status)
     }
 
     // --- verwijder / ophalen ---
 
     @Test
-    fun `verwijder delegeert en vertaalt Redis-fouten naar 503`() {
+    fun `verwijder delegeert en vertaalt Redis-fouten naar Onbereikbaar`() {
         val id = UUID.randomUUID()
 
         every { service.verwijderBericht(id, ontvanger) } returns Uni.createFrom().voidItem()
@@ -171,9 +162,7 @@ class BlockingSessiecacheTest {
         every { service.verwijderBericht(id, ontvanger) } returns
             Uni.createFrom().failure(RuntimeException("redis weg"))
 
-        val ex = assertThrows<WebApplicationException> { facade.verwijder(ontvanger, id) }
-
-        assertEquals(503, ex.response.status)
+        assertThrows<SessiecacheException.Onbereikbaar> { facade.verwijder(ontvanger, id) }
     }
 
     @Test
@@ -190,21 +179,17 @@ class BlockingSessiecacheTest {
     // --- schrijfBericht ---
 
     @Test
-    fun `schrijfBericht wijst ontvanger-mismatch af met 400`() {
-        val ex = assertThrows<WebApplicationException> {
+    fun `schrijfBericht wijst ontvanger-mismatch af met OngeldigeInvoer`() {
+        assertThrows<SessiecacheException.OngeldigeInvoer> {
             facade.schrijfBericht(ontvanger, testBericht(ontvangerWaarde = "999990020"))
         }
-
-        assertEquals(400, ex.response.status)
     }
 
     @Test
-    fun `schrijfBericht zonder actieve sessie geeft 404`() {
+    fun `schrijfBericht zonder actieve sessie geeft GeenActieveSessie`() {
         stubStatus(null)
 
-        val ex = assertThrows<WebApplicationException> { facade.schrijfBericht(ontvanger, testBericht()) }
-
-        assertEquals(404, ex.response.status)
+        assertThrows<SessiecacheException.GeenActieveSessie> { facade.schrijfBericht(ontvanger, testBericht()) }
     }
 
     @Test
@@ -218,7 +203,7 @@ class BlockingSessiecacheTest {
     }
 
     @Test
-    fun `schrijfBericht vertaalt validator-afwijzing naar 400`() {
+    fun `schrijfBericht vertaalt validator-afwijzing naar OngeldigeInvoer`() {
         stubStatus(gereed)
         val bericht = testBericht()
 
@@ -226,56 +211,49 @@ class BlockingSessiecacheTest {
             throw IllegalArgumentException("Maximaal 100 bijlagen per bericht")
         }
 
-        val ex = assertThrows<WebApplicationException> { facade.schrijfBericht(ontvanger, bericht) }
-
-        assertEquals(400, ex.response.status)
+        assertThrows<SessiecacheException.OngeldigeInvoer> { facade.schrijfBericht(ontvanger, bericht) }
     }
 
     // --- foutvertaling awaitOrServiceUnavailable ---
 
     @Test
-    fun `cache-deserialisatiefout geeft 500`() {
+    fun `cache-deserialisatiefout geeft Onleesbaar`() {
         stubStatus(gereed)
         val id = UUID.randomUUID()
 
         every { service.getBerichtById(id, ontvanger) } returns
             Uni.createFrom().failure(JsonParseException(null, "corrupt"))
 
-        val ex = assertThrows<WebApplicationException> { facade.bericht(ontvanger, id) }
-
-        assertEquals(500, ex.response.status)
+        assertThrows<SessiecacheException.Onleesbaar> { facade.bericht(ontvanger, id) }
     }
 
     @Test
-    fun `corrupte cache-hash geeft 500`() {
+    fun `corrupte cache-hash geeft Onleesbaar`() {
         stubStatus(gereed)
         val id = UUID.randomUUID()
 
         every { service.getBerichtById(id, ontvanger) } returns
             Uni.createFrom().failure(CacheCorruptedException.veldOntbreekt("onderwerp"))
 
-        val ex = assertThrows<WebApplicationException> { facade.bericht(ontvanger, id) }
-
-        assertEquals(500, ex.response.status)
+        assertThrows<SessiecacheException.Onleesbaar> { facade.bericht(ontvanger, id) }
     }
 
     @Test
-    fun `onverwachte fout geeft 503`() {
+    fun `onverwachte fout geeft Onbereikbaar`() {
         every { service.getAggregationStatus(ontvanger) } returns
             Uni.createFrom().failure(IllegalStateException("redis connection reset"))
 
-        val ex = assertThrows<WebApplicationException> { facade.lijst(ontvanger) }
-
-        assertEquals(503, ex.response.status)
+        assertThrows<SessiecacheException.Onbereikbaar> { facade.lijst(ontvanger) }
     }
 
     @Test
-    fun `WebApplicationException uit de service propageert ongewijzigd`() {
+    fun `onverwacht transport-type uit de service lekt niet, maar wordt Onbereikbaar`() {
+        // De interne service hoort op de sync-paden geen WebApplicationException te gooien;
+        // mocht dat tóch gebeuren, dan maskeert de facade dit als infrastructuurfout zodat er
+        // geen HTTP-transport-type uit het library-contract lekt.
         every { service.getAggregationStatus(ontvanger) } returns
             Uni.createFrom().failure(WebApplicationException("teapot", 418))
 
-        val ex = assertThrows<WebApplicationException> { facade.lijst(ontvanger) }
-
-        assertEquals(418, ex.response.status)
+        assertThrows<SessiecacheException.Onbereikbaar> { facade.lijst(ontvanger) }
     }
 }

--- a/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnClientWireMockTest.kt
+++ b/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnClientWireMockTest.kt
@@ -8,8 +8,8 @@ import io.quarkus.test.junit.QuarkusTest
 import io.quarkus.test.junit.TestProfile
 import io.smallrye.mutiny.Multi
 import jakarta.inject.Inject
-import jakarta.ws.rs.WebApplicationException
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.Sessiecache
+import nl.rijksoverheid.moz.fbs.berichtensessiecache.SessiecacheException
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.EventType
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.MagazijnEvent
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.MagazijnStatus
@@ -172,8 +172,8 @@ class MagazijnClientWireMockTest {
         buitenste.subscribe().with({ }, { }, { }).cancel()
 
         // De aggregatie rondt de magazijns rond 800ms af en vult de cache, ondanks de
-        // disconnect. Tijdens het ophalen gooit de facade 409 (ophalen-bezig); pas wanneer
-        // de aggregatie de status op GEREED zet komt de lijst terug. Poll dus tot data of
+        // disconnect. Tijdens het ophalen gooit de facade OphalenBezig; pas wanneer de
+        // aggregatie de status op GEREED zet komt de lijst terug. Poll dus tot data of
         // tot een ruime deadline verstrijkt.
         val deadline = System.currentTimeMillis() + 6_000
         var totaal = 0L
@@ -184,19 +184,19 @@ class MagazijnClientWireMockTest {
                 totaal = sessiecache.lijst(ontvanger).totalElements
 
                 if (totaal >= 1) break
-            } catch (e: WebApplicationException) {
-                if (e.response.status == 409) zagOphalenBezig = true
+            } catch (e: SessiecacheException.OphalenBezig) {
+                zagOphalenBezig = true
             }
 
             Thread.sleep(150)
         }
 
-        // 409 ná de disconnect bewijst dat de aggregatie nog liep (de disconnect is dus
-        // load-bearing, niet een race ná completion); totalElements>=1 bewijst dat ze alsnog
+        // OphalenBezig ná de disconnect bewijst dat de aggregatie nog liep (de disconnect is
+        // dus load-bearing, niet een race ná completion); totalElements>=1 bewijst dat ze alsnog
         // afrondde en de cache vulde. Beide samen pinnen "disconnect stopt de cache-vulling niet".
         assertTrue(
             zagOphalenBezig,
-            "Verwacht minstens één 409 (ophalen-bezig) ná de disconnect — anders liep de aggregatie niet door",
+            "Verwacht minstens één OphalenBezig ná de disconnect — anders liep de aggregatie niet door",
         )
         assertTrue(
             totaal >= 1,

--- a/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/aanmeld/AanmeldService.kt
+++ b/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/aanmeld/AanmeldService.kt
@@ -5,7 +5,9 @@ import jakarta.ws.rs.WebApplicationException
 import jakarta.ws.rs.core.Response
 import nl.mijnoverheidzakelijk.ldv.logboekdataverwerking.LogboekContext
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.Sessiecache
+import nl.rijksoverheid.moz.fbs.berichtensessiecache.SessiecacheException
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.Bericht
+import nl.rijksoverheid.moz.fbs.berichtenuitvraag.uitvraag.naApiFout
 import nl.rijksoverheid.moz.fbs.common.exception.DomainValidationException
 import nl.rijksoverheid.moz.fbs.common.identificatie.Identificatienummer
 import nl.rijksoverheid.moz.fbs.common.identificatie.IdentificatienummerType
@@ -89,14 +91,17 @@ class AanmeldService(
             sessiecache.schrijfBericht(event.ontvanger, bericht)
 
             return true
-        } catch (e: WebApplicationException) {
-            if (e.response.status == Response.Status.NOT_FOUND.statusCode) {
-                log.debug("Geen actieve sessie voor ontvanger; aanmelding overgeslagen")
+        } catch (ignored: SessiecacheException.GeenActieveSessie) {
+            // Geen actieve sessie is het normale geval (de meeste ontvangers hebben er geen):
+            // geaccepteerd-maar-overgeslagen, geen fout. Bewust geen detail loggen.
+            log.debug("Geen actieve sessie voor ontvanger; aanmelding overgeslagen")
 
-                return false
-            }
-
-            throw e
+            return false
+        } catch (e: SessiecacheException) {
+            // Overige cache-fouten (ongeldige invoer, opslag onbereikbaar, onleesbaar)
+            // status-behoudend naar de webhook-caller: naApiFout reproduceert dezelfde
+            // status (400/503/500) die de facade voorheen zelf gooide.
+            throw e.naApiFout()
         }
     }
 

--- a/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/BerichtBeheerService.kt
+++ b/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/BerichtBeheerService.kt
@@ -5,6 +5,7 @@ import jakarta.ws.rs.NotFoundException
 import jakarta.ws.rs.WebApplicationException
 import jakarta.ws.rs.core.Response
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.Sessiecache
+import nl.rijksoverheid.moz.fbs.berichtensessiecache.SessiecacheException
 import nl.rijksoverheid.moz.fbs.berichtenuitvraag.api.model.Bericht
 import nl.rijksoverheid.moz.fbs.berichtenuitvraag.api.model.BerichtPatch
 import nl.rijksoverheid.moz.fbs.common.identificatie.Identificatienummer
@@ -54,8 +55,8 @@ class BerichtBeheerService(
 
         val bijgewerkt = try {
             sessiecache.werkBerichtBij(ontvangerId, berichtId, UitvraagDtoMapper.toLeesstatus(patch.status), patch.map)
-        } catch (e: WebApplicationException) {
-            if (!isUpstreamStoring(e)) {
+        } catch (e: SessiecacheException) {
+            if (!isUpstreamStoring(e.naApiFout())) {
                 // 4xx ná een geslaagde magazijn-write is een contract-bug, geen transport-
                 // storing: de client-request passeerde immers al de magazijn-validatie, dus
                 // hoort de cache hier geen 4xx te geven. Niet compenseren, maar wél met
@@ -64,12 +65,12 @@ class BerichtBeheerService(
                 // 5xx-desync, dus géén stille warnf maar een alertbare errorf. Status propageert.
                 log.errorf(e, "%s cache-PATCH 4xx ná geslaagde magazijn-PATCH; magazijn↔cache stale tot TTL. berichtId=%s", ALERT_CACHE_DESYNC, berichtId)
 
-                throw e
+                throw e.naApiFout()
             }
 
             log.errorf(e, "cache-PATCH 5xx na geslaagde magazijn-PATCH; invalidate volgt. berichtId=%s", berichtId)
             invalideerCacheNaMagazijnWrite(ontvangerId, berichtId)
-            throw badGateway()
+            throw badGateway(e)
         }
 
         if (bijgewerkt == null) {
@@ -97,23 +98,23 @@ class BerichtBeheerService(
         try {
             // Idempotente invalidate: "niet in cache" is geen fout, dus geen 404-pad hier.
             sessiecache.verwijder(ontvangerId, berichtId)
-        } catch (e: WebApplicationException) {
-            if (!isUpstreamStoring(e)) {
+        } catch (e: SessiecacheException) {
+            if (!isUpstreamStoring(e.naApiFout())) {
                 log.errorf(e, "%s cache-DELETE 4xx ná geslaagde magazijn-DELETE; magazijn↔cache stale tot TTL. berichtId=%s", ALERT_CACHE_DESYNC, berichtId)
 
-                throw e
+                throw e.naApiFout()
             }
 
             log.errorf(e, "cache-DELETE 5xx na geslaagde magazijn-DELETE; invalidate volgt. berichtId=%s", berichtId)
             invalideerCacheNaMagazijnWrite(ontvangerId, berichtId)
-            throw badGateway()
+            throw badGateway(e)
         }
     }
 
     private fun invalideerCacheNaMagazijnWrite(ontvanger: Identificatienummer, berichtId: UUID) {
         try {
             sessiecache.verwijder(ontvanger, berichtId)
-        } catch (e: WebApplicationException) {
+        } catch (e: SessiecacheException) {
             // Dubbele cache-faal: de write naar de cache faalde én de compenserende
             // invalidate faalde. De cache blijft stale tot de TTL zonder self-heal —
             // errorf (niet warnf) zodat een aanhoudende cache-outage alertbaar is i.p.v.
@@ -125,8 +126,9 @@ class BerichtBeheerService(
     }
 
     // 502: magazijn-write slaagde, maar de cache-update faalde (zie [upstreamBadGateway]).
-    private fun badGateway(): WebApplicationException =
-        upstreamBadGateway("cache-update faalde; magazijn bijgewerkt")
+    // De cache-fout gaat als cause mee zodat de oorzaak in exception-keten-logging behouden blijft.
+    private fun badGateway(cause: Throwable): WebApplicationException =
+        upstreamBadGateway("cache-update faalde; magazijn bijgewerkt", cause)
 
     private companion object {
         private val log: Logger = Logger.getLogger(BerichtBeheerService::class.java)

--- a/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/BerichtBeheerService.kt
+++ b/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/BerichtBeheerService.kt
@@ -68,7 +68,7 @@ class BerichtBeheerService(
                 throw e.naApiFout()
             }
 
-            log.errorf(e, "cache-PATCH 5xx na geslaagde magazijn-PATCH; invalidate volgt. berichtId=%s", berichtId)
+            log.errorf(e, "cache-PATCH storing na geslaagde magazijn-PATCH; invalidate volgt. berichtId=%s", berichtId)
             invalideerCacheNaMagazijnWrite(ontvangerId, berichtId)
             throw badGateway(e)
         }
@@ -105,7 +105,7 @@ class BerichtBeheerService(
                 throw e.naApiFout()
             }
 
-            log.errorf(e, "cache-DELETE 5xx na geslaagde magazijn-DELETE; invalidate volgt. berichtId=%s", berichtId)
+            log.errorf(e, "cache-DELETE storing na geslaagde magazijn-DELETE; invalidate volgt. berichtId=%s", berichtId)
             invalideerCacheNaMagazijnWrite(ontvangerId, berichtId)
             throw badGateway(e)
         }

--- a/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/BerichtBeheerService.kt
+++ b/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/BerichtBeheerService.kt
@@ -14,11 +14,11 @@ import java.util.UUID
 
 /**
  * Schrijft naar magazijn (bron van waarheid) en sessiecache (afgeleide cache).
- * Magazijn-faal → fout naar client, cache niet aangeraakt. Magazijn-OK + cache-faal
+ * Magazijn-faal → fout naar client, cache niet aangeraakt. Magazijn-OK + cache-storing
  * → best-effort invalidate ('stale' wordt 'leeg'), dan 502 om de inconsistentie te
- * signaleren. "Cache-faal" = een 5xx uit de facade (Redis-storing, schrijf-contentie,
- * corruptie); een 4xx duidt op een contract-bug en gaat onveranderd door zonder
- * invalidatie.
+ * signaleren. "Cache-storing" = [SessiecacheException.isStoring] (Redis-storing, schrijf-
+ * contentie, corruptie, mislukte ophaling); een niet-storing cache-fout duidt op een
+ * contract-bug en gaat status-behoudend door zonder invalidatie.
  *
  * De client geeft de `magazijnId` mee (uit de GET-response, `Bericht.magazijnId` of
  * `BerichtSamenvatting.magazijnId`). Daarmee hoeven we het bron-magazijn niet meer
@@ -56,14 +56,14 @@ class BerichtBeheerService(
         val bijgewerkt = try {
             sessiecache.werkBerichtBij(ontvangerId, berichtId, UitvraagDtoMapper.toLeesstatus(patch.status), patch.map)
         } catch (e: SessiecacheException) {
-            if (!isUpstreamStoring(e.naApiFout())) {
-                // 4xx ná een geslaagde magazijn-write is een contract-bug, geen transport-
-                // storing: de client-request passeerde immers al de magazijn-validatie, dus
-                // hoort de cache hier geen 4xx te geven. Niet compenseren, maar wél met
-                // hetzelfde alert-anker als de dubbele-faal-tak loggen: magazijn↔cache
+            if (!e.isStoring()) {
+                // Een niet-storing fout ná een geslaagde magazijn-write is een contract-bug,
+                // geen transport-storing: de client-request passeerde immers al de magazijn-
+                // validatie, dus hoort de cache hier geen client-fout te geven. Niet compenseren,
+                // maar wél met hetzelfde alert-anker als de dubbele-faal-tak loggen: magazijn↔cache
                 // desyncen zonder self-heal tot de TTL — dezelfde operationele impact als een
-                // 5xx-desync, dus géén stille warnf maar een alertbare errorf. Status propageert.
-                log.errorf(e, "%s cache-PATCH 4xx ná geslaagde magazijn-PATCH; magazijn↔cache stale tot TTL. berichtId=%s", ALERT_CACHE_DESYNC, berichtId)
+                // storing-desync, dus géén stille warnf maar een alertbare errorf. Status propageert.
+                log.errorf(e, "%s cache-PATCH niet-storing ná geslaagde magazijn-PATCH; magazijn↔cache stale tot TTL. berichtId=%s", ALERT_CACHE_DESYNC, berichtId)
 
                 throw e.naApiFout()
             }
@@ -99,8 +99,8 @@ class BerichtBeheerService(
             // Idempotente invalidate: "niet in cache" is geen fout, dus geen 404-pad hier.
             sessiecache.verwijder(ontvangerId, berichtId)
         } catch (e: SessiecacheException) {
-            if (!isUpstreamStoring(e.naApiFout())) {
-                log.errorf(e, "%s cache-DELETE 4xx ná geslaagde magazijn-DELETE; magazijn↔cache stale tot TTL. berichtId=%s", ALERT_CACHE_DESYNC, berichtId)
+            if (!e.isStoring()) {
+                log.errorf(e, "%s cache-DELETE niet-storing ná geslaagde magazijn-DELETE; magazijn↔cache stale tot TTL. berichtId=%s", ALERT_CACHE_DESYNC, berichtId)
 
                 throw e.naApiFout()
             }

--- a/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/BerichtOphaalService.kt
+++ b/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/BerichtOphaalService.kt
@@ -126,7 +126,7 @@ class BerichtOphaalService(
     }
 
     private fun zoekBerichtInCache(xOntvanger: String, berichtId: UUID) =
-        mapUpstreamFout(log, "cache-bericht-lookup (berichtId=$berichtId)") {
+        leesUitCache(log, "cache-bericht-lookup (berichtId=$berichtId)") {
             sessiecache.bericht(Identificatienummer.fromHeader(xOntvanger), berichtId)
         }
 

--- a/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/BerichtenlijstService.kt
+++ b/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/BerichtenlijstService.kt
@@ -17,11 +17,10 @@ import java.nio.charset.StandardCharsets
  * levert domein-types; deze service mapt naar de uitvraag-API-modellen en bouwt
  * de HAL-paginering-links met de uitvraag-parameternamen (`pagina`/`paginaGrootte`).
  *
- * [leesUitCache] blijft de fout-grens: een [SessiecacheException] wordt
- * naar zijn status vertaald en daarna geldt dezelfde upstream-politiek als op het
- * magazijn — een storing (Redis-storing, mislukte ophaling, cache-corruptie) wordt
- * 502 (de cache is voor de portaal-client een upstream-bron, of die nu over REST of
- * in-process wordt aangesproken); een 409 (cache nog niet gevuld / ophalen bezig)
+ * [leesUitCache] blijft de fout-grens: een [SessiecacheException] wordt naar zijn status
+ * vertaald en daarna geldt dezelfde upstream-politiek als op het magazijn — een storing
+ * (cache onbereikbaar, mislukte ophaling, cache-corruptie) wordt 502, omdat de cache voor
+ * de portaal-client een upstream-bron is; een 409 (cache nog niet gevuld / ophalen bezig)
  * propageert ongewijzigd.
  */
 @ApplicationScoped

--- a/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/BerichtenlijstService.kt
+++ b/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/BerichtenlijstService.kt
@@ -17,7 +17,7 @@ import java.nio.charset.StandardCharsets
  * levert domein-types; deze service mapt naar de uitvraag-API-modellen en bouwt
  * de HAL-paginering-links met de uitvraag-parameternamen (`pagina`/`paginaGrootte`).
  *
- * [leesUitCache] blijft de fout-grens: een [SessiecacheException] wordt exhaustief
+ * [leesUitCache] blijft de fout-grens: een [SessiecacheException] wordt
  * naar zijn status vertaald en daarna geldt dezelfde upstream-politiek als op het
  * magazijn — een storing (Redis-storing, mislukte ophaling, cache-corruptie) wordt
  * 502 (de cache is voor de portaal-client een upstream-bron, of die nu over REST of

--- a/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/BerichtenlijstService.kt
+++ b/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/BerichtenlijstService.kt
@@ -17,10 +17,12 @@ import java.nio.charset.StandardCharsets
  * levert domein-types; deze service mapt naar de uitvraag-API-modellen en bouwt
  * de HAL-paginering-links met de uitvraag-parameternamen (`pagina`/`paginaGrootte`).
  *
- * [mapUpstreamFout] blijft de fout-grens: een 5xx uit de facade (Redis-storing,
- * mislukte ophaling, cache-corruptie) wordt 502 — voor de portaal-client is de
- * cache een upstream-bron, of die nu over REST of in-process wordt aangesproken.
- * Een 409 (cache nog niet gevuld / ophalen bezig) propageert ongewijzigd.
+ * [leesUitCache] blijft de fout-grens: een [SessiecacheException] wordt exhaustief
+ * naar zijn status vertaald en daarna geldt dezelfde upstream-politiek als op het
+ * magazijn — een storing (Redis-storing, mislukte ophaling, cache-corruptie) wordt
+ * 502 (de cache is voor de portaal-client een upstream-bron, of die nu over REST of
+ * in-process wordt aangesproken); een 409 (cache nog niet gevuld / ophalen bezig)
+ * propageert ongewijzigd.
  */
 @ApplicationScoped
 class BerichtenlijstService(
@@ -28,14 +30,14 @@ class BerichtenlijstService(
 ) {
     fun lijst(xOntvanger: String, pagina: Int?, paginaGrootte: Int?): BerichtenLijst {
         val ontvanger = Identificatienummer.fromHeader(xOntvanger)
-        val resultaat = mapUpstreamFout(log, "cache-lijst") { sessiecache.lijst(ontvanger, pagina, paginaGrootte) }
+        val resultaat = leesUitCache(log, "cache-lijst") { sessiecache.lijst(ontvanger, pagina, paginaGrootte) }
 
         return toBerichtenLijst(resultaat) { p -> "${ApiInfo.BASE_PATH}/berichten?pagina=$p&paginaGrootte=${resultaat.pageSize}" }
     }
 
     fun zoek(xOntvanger: String, q: String): BerichtenLijst {
         val ontvanger = Identificatienummer.fromHeader(xOntvanger)
-        val resultaat = mapUpstreamFout(log, "cache-zoek") { sessiecache.zoek(ontvanger, q) }
+        val resultaat = leesUitCache(log, "cache-zoek") { sessiecache.zoek(ontvanger, q) }
         val encodedQ = URLEncoder.encode(q, StandardCharsets.UTF_8)
 
         // `_zoeken` kent geen paginering-parameters in de uitvraag-spec; alleen een

--- a/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/UpstreamFault.kt
+++ b/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/UpstreamFault.kt
@@ -63,9 +63,9 @@ internal fun upstreamBadGateway(detail: String, cause: Throwable? = null): WebAp
 
 /**
  * Of een cache-fout een upstream-storing is (de cache zelf hapert) dan wel een client-/
- * contract-aanwijzing die status-behoudend hoort te propageren. Exhaustief náást [naApiFout],
- * waarmee de cache→transport-kennis op één plek belegd blijft; een nieuw [SessiecacheException]-
- * geval breekt ook hier de build. Het schrijfpad gebruikt dit om te beslissen of het na een
+ * contract-aanwijzing die status-behoudend hoort te propageren. Dekt alle gevallen af, náást
+ * [naApiFout], waarmee de cache→transport-kennis op één plek belegd blijft; een nieuw
+ * [SessiecacheException]-geval breekt ook hier de build. Het schrijfpad gebruikt dit om te beslissen of het na een
  * geslaagde magazijn-write de cache compenseert (invalidate + 502) of de status doorlaat —
  * zonder daarvoor een wegwerp-[WebApplicationException] te bouwen of statuscode-ranges te
  * reverse-engineeren.
@@ -85,7 +85,7 @@ internal fun SessiecacheException.isStoring(): Boolean = when (this) {
 
 /**
  * Enige plek waar de gesloten [SessiecacheException]-hiërarchie naar een HTTP-status
- * wordt vertaald. De `when` is exhaustief zónder `else`: een nieuw foutscenario in de
+ * wordt vertaald. De `when` dekt alle gevallen zónder `else`: een nieuw foutscenario in de
  * cache-library breekt hier de build i.p.v. stil verkeerd bij de gebruiker te landen.
  *
  * Bewust géén 502-mapping hier: deze functie reproduceert exact de status die de
@@ -105,7 +105,7 @@ internal fun SessiecacheException.naApiFout(): WebApplicationException = when (t
 
 /**
  * Lees-pad-grens voor cache-facade-calls: vertaalt een [SessiecacheException] eerst
- * exhaustief naar zijn status ([naApiFout]) en past daarna dezelfde upstream-politiek
+ * naar zijn status ([naApiFout]) en past daarna dezelfde upstream-politiek
  * toe als op het magazijn ([mapUpstreamFout]) — een 5xx wordt 502, een 4xx (409 cache-
  * nog-niet-gevuld) propageert ongewijzigd. Zo blijft "502 = upstream-fout" gelden voor
  * de in-process cache zoals voorheen.

--- a/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/UpstreamFault.kt
+++ b/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/UpstreamFault.kt
@@ -88,10 +88,9 @@ internal fun SessiecacheException.isStoring(): Boolean = when (this) {
  * wordt vertaald. De `when` dekt alle gevallen zónder `else`: een nieuw foutscenario in de
  * cache-library breekt hier de build i.p.v. stil verkeerd bij de gebruiker te landen.
  *
- * Bewust géén 502-mapping hier: deze functie reproduceert exact de status die de
- * facade vroeger zelf gooide. De per-consumer transportpolitiek (lees-pad → [mapUpstreamFout]
- * dat 5xx naar 502 maakt; aanmeld-pad → status-behoudend) blijft daar belegd, zodat
- * het externe gedrag ongewijzigd is.
+ * Bewust géén 502-mapping hier: deze functie levert puur de status die per cache-foutgeval
+ * hoort. De per-consumer transportpolitiek (lees-pad → [mapUpstreamFout] dat 5xx naar 502
+ * maakt; aanmeld-pad → status-behoudend) blijft daar belegd.
  */
 internal fun SessiecacheException.naApiFout(): WebApplicationException = when (this) {
     is SessiecacheException.NogNietGevuld -> WebApplicationException(message, this, Response.Status.CONFLICT)
@@ -107,8 +106,8 @@ internal fun SessiecacheException.naApiFout(): WebApplicationException = when (t
  * Lees-pad-grens voor cache-facade-calls: vertaalt een [SessiecacheException] eerst
  * naar zijn status ([naApiFout]) en past daarna dezelfde upstream-politiek
  * toe als op het magazijn ([mapUpstreamFout]) — een 5xx wordt 502, een 4xx (409 cache-
- * nog-niet-gevuld) propageert ongewijzigd. Zo blijft "502 = upstream-fout" gelden voor
- * de in-process cache zoals voorheen.
+ * nog-niet-gevuld) propageert ongewijzigd. Zo geldt "502 = upstream-fout" ook voor
+ * de in-process cache.
  *
  * De lees-facademethoden (`lijst`/`zoek`/`bericht`) produceren alleen storing-fouten en de
  * 409-gating ([SessiecacheException.NogNietGevuld]/[SessiecacheException.OphalenBezig]); de

--- a/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/UpstreamFault.kt
+++ b/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/UpstreamFault.kt
@@ -62,16 +62,6 @@ internal fun upstreamBadGateway(detail: String, cause: Throwable? = null): WebAp
     WebApplicationException(detail, cause, Response.Status.BAD_GATEWAY)
 
 /**
- * Enige plek waar de gesloten [SessiecacheException]-hiërarchie naar een HTTP-status
- * wordt vertaald. De `when` is exhaustief zónder `else`: een nieuw foutscenario in de
- * cache-library breekt hier de build i.p.v. stil verkeerd bij de gebruiker te landen.
- *
- * Bewust géén 502-mapping hier: deze functie reproduceert exact de status die de
- * facade vroeger zelf gooide. De per-consumer transportpolitiek (lees-pad → [mapUpstreamFout]
- * dat 5xx naar 502 maakt; aanmeld-pad → status-behoudend) blijft daar belegd, zodat
- * het externe gedrag ongewijzigd is.
- */
-/**
  * Of een cache-fout een upstream-storing is (de cache zelf hapert) dan wel een client-/
  * contract-aanwijzing die status-behoudend hoort te propageren. Exhaustief náást [naApiFout],
  * waarmee de cache→transport-kennis op één plek belegd blijft; een nieuw [SessiecacheException]-
@@ -93,6 +83,16 @@ internal fun SessiecacheException.isStoring(): Boolean = when (this) {
     -> false
 }
 
+/**
+ * Enige plek waar de gesloten [SessiecacheException]-hiërarchie naar een HTTP-status
+ * wordt vertaald. De `when` is exhaustief zónder `else`: een nieuw foutscenario in de
+ * cache-library breekt hier de build i.p.v. stil verkeerd bij de gebruiker te landen.
+ *
+ * Bewust géén 502-mapping hier: deze functie reproduceert exact de status die de
+ * facade vroeger zelf gooide. De per-consumer transportpolitiek (lees-pad → [mapUpstreamFout]
+ * dat 5xx naar 502 maakt; aanmeld-pad → status-behoudend) blijft daar belegd, zodat
+ * het externe gedrag ongewijzigd is.
+ */
 internal fun SessiecacheException.naApiFout(): WebApplicationException = when (this) {
     is SessiecacheException.NogNietGevuld -> WebApplicationException(message, this, Response.Status.CONFLICT)
     is SessiecacheException.OphalenBezig -> WebApplicationException(message, this, Response.Status.CONFLICT)
@@ -109,6 +109,11 @@ internal fun SessiecacheException.naApiFout(): WebApplicationException = when (t
  * toe als op het magazijn ([mapUpstreamFout]) — een 5xx wordt 502, een 4xx (409 cache-
  * nog-niet-gevuld) propageert ongewijzigd. Zo blijft "502 = upstream-fout" gelden voor
  * de in-process cache zoals voorheen.
+ *
+ * De lees-facademethoden (`lijst`/`zoek`/`bericht`) produceren alleen storing-fouten en de
+ * 409-gating ([SessiecacheException.NogNietGevuld]/[SessiecacheException.OphalenBezig]); de
+ * 400/404-gevallen ([SessiecacheException.OngeldigeInvoer]/[SessiecacheException.GeenActieveSessie])
+ * ontstaan uitsluitend op de schrijfpaden en bereiken deze grens dus niet.
  */
 internal inline fun <T> leesUitCache(log: Logger, context: String, block: () -> T): T =
     mapUpstreamFout(log, context) {

--- a/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/UpstreamFault.kt
+++ b/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/UpstreamFault.kt
@@ -71,6 +71,28 @@ internal fun upstreamBadGateway(detail: String, cause: Throwable? = null): WebAp
  * dat 5xx naar 502 maakt; aanmeld-pad → status-behoudend) blijft daar belegd, zodat
  * het externe gedrag ongewijzigd is.
  */
+/**
+ * Of een cache-fout een upstream-storing is (de cache zelf hapert) dan wel een client-/
+ * contract-aanwijzing die status-behoudend hoort te propageren. Exhaustief náást [naApiFout],
+ * waarmee de cache→transport-kennis op één plek belegd blijft; een nieuw [SessiecacheException]-
+ * geval breekt ook hier de build. Het schrijfpad gebruikt dit om te beslissen of het na een
+ * geslaagde magazijn-write de cache compenseert (invalidate + 502) of de status doorlaat —
+ * zonder daarvoor een wegwerp-[WebApplicationException] te bouwen of statuscode-ranges te
+ * reverse-engineeren.
+ */
+internal fun SessiecacheException.isStoring(): Boolean = when (this) {
+    is SessiecacheException.OphalenMislukt,
+    is SessiecacheException.Onbereikbaar,
+    is SessiecacheException.Onleesbaar,
+    -> true
+
+    is SessiecacheException.NogNietGevuld,
+    is SessiecacheException.OphalenBezig,
+    is SessiecacheException.OngeldigeInvoer,
+    is SessiecacheException.GeenActieveSessie,
+    -> false
+}
+
 internal fun SessiecacheException.naApiFout(): WebApplicationException = when (this) {
     is SessiecacheException.NogNietGevuld -> WebApplicationException(message, this, Response.Status.CONFLICT)
     is SessiecacheException.OphalenBezig -> WebApplicationException(message, this, Response.Status.CONFLICT)

--- a/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/UpstreamFault.kt
+++ b/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/UpstreamFault.kt
@@ -3,6 +3,7 @@ package nl.rijksoverheid.moz.fbs.berichtenuitvraag.uitvraag
 import jakarta.ws.rs.ProcessingException
 import jakarta.ws.rs.WebApplicationException
 import jakarta.ws.rs.core.Response
+import nl.rijksoverheid.moz.fbs.berichtensessiecache.SessiecacheException
 import org.jboss.logging.Logger
 
 /**
@@ -59,3 +60,39 @@ internal fun isUpstreamStoring(e: WebApplicationException): Boolean {
 // mee zodat exception-keten-gebaseerde logging de oorzaak niet verliest.
 internal fun upstreamBadGateway(detail: String, cause: Throwable? = null): WebApplicationException =
     WebApplicationException(detail, cause, Response.Status.BAD_GATEWAY)
+
+/**
+ * Enige plek waar de gesloten [SessiecacheException]-hiërarchie naar een HTTP-status
+ * wordt vertaald. De `when` is exhaustief zónder `else`: een nieuw foutscenario in de
+ * cache-library breekt hier de build i.p.v. stil verkeerd bij de gebruiker te landen.
+ *
+ * Bewust géén 502-mapping hier: deze functie reproduceert exact de status die de
+ * facade vroeger zelf gooide. De per-consumer transportpolitiek (lees-pad → [mapUpstreamFout]
+ * dat 5xx naar 502 maakt; aanmeld-pad → status-behoudend) blijft daar belegd, zodat
+ * het externe gedrag ongewijzigd is.
+ */
+internal fun SessiecacheException.naApiFout(): WebApplicationException = when (this) {
+    is SessiecacheException.NogNietGevuld -> WebApplicationException(message, this, Response.Status.CONFLICT)
+    is SessiecacheException.OphalenBezig -> WebApplicationException(message, this, Response.Status.CONFLICT)
+    is SessiecacheException.OphalenMislukt -> WebApplicationException(message, this, Response.Status.INTERNAL_SERVER_ERROR)
+    is SessiecacheException.Onbereikbaar -> WebApplicationException(message, this, Response.Status.SERVICE_UNAVAILABLE)
+    is SessiecacheException.Onleesbaar -> WebApplicationException(message, this, Response.Status.INTERNAL_SERVER_ERROR)
+    is SessiecacheException.OngeldigeInvoer -> WebApplicationException(message, this, Response.Status.BAD_REQUEST)
+    is SessiecacheException.GeenActieveSessie -> WebApplicationException(message, this, Response.Status.NOT_FOUND)
+}
+
+/**
+ * Lees-pad-grens voor cache-facade-calls: vertaalt een [SessiecacheException] eerst
+ * exhaustief naar zijn status ([naApiFout]) en past daarna dezelfde upstream-politiek
+ * toe als op het magazijn ([mapUpstreamFout]) — een 5xx wordt 502, een 4xx (409 cache-
+ * nog-niet-gevuld) propageert ongewijzigd. Zo blijft "502 = upstream-fout" gelden voor
+ * de in-process cache zoals voorheen.
+ */
+internal inline fun <T> leesUitCache(log: Logger, context: String, block: () -> T): T =
+    mapUpstreamFout(log, context) {
+        try {
+            block()
+        } catch (e: SessiecacheException) {
+            throw e.naApiFout()
+        }
+    }

--- a/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/aanmeld/AanmeldResourceTest.kt
+++ b/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/aanmeld/AanmeldResourceTest.kt
@@ -9,7 +9,7 @@ import io.quarkus.test.junit.TestProfile
 import io.restassured.RestAssured.given
 import jakarta.inject.Inject
 import jakarta.ws.rs.WebApplicationException
-import jakarta.ws.rs.core.Response
+import nl.rijksoverheid.moz.fbs.berichtensessiecache.SessiecacheException
 import nl.rijksoverheid.moz.fbs.berichtenuitvraag.uitvraag.MockSessiecache
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -100,7 +100,7 @@ class AanmeldResourceTest {
 
     @Test
     fun `geen actieve sessie geeft 202 maar schrijft niets`() {
-        sessiecache.schrijfFouten.add(WebApplicationException("geen sessie", Response.Status.NOT_FOUND))
+        sessiecache.schrijfFouten.add(SessiecacheException.GeenActieveSessie("geen sessie"))
 
         given()
             .contentType(cloudEventsJson)
@@ -166,7 +166,7 @@ class AanmeldResourceTest {
         val berichtId = UUID.randomUUID()
 
         // Eerste levering: geen actieve sessie → 202, niets geschreven, marker vrijgegeven.
-        sessiecache.schrijfFouten.add(WebApplicationException("geen sessie", Response.Status.NOT_FOUND))
+        sessiecache.schrijfFouten.add(SessiecacheException.GeenActieveSessie("geen sessie"))
         given()
             .contentType(cloudEventsJson)
             .body(event(id = id, berichtId = berichtId))

--- a/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/aanmeld/AanmeldServiceTest.kt
+++ b/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/aanmeld/AanmeldServiceTest.kt
@@ -107,6 +107,19 @@ class AanmeldServiceTest {
     }
 
     @Test
+    fun `cache ongeldige-invoer propageert status-behoudend 400`() {
+        // Een niet-GeenActieveSessie cache-fout op het aanmeld-pad gaat status-behoudend
+        // door via naApiFout (geen 502-conversie): OngeldigeInvoer blijft 400.
+        every { sessiecache.schrijfBericht(ontvanger, any()) } throws
+            SessiecacheException.OngeldigeInvoer("bericht overschrijdt limiet")
+
+        val ex = assertThrows<WebApplicationException> { service.verwerk(event()) }
+
+        assertEquals(400, ex.response.status)
+        verify(exactly = 1) { dedup.verwijder("evt-1") }
+    }
+
+    @Test
     fun `dedup-store onbereikbaar (503) propageert zonder schrijven`() {
         every { dedup.eerstgezien("evt-1") } throws WebApplicationException("redis down", 503)
 

--- a/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/aanmeld/AanmeldServiceTest.kt
+++ b/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/aanmeld/AanmeldServiceTest.kt
@@ -7,9 +7,9 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import jakarta.ws.rs.WebApplicationException
-import jakarta.ws.rs.core.Response
 import nl.mijnoverheidzakelijk.ldv.logboekdataverwerking.LogboekContext
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.Sessiecache
+import nl.rijksoverheid.moz.fbs.berichtensessiecache.SessiecacheException
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.Bericht
 import nl.rijksoverheid.moz.fbs.common.identificatie.Identificatienummer
 import nl.rijksoverheid.moz.fbs.common.identificatie.IdentificatienummerType
@@ -84,9 +84,9 @@ class AanmeldServiceTest {
     }
 
     @Test
-    fun `geen actieve sessie (404) wordt geaccepteerd-maar-overgeslagen`() {
+    fun `geen actieve sessie wordt geaccepteerd-maar-overgeslagen`() {
         every { sessiecache.schrijfBericht(ontvanger, any()) } throws
-            WebApplicationException("geen sessie", Response.Status.NOT_FOUND)
+            SessiecacheException.GeenActieveSessie("geen sessie")
 
         // Geen exception: webhook geeft 202.
         service.verwerk(event())
@@ -96,9 +96,9 @@ class AanmeldServiceTest {
     }
 
     @Test
-    fun `cache onbereikbaar (503) propageert en rolt de marker terug`() {
+    fun `cache onbereikbaar propageert 503 en rolt de marker terug`() {
         every { sessiecache.schrijfBericht(ontvanger, any()) } throws
-            WebApplicationException("cache down", 503)
+            SessiecacheException.Onbereikbaar("cache down")
 
         val ex = assertThrows<WebApplicationException> { service.verwerk(event()) }
 

--- a/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/BerichtBeheerServiceTest.kt
+++ b/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/BerichtBeheerServiceTest.kt
@@ -10,6 +10,7 @@ import jakarta.ws.rs.NotFoundException
 import jakarta.ws.rs.WebApplicationException
 import jakarta.ws.rs.core.Response
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.Sessiecache
+import nl.rijksoverheid.moz.fbs.berichtensessiecache.SessiecacheException
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.Bericht
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.Leesstatus
 import nl.rijksoverheid.moz.fbs.berichtenuitvraag.api.model.BerichtPatch
@@ -101,7 +102,7 @@ class BerichtBeheerServiceTest {
     @Test
     fun `patch cache-faal triggert invalidate en gooit 502`() {
         every { magazijn.patchBericht(any(), any(), any()) } returns Unit
-        every { sessiecache.werkBerichtBij(ontvangerId, any(), any(), any()) } throws WebApplicationException("cache-down", 503)
+        every { sessiecache.werkBerichtBij(ontvangerId, any(), any(), any()) } throws SessiecacheException.Onbereikbaar("cache-down")
         every { sessiecache.verwijder(ontvangerId, any()) } returns Unit
 
         val ex = assertThrows(WebApplicationException::class.java) {
@@ -115,8 +116,8 @@ class BerichtBeheerServiceTest {
     @Test
     fun `patch cache-faal en invalidate-faal gooit nog steeds 502`() {
         every { magazijn.patchBericht(any(), any(), any()) } returns Unit
-        every { sessiecache.werkBerichtBij(ontvangerId, any(), any(), any()) } throws WebApplicationException("cache-down", 503)
-        every { sessiecache.verwijder(ontvangerId, any()) } throws WebApplicationException("ook-down", 503)
+        every { sessiecache.werkBerichtBij(ontvangerId, any(), any(), any()) } throws SessiecacheException.Onbereikbaar("cache-down")
+        every { sessiecache.verwijder(ontvangerId, any()) } throws SessiecacheException.Onbereikbaar("ook-down")
 
         val ex = assertThrows(WebApplicationException::class.java) {
             service.patch(ontvanger, id, magazijnId, patch)
@@ -140,16 +141,19 @@ class BerichtBeheerServiceTest {
     }
 
     @Test
-    fun `patch cache-4xx propageert onveranderd zonder compensatie`() {
+    fun `patch cache-niet-storing-fout propageert onveranderd zonder compensatie`() {
+        // Een niet-storing cache-fout (OngeldigeInvoer → 400) ná een geslaagde magazijn-
+        // write is een contract-bug, geen transport-storing: status-behoudend door, geen
+        // invalidate (de cache-write is niet doorgegaan).
         every { magazijn.patchBericht(any(), any(), any()) } returns Unit
         every { sessiecache.werkBerichtBij(ontvangerId, any(), any(), any()) } throws
-            WebApplicationException("cache-conflict", Response.Status.CONFLICT)
+            SessiecacheException.OngeldigeInvoer("cache-ongeldig")
 
         val ex = assertThrows(WebApplicationException::class.java) {
             service.patch(ontvanger, id, magazijnId, patch)
         }
 
-        assertEquals(Response.Status.CONFLICT.statusCode, ex.response.status)
+        assertEquals(Response.Status.BAD_REQUEST.statusCode, ex.response.status)
         verify(exactly = 0) { sessiecache.verwijder(ontvangerId, any()) }
     }
 
@@ -186,7 +190,7 @@ class BerichtBeheerServiceTest {
         every { sessiecache.verwijder(ontvangerId, any()) } answers {
             aanroepen++
 
-            if (aanroepen == 1) throw WebApplicationException("cache-down", 503)
+            if (aanroepen == 1) throw SessiecacheException.Onbereikbaar("cache-down")
         }
 
         val ex = assertThrows(WebApplicationException::class.java) {
@@ -198,23 +202,23 @@ class BerichtBeheerServiceTest {
     }
 
     @Test
-    fun `verwijder cache-403 propageert zonder compensatie`() {
+    fun `verwijder cache-niet-storing-fout propageert zonder compensatie`() {
         every { magazijn.verwijderBericht(any(), any()) } returns Unit
-        every { sessiecache.verwijder(ontvangerId, any()) } throws ForbiddenException("cache-weigert")
+        every { sessiecache.verwijder(ontvangerId, any()) } throws SessiecacheException.OngeldigeInvoer("cache-ongeldig")
 
-        val ex = assertThrows(ForbiddenException::class.java) {
+        val ex = assertThrows(WebApplicationException::class.java) {
             service.verwijder(ontvanger, id, magazijnId)
         }
 
-        assertEquals(Response.Status.FORBIDDEN.statusCode, ex.response.status)
-        // Eén call (de write die 403 gaf); geen tweede compensatie-call.
+        assertEquals(Response.Status.BAD_REQUEST.statusCode, ex.response.status)
+        // Eén call (de write die de niet-storing-fout gaf); geen tweede compensatie-call.
         verify(exactly = 1) { sessiecache.verwijder(ontvangerId, id) }
     }
 
     @Test
     fun `verwijder cache-faal + compensatie-faal gooit 502`() {
         every { magazijn.verwijderBericht(any(), any()) } returns Unit
-        every { sessiecache.verwijder(ontvangerId, any()) } throws WebApplicationException("cache-down", 503)
+        every { sessiecache.verwijder(ontvangerId, any()) } throws SessiecacheException.Onbereikbaar("cache-down")
 
         val ex = assertThrows(WebApplicationException::class.java) {
             service.verwijder(ontvanger, id, magazijnId)

--- a/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/BerichtenlijstServiceTest.kt
+++ b/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/BerichtenlijstServiceTest.kt
@@ -5,6 +5,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import jakarta.ws.rs.WebApplicationException
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.Sessiecache
+import nl.rijksoverheid.moz.fbs.berichtensessiecache.SessiecacheException
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.BerichtSamenvatting
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.BerichtenPagina
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.Leesstatus
@@ -117,14 +118,14 @@ class BerichtenlijstServiceTest {
     }
 
     @Test
-    fun `cache-storing wordt 502 en cache-409 propageert`() {
-        every { sessiecache.lijst(ontvanger, null, null) } throws WebApplicationException("cache weg", 503)
+    fun `cache-storing wordt 502 en cache-NogNietGevuld propageert 409`() {
+        every { sessiecache.lijst(ontvanger, null, null) } throws SessiecacheException.Onbereikbaar("cache weg")
 
         val storing = assertThrows<WebApplicationException> { service.lijst("BSN:999990019", null, null) }
 
         assertEquals(502, storing.response.status)
 
-        every { sessiecache.lijst(ontvanger, null, null) } throws WebApplicationException("nog niet opgehaald", 409)
+        every { sessiecache.lijst(ontvanger, null, null) } throws SessiecacheException.NogNietGevuld("nog niet opgehaald")
 
         val conflict = assertThrows<WebApplicationException> { service.lijst("BSN:999990019", null, null) }
 

--- a/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/DualWriteFaultTest.kt
+++ b/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/DualWriteFaultTest.kt
@@ -11,7 +11,7 @@ import io.quarkus.test.junit.QuarkusTest
 import io.quarkus.test.junit.TestProfile
 import io.restassured.RestAssured.given
 import jakarta.inject.Inject
-import jakarta.ws.rs.WebApplicationException
+import nl.rijksoverheid.moz.fbs.berichtensessiecache.SessiecacheException
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.Bericht
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -66,7 +66,7 @@ class DualWriteFaultTest {
         )
     }
 
-    private fun cacheStoring() = WebApplicationException("Cache niet bereikbaar.", 503)
+    private fun cacheStoring() = SessiecacheException.Onbereikbaar("Cache niet bereikbaar.")
 
     // ───── PATCH ─────
 
@@ -177,14 +177,14 @@ class DualWriteFaultTest {
     }
 
     @Test
-    fun `PATCH cache-4xx na magazijn-OK propageert 4xx zonder compensatie`() {
-        // 4xx = contract-bug (geen transport-storing) — moet 1-op-1 propageren
-        // i.p.v. als 502 maskeren, anders ziet ops "magazijn bijgewerkt" terwijl
-        // het probleem in de cache-implementatie zit.
+    fun `PATCH cache-niet-storing na magazijn-OK propageert status zonder compensatie`() {
+        // Een niet-storing cache-fout (OngeldigeInvoer → 400, geen transport-storing) moet
+        // 1-op-1 propageren i.p.v. als 502 maskeren, anders ziet ops "magazijn bijgewerkt"
+        // terwijl het probleem in de cache-implementatie zit.
         val id = UUID.randomUUID()
         seedBericht(id)
         stubMagazijnPatchOk(id)
-        sessiecache.werkBijFouten += WebApplicationException("cache-conflict", 409)
+        sessiecache.werkBijFouten += SessiecacheException.OngeldigeInvoer("cache-ongeldig")
 
         given()
             .header("X-Ontvanger", "BSN:999990019")
@@ -193,7 +193,7 @@ class DualWriteFaultTest {
             .`when`()
             .patch("/api/v1/berichten/$id?magazijnId=${WireMockBackendsResource.OIN_A}")
             .then()
-            .statusCode(409)
+            .statusCode(400)
 
         assertEquals(emptyList<UUID>(), sessiecache.verwijderAanroepen)
     }
@@ -315,20 +315,20 @@ class DualWriteFaultTest {
     }
 
     @Test
-    fun `DELETE cache-4xx na magazijn-OK propageert 4xx zonder compensatie`() {
+    fun `DELETE cache-niet-storing na magazijn-OK propageert status zonder compensatie`() {
         val id = UUID.randomUUID()
         seedBericht(id)
         stubMagazijnDeleteOk(id)
-        sessiecache.verwijderFouten += WebApplicationException("cache-weigert", 403)
+        sessiecache.verwijderFouten += SessiecacheException.OngeldigeInvoer("cache-ongeldig")
 
         given()
             .header("X-Ontvanger", "BSN:999990019")
             .`when`()
             .delete("/api/v1/berichten/$id?magazijnId=${WireMockBackendsResource.OIN_A}")
             .then()
-            .statusCode(403)
+            .statusCode(400)
 
-        // Eén call (de write die 403 gaf); geen tweede compensatie-call.
+        // Eén call (de write die de niet-storing-fout gaf); geen tweede compensatie-call.
         assertEquals(listOf(id), sessiecache.verwijderAanroepen)
     }
 }

--- a/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/MockSessiecache.kt
+++ b/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/MockSessiecache.kt
@@ -5,6 +5,7 @@ import io.smallrye.mutiny.Multi
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.enterprise.inject.Alternative
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.Sessiecache
+import nl.rijksoverheid.moz.fbs.berichtensessiecache.SessiecacheException
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.Bericht
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.BerichtenPagina
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.Leesstatus
@@ -30,11 +31,15 @@ class MockSessiecache : Sessiecache {
 
     val berichten = ConcurrentHashMap<UUID, Bericht>()
 
-    var lijstFout: RuntimeException? = null
-    var zoekFout: RuntimeException? = null
-    var berichtFout: RuntimeException? = null
-    val werkBijFouten = ArrayDeque<RuntimeException>()
-    val verwijderFouten = ArrayDeque<RuntimeException>()
+    // Sync-facade-foutinjectie is getypeerd op SessiecacheException: de echte facade gooit
+    // uitsluitend dat type, dus dwingt de compiler af dat tests geen onbereikbaar fout-pad
+    // (bv. een rauwe WebApplicationException/ForbiddenException) simuleren.
+    var lijstFout: SessiecacheException? = null
+    var zoekFout: SessiecacheException? = null
+    var berichtFout: SessiecacheException? = null
+    val werkBijFouten = ArrayDeque<SessiecacheException>()
+    val verwijderFouten = ArrayDeque<SessiecacheException>()
+    // ophalen() is het streaming-pad met een eigen (WAE-)foutkanaal; bewust niet vernauwd.
     var ophalenFout: RuntimeException? = null
     var ophalenEvents: Multi<MagazijnEvent> = Multi.createFrom().empty()
 
@@ -48,7 +53,7 @@ class MockSessiecache : Sessiecache {
     var werkBijAanroepen = 0
     val verwijderAanroepen = mutableListOf<UUID>()
 
-    val schrijfFouten = ArrayDeque<RuntimeException>()
+    val schrijfFouten = ArrayDeque<SessiecacheException>()
     val schrijfAanroepen = mutableListOf<Bericht>()
 
     fun reset() {

--- a/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/OpenApiContractTest.kt
+++ b/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/OpenApiContractTest.kt
@@ -217,9 +217,10 @@ class OpenApiContractTest {
     }
 
     @Test
-    fun `GET bericht by id - cache-403 levert valide Problem-403`() {
-        // De facade dwingt de ontvanger-match af; een 403 propageert status-behoudend
-        // (4xx-allowlist) en moet als gedeclareerde Problem-403 valideren tegen de spec.
+    fun `GET bericht by id - propagerende 4xx op leespad levert valide Problem-403`() {
+        // Een propagerende client-/contract-4xx op het leespad (allowlist in
+        // mapUpstreamFout) gaat status-behoudend door en moet als gedeclareerde
+        // Problem-403 valideren tegen de spec.
         val id = UUID.randomUUID()
         sessiecache.berichtFout = ForbiddenException("ontvanger-match geweigerd")
 
@@ -235,7 +236,7 @@ class OpenApiContractTest {
 
     @Test
     fun `GET berichten - cache nog niet gevuld levert valide Problem-409`() {
-        sessiecache.lijstFout = jakarta.ws.rs.WebApplicationException("Berichten zijn nog niet opgehaald.", 409)
+        sessiecache.lijstFout = nl.rijksoverheid.moz.fbs.berichtensessiecache.SessiecacheException.NogNietGevuld("Berichten zijn nog niet opgehaald.")
 
         given()
             .filter(validator)

--- a/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/OpenApiContractTest.kt
+++ b/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/OpenApiContractTest.kt
@@ -15,7 +15,6 @@ import io.quarkus.test.junit.QuarkusTest
 import io.quarkus.test.junit.TestProfile
 import io.restassured.RestAssured.given
 import jakarta.inject.Inject
-import jakarta.ws.rs.ForbiddenException
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.Bericht
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -217,12 +216,13 @@ class OpenApiContractTest {
     }
 
     @Test
-    fun `GET bericht by id - propagerende 4xx op leespad levert valide Problem-403`() {
-        // Een propagerende client-/contract-4xx op het leespad (allowlist in
-        // mapUpstreamFout) gaat status-behoudend door en moet als gedeclareerde
-        // Problem-403 valideren tegen de spec.
+    fun `GET bericht by id - cache nog niet gevuld levert valide Problem-409`() {
+        // De gereed-status-gating geldt óók op het detail-pad: NogNietGevuld propageert
+        // status-behoudend als 409 (client-aanwijzing: eerst _ophalen) en moet als
+        // gedeclareerde Problem-409 valideren tegen de spec.
         val id = UUID.randomUUID()
-        sessiecache.berichtFout = ForbiddenException("ontvanger-match geweigerd")
+        sessiecache.berichtFout =
+            nl.rijksoverheid.moz.fbs.berichtensessiecache.SessiecacheException.NogNietGevuld("Berichten zijn nog niet opgehaald.")
 
         given()
             .filter(validator)
@@ -230,7 +230,7 @@ class OpenApiContractTest {
             .`when`()
             .get("/api/v1/berichten/$id")
             .then()
-            .statusCode(403)
+            .statusCode(409)
             .contentType("application/problem+json")
     }
 

--- a/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/ServiceCoverageTest.kt
+++ b/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/ServiceCoverageTest.kt
@@ -15,7 +15,7 @@ import io.quarkus.test.junit.QuarkusTest
 import io.quarkus.test.junit.TestProfile
 import io.restassured.RestAssured.given
 import jakarta.inject.Inject
-import jakarta.ws.rs.WebApplicationException
+import nl.rijksoverheid.moz.fbs.berichtensessiecache.SessiecacheException
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.Bericht
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.BerichtenPagina
 import org.hamcrest.Matchers.containsString
@@ -343,7 +343,7 @@ class ServiceCoverageTest {
     @Test
     fun `bericht-detail bij cache-storing mapt naar 502`() {
         val id = UUID.randomUUID()
-        sessiecache.berichtFout = WebApplicationException("Cache niet bereikbaar.", 503)
+        sessiecache.berichtFout = SessiecacheException.Onbereikbaar("Cache niet bereikbaar.")
 
         given()
             .header("X-Ontvanger", "BSN:999990019")
@@ -366,7 +366,7 @@ class ServiceCoverageTest {
 
     @Test
     fun `lijst bij cache-storing mapt naar 502`() {
-        sessiecache.lijstFout = WebApplicationException("Cache niet bereikbaar.", 503)
+        sessiecache.lijstFout = SessiecacheException.Onbereikbaar("Cache niet bereikbaar.")
 
         given()
             .header("X-Ontvanger", "BSN:999990019")
@@ -380,7 +380,7 @@ class ServiceCoverageTest {
     fun `lijst bij cache-nog-niet-gevuld propageert 409`() {
         // De gereed-status-gating van de facade (409) is een client-aanwijzing
         // (eerst _ophalen), geen upstream-storing — propageert dus 1-op-1.
-        sessiecache.lijstFout = WebApplicationException("Berichten zijn nog niet opgehaald.", 409)
+        sessiecache.lijstFout = SessiecacheException.NogNietGevuld("Berichten zijn nog niet opgehaald.")
 
         given()
             .header("X-Ontvanger", "BSN:999990019")
@@ -392,7 +392,7 @@ class ServiceCoverageTest {
 
     @Test
     fun `zoek bij cache-storing mapt naar 502`() {
-        sessiecache.zoekFout = WebApplicationException("Cache niet bereikbaar.", 503)
+        sessiecache.zoekFout = SessiecacheException.Onbereikbaar("Cache niet bereikbaar.")
 
         given()
             .header("X-Ontvanger", "BSN:999990019")

--- a/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/SessiecacheFoutMappingTest.kt
+++ b/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/SessiecacheFoutMappingTest.kt
@@ -4,6 +4,8 @@ import jakarta.ws.rs.WebApplicationException
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.SessiecacheException
 import org.jboss.logging.Logger
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -30,6 +32,18 @@ class SessiecacheFoutMappingTest {
         assertEquals(500, SessiecacheException.Onleesbaar("x").naApiFout().response.status)
         assertEquals(400, SessiecacheException.OngeldigeInvoer("x").naApiFout().response.status)
         assertEquals(404, SessiecacheException.GeenActieveSessie("x").naApiFout().response.status)
+    }
+
+    @Test
+    fun `isStoring classificeert storing- versus client-fouten`() {
+        assertTrue(SessiecacheException.OphalenMislukt("x").isStoring())
+        assertTrue(SessiecacheException.Onbereikbaar("x").isStoring())
+        assertTrue(SessiecacheException.Onleesbaar("x").isStoring())
+
+        assertFalse(SessiecacheException.NogNietGevuld("x").isStoring())
+        assertFalse(SessiecacheException.OphalenBezig("x").isStoring())
+        assertFalse(SessiecacheException.OngeldigeInvoer("x").isStoring())
+        assertFalse(SessiecacheException.GeenActieveSessie("x").isStoring())
     }
 
     @Test

--- a/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/SessiecacheFoutMappingTest.kt
+++ b/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/SessiecacheFoutMappingTest.kt
@@ -65,6 +65,15 @@ class SessiecacheFoutMappingTest {
     }
 
     @Test
+    fun `leesUitCache maakt Onleesbaar 502`() {
+        val ex = assertThrows<WebApplicationException> {
+            leesUitCache<Unit>(log, "test") { throw SessiecacheException.Onleesbaar("cache-data niet leesbaar") }
+        }
+
+        assertEquals(502, ex.response.status)
+    }
+
+    @Test
     fun `leesUitCache laat een client-aanwijzing (409) ongewijzigd door`() {
         val ex = assertThrows<WebApplicationException> {
             leesUitCache<Unit>(log, "test") { throw SessiecacheException.NogNietGevuld("nog niet opgehaald") }

--- a/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/SessiecacheFoutMappingTest.kt
+++ b/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/SessiecacheFoutMappingTest.kt
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.assertThrows
  * Pint dat [naApiFout] exact de status reproduceert die de facade vroeger zelf gooide
  * (gedragspariteit), en dat het lees-pad daar bovenop dezelfde upstream-politiek
  * toepast als op het magazijn: storing → 502, client-aanwijzing (409) propageert.
- * De `when` in [naApiFout] is exhaustief zonder `else`, dus een nieuw foutscenario in
+ * De `when` in [naApiFout] dekt alle gevallen zonder `else`, dus een nieuw foutscenario in
  * de cache-library breekt hier de build i.p.v. stil verkeerd bij de gebruiker te landen.
  */
 class SessiecacheFoutMappingTest {

--- a/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/SessiecacheFoutMappingTest.kt
+++ b/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/SessiecacheFoutMappingTest.kt
@@ -1,0 +1,66 @@
+package nl.rijksoverheid.moz.fbs.berichtenuitvraag.uitvraag
+
+import jakarta.ws.rs.WebApplicationException
+import nl.rijksoverheid.moz.fbs.berichtensessiecache.SessiecacheException
+import org.jboss.logging.Logger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * De enige plek waar de gesloten [SessiecacheException]-hiërarchie naar een API-status
+ * wordt vertaald ([naApiFout]) en het lees-pad-gedrag erbovenop ([leesUitCache]).
+ *
+ * Pint dat [naApiFout] exact de status reproduceert die de facade vroeger zelf gooide
+ * (gedragspariteit), en dat het lees-pad daar bovenop dezelfde upstream-politiek
+ * toepast als op het magazijn: storing → 502, client-aanwijzing (409) propageert.
+ * De `when` in [naApiFout] is exhaustief zonder `else`, dus een nieuw foutscenario in
+ * de cache-library breekt hier de build i.p.v. stil verkeerd bij de gebruiker te landen.
+ */
+class SessiecacheFoutMappingTest {
+
+    private val log: Logger = Logger.getLogger(SessiecacheFoutMappingTest::class.java)
+
+    @Test
+    fun `naApiFout reproduceert de facade-statuscodes per foutscenario`() {
+        assertEquals(409, SessiecacheException.NogNietGevuld("x").naApiFout().response.status)
+        assertEquals(409, SessiecacheException.OphalenBezig("x").naApiFout().response.status)
+        assertEquals(500, SessiecacheException.OphalenMislukt("x").naApiFout().response.status)
+        assertEquals(503, SessiecacheException.Onbereikbaar("x").naApiFout().response.status)
+        assertEquals(500, SessiecacheException.Onleesbaar("x").naApiFout().response.status)
+        assertEquals(400, SessiecacheException.OngeldigeInvoer("x").naApiFout().response.status)
+        assertEquals(404, SessiecacheException.GeenActieveSessie("x").naApiFout().response.status)
+    }
+
+    @Test
+    fun `leesUitCache maakt een cache-storing 502`() {
+        val ex = assertThrows<WebApplicationException> {
+            leesUitCache<Unit>(log, "test") { throw SessiecacheException.Onbereikbaar("cache weg") }
+        }
+
+        assertEquals(502, ex.response.status)
+    }
+
+    @Test
+    fun `leesUitCache maakt OphalenMislukt 502`() {
+        val ex = assertThrows<WebApplicationException> {
+            leesUitCache<Unit>(log, "test") { throw SessiecacheException.OphalenMislukt("ophaling mislukt") }
+        }
+
+        assertEquals(502, ex.response.status)
+    }
+
+    @Test
+    fun `leesUitCache laat een client-aanwijzing (409) ongewijzigd door`() {
+        val ex = assertThrows<WebApplicationException> {
+            leesUitCache<Unit>(log, "test") { throw SessiecacheException.NogNietGevuld("nog niet opgehaald") }
+        }
+
+        assertEquals(409, ex.response.status)
+    }
+
+    @Test
+    fun `leesUitCache geeft een succesvol resultaat ongewijzigd terug`() {
+        assertEquals(42, leesUitCache(log, "test") { 42 })
+    }
+}


### PR DESCRIPTION
## Aanleiding

Sinds de berichtensessiecache als interne library in de berichten-uitvraag draait, droeg de `Sessiecache`-facade zijn foutsemantiek via `jakarta.ws.rs.WebApplicationException` + statuscode — een HTTP-transport-type in een library zonder HTTP-laag. Consumers moesten status-ranges reverse-engineeren (`mapUpstreamFout`, en een losse `status == 404`-check in de aanmeld-verwerking). Niets dwong af dat elk foutscenario bewust werd afgehandeld; een nieuw of gewijzigd foutgeval kon onopgemerkt verkeerd bij de gebruiker terechtkomen.

## Wat verandert

De synchrone facade gooit nu een gesloten `SessiecacheException`-hiërarchie i.p.v. HTTP-types:

`NogNietGevuld` · `OphalenBezig` · `OphalenMislukt` · `Onbereikbaar` · `Onleesbaar` · `OngeldigeInvoer` · `GeenActieveSessie`

De consument vertaalt elk geval **exhaustief op één plek** (`naApiFout` in `UpstreamFault.kt`, plus `isStoring` voor de write-pad-compensatiebeslissing). Beide `when`-statements zijn `sealed` zonder `else`, dus een nieuw foutscenario breekt de build bij de consument i.p.v. stil verkeerd te landen.

De per-consumer transportpolitiek blijft ongewijzigd, zodat het **externe gedrag identiek** is:
- **lees-pad** (`leesUitCache` → `mapUpstreamFout`): storing → 502, `NogNietGevuld`/`OphalenBezig` (409) propageren;
- **schrijf-pad** (`BerichtBeheerService`): storing → invalidate + 502, niet-storing → status-behoudend zonder compensatie;
- **aanmeld-pad**: `GeenActieveSessie` → geaccepteerd-maar-overgeslagen (202), overige status-behoudend (400/500/503).

Het streaming-ophaalpad (`Sessiecache.ophalen`) houdt zijn eigen asynchrone `Multi`-foutkanaal en valt bewust buiten scope (het is geen onderdeel van de `mapUpstreamFout`-reverse-engineering die het issue benoemt).

## Acceptatiecriteria

- ✅ **Nieuw foutscenario → bouwfout bij de consument** (sealed hiërarchie + exhaustieve `when` zonder `else` op twee assen: transport-mapping én storing-classificatie).
- ✅ **Bestaand foutgedrag ongewijzigd** (statuscodes, retriable-semantiek, meldteksten) — `naApiFout` reproduceert exact de statussen die de facade voorheen zelf gooide; bestaande facade-, endpoint- en dual-write-tests borgen de pariteit. Het `FBS_ALERT[cache_desync_no_selfheal]`-alert-anker is ongewijzigd.
- ✅ **Cache→API-vertaling op één plek getest** (`SessiecacheFoutMappingTest`).

## Reviewrondes

Drie review+fix-rondes met overheids- en kwaliteits-skills:
1. **digital-waste-spotter** — wegwerp-`WebApplicationException` op het write-pad geëlimineerd via een type-gebaseerde `isStoring()` (geen statuscode-range-reverse-engineering meer).
2. **NeRDS-veiligheid/-privacy, ADR/problem+json, testkwaliteit, comment-accuraatheid** — KDoc-correcties, consistente terminologie, fictief 403-testpad vervangen door een bereikbaar 409, `MockSessiecache`-foutvelden getypeerd op `SessiecacheException` als guardrail.
3. **completeness-critic + ADR** — bevestigd dat alle drie de acceptatiecriteria aantoonbaar voldaan zijn; extra aanmeld-pad-testdekking toegevoegd.

## Verificatie

`./mvnw clean verify -pl libraries/fbs-berichtensessiecache,services/berichtenuitvraag -am` — groen: tests, detekt (0 smells), JaCoCo 90%-gate.

Lost op: MinBZK/MijnOverheidZakelijk#623

🤖 Generated with [Claude Code](https://claude.com/claude-code)