### PR TITLE
CI-guard: redis-stack-server-pin uniform houden (drift-bescherming)

### DIFF
--- a/.github/workflows/pin-consistency.yml
+++ b/.github/workflows/pin-consistency.yml
@@ -1,0 +1,32 @@
+# Houdt de redis-stack-server-image-pin uniform over alle locaties.
+#
+# De pin staat (bewust expliciet, conform Scorecard Pinned-Dependencies) op meerdere
+# plekken: compose.yaml, .github/workflows/deploy.yml (REDIS_IMAGE) en de test-
+# devservices-image-names. Dependabot's docker-compose-ecosystem ziet alléén
+# compose.yaml; de workflow-env en de Kotlin-test-strings niet. Een Dependabot-bump
+# zou dus drift veroorzaken. Deze guard maakt zo'n gedeeltelijke bump een harde fout,
+# zodat alle pins samen bewegen (de pins zelf blijven expliciet).
+
+name: Pin consistency
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  redis-stack-pin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - name: redis-stack-server-pin moet overal identiek zijn
+        run: |
+          mapfile -t pins < <(git ls-files | xargs grep -hoE 'redis/redis-stack-server:[A-Za-z0-9._-]+' 2>/dev/null | sort -u)
+          printf 'gevonden pin(s): %s\n' "${pins[*]:-<geen>}"
+          if [ "${#pins[@]}" -gt 1 ]; then
+            echo "::error::redis-stack-server-pin niet uniform (${pins[*]}). Sync compose.yaml, .github/workflows/deploy.yml en de test-image-names; Dependabot bumpt alleen compose.yaml."
+            exit 1
+          fi


### PR DESCRIPTION
## Aanleiding

De `redis/redis-stack-server`-versie staat op meerdere plekken gepind (bewust expliciet, conform de Scorecard Pinned-Dependencies-conventie): `compose.yaml`, straks `.github/workflows/deploy.yml` (`REDIS_IMAGE`), en de test-devservices-image-names. Dependabot's `docker-compose`-ecosystem ziet **alleen** `compose.yaml` — niet de workflow-env, niet de Kotlin-test-strings. Een Dependabot-bump zou de versies dus stil uiteen laten lopen.

## Wat dit doet

Een kleine CI-guard die faalt zodra de `redis-stack-server`-pin niet overal identiek is. Daardoor wordt een gedeeltelijke bump (alleen compose) een harde fout, en bewegen alle pins samen. De pins zelf blijven expliciet — Scorecard blijft tevreden.

## Waarom deze aanpak

We kunnen Dependabot **niet** op de workflow-env of Kotlin-strings richten (geen manifest-formaat). De pin weghalen/afleiden zou de expliciete pin opheffen (Scorecard-regressie). Een consistentie-guard houdt de pins én vangt drift.

## Verificatie

Lokaal getest: bij 1 uniforme pin → PASS; bij divergentie → exit 1 met een melding welke locaties te synchen. Geen untrusted input in de `run:` (alleen `git ls-files` + grep). `actions/checkout` SHA-gepind conform de repo-conventie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)