### PR TITLE
docs: aanpak-en-keuzes-document + C4-model in-process CDI

### DIFF
--- a/docs/aanpak-en-keuzes.md
+++ b/docs/aanpak-en-keuzes.md
@@ -9,7 +9,7 @@ aanpassingen om verschillende situaties te doorlopen, al dan niet naast elkaar.
 
 Dit document beschrijft **hoe** we deze Proof of Concept (PoC) aanvliegen en
 **welke keuzes** we aan het begin hebben gemaakt — de context die het C4-model
-(zie [`docs/architecture/`](architecture/)) zelf niet geeft. Het C4-model toont
+(zie [`architecture/`](architecture/)) zelf niet geeft. Het C4-model toont
 *wat* er is; deze pagina geeft het *waarom* en de herkomst van de keuzes.
 
 ## 1. Hoe we dit project aanvliegen
@@ -64,7 +64,7 @@ een bronlink.
 | [OIN-Stelsel](https://www.logius.nl/diensten/oin) | Deelnemende organisaties worden geïdentificeerd via hun OIN; het `magazijnId` dat door het systeem stroomt *is* de afzender-OIN (publiek, geen PII) | Landelijke identificatie van overheidsorganisaties; basis voor het FSC PeerID |
 | [Digikoppeling](https://www.logius.nl/diensten/digikoppeling) (REST-API, Identificatie & Authenticatie) | Magazijn-koppelvlakken als Digikoppeling REST-API; OIN uit het `subject.serialNumber` van het PKIoverheid-certificaat | Verplichte koppelvlakstandaard voor gegevensuitwisseling tussen overheden |
 | [FSC (Federated Service Connectivity)](https://fsc-standaard.nl/) | mTLS-transportlaag met ondertekende contracten als doel-architectuur; in de PoC nog plain HTTP (zie PoC-afwijkingen) | Opvolger van NLX; verplicht transport bij Digikoppeling REST-API |
-| OAuth 2.0 / OpenID Connect — NL GOV-profiel | Token-uitgifte door de Interactielaag en JWT-bearer-tokenvalidatie in de Berichten Uitvraag Service (doel-architectuur) | Standaard voor authenticatie/autorisatie bij de overheid |
+| [OAuth 2.0 / OpenID Connect — NL GOV-profiel](https://publicatie.centrumvoorstandaarden.nl/api/oauth/) | Token-uitgifte door de Interactielaag en JWT-bearer-tokenvalidatie in de Berichten Uitvraag Service (doel-architectuur) | Standaard voor authenticatie/autorisatie bij de overheid |
 | [NL GOV CloudEvents-profiel](https://vng-realisatie.github.io/NL-GOV-profile-for-CloudEvents/) | Notificatie-forwarding via CloudEvents (structured mode, `source` als OIN-URN) | Standaardprofiel voor notificaties tussen overheidsorganisaties |
 | [Logboek Dataverwerkingen (LDV)](https://logius-standaarden.github.io/logboek-dataverwerkingen/) (NEN 7513) | Verwerkingenlogging via OpenTelemetry/OTLP voor elk component dat persoonsgegevens verwerkt | AVG/GDPR-transparantie; vastgelegd in de LDV-standaard |
 | [NeRDS](https://github.com/MinBZK/nerds) / [BIO](https://www.digitaleoverheid.nl/overzicht-van-alle-onderwerpen/cybersecurity/kaders-voor-cybersecurity/baseline-informatiebeveiliging-overheid/) / AVG | Functionele package-structuur, security-headers en -scans, geen persoonsgegevens in de PoC | Richtlijnen voor verantwoorde overheidssoftware |

--- a/docs/aanpak-en-keuzes.md
+++ b/docs/aanpak-en-keuzes.md
@@ -1,0 +1,128 @@
+# Aanpak en keuzes van de PoC
+
+Een Federatief Berichtenstelsel werkt anders dan een centraal beheerde
+berichtenbox. Het doel van de PoC is om een omgeving op te zetten waarmee we
+verschillende experimenten kunnen uitvoeren. Die zetten we enerzijds vanuit
+gebruikersperspectief op, en anderzijds vanuit de techniek. We beginnen met een
+eerste versie die fungeert als interactieve praatplaat. Daarna maken we
+aanpassingen om verschillende situaties te doorlopen, al dan niet naast elkaar.
+
+Dit document beschrijft **hoe** we deze Proof of Concept (PoC) aanvliegen en
+**welke keuzes** we aan het begin hebben gemaakt — de context die het C4-model
+(zie [`docs/architecture/`](architecture/)) zelf niet geeft. Het C4-model toont
+*wat* er is; deze pagina geeft het *waarom* en de herkomst van de keuzes.
+
+## 1. Hoe we dit project aanvliegen
+
+- **Vertrekpunt: inventarisatie van de BBO.** We zijn begonnen met een
+  inventarisatie van hoe de Berichtenbox voor Burgers en Ondernemers (BBO) wordt ontwikkeld,
+  met de vraag hoe we die *federatief* en *geschikt voor ondernemers* kunnen
+  maken. Die blik — een federatief stelsel waarin ook zakelijke ontvangers passen
+  — bepaalt de richting van de doel-architectuur en daarmee de keuzes hieronder.
+  Daarnaast hebben we met architecten van Logius afgestemd of de plannen stroken
+  met de visie van het Federatief Berichtenstelsel (FBS).
+
+- **PoC binnen MOZa, met de doel-architectuur als kompas.** Het C4-model
+  beschrijft de doel-architectuur van het FBS. De PoC werkt toe naar dat
+  **volledige** doel — het is geen bewust afgebakende deelverzameling. Wat nu nog
+  niet gerealiseerd is, houden we expliciet bij in
+  [PoC-afwijkingen](architecture/workspace-docs/03-poc-afwijkingen.md).
+
+- **Aansluitvoorwaarden van Logius als uitgangspunt.** We volgen de
+  aansluitvoorwaarden van Logius rondom beheer en de relevante Logius-stelsels en -standaarden als
+  randvoorwaarde voor de architectuur. De aansluitvoorwaarden voor beheer moeten nog **centraal in
+  de MOZa-documentatie** worden belegd.
+
+- **Spec-driven / OpenAPI-first.** De OpenAPI-spec per service is de bron van
+  waarheid. Server-interfaces worden uit de spec gegenereerd (`jaxrs-spec`,
+  `interfaceOnly=true`); de implementatie kan niet ongemerkt van het contract
+  afwijken, want compilatie faalt dan. Uitgaande clients en foutresponses worden
+  tegen dezelfde spec gevalideerd.
+
+- **AI onder menselijke regie, naleving van standaarden geborgd met overheidsskills.**
+  De code is grotendeels gegenereerd met een AI-assistant onder menselijke
+  eindverantwoordelijkheid; de
+  [overheidsskills](https://github.com/developer-overheid-nl/skills-marketplace)
+  helpen het resultaat aantoonbaar in lijn te brengen met de Nederlandse
+  overheidsstandaarden. De volledige verantwoording staat in
+  [`ai-verantwoording.md`](ai-verantwoording.md).
+
+- **C4 als levend doelmodel.** De architectuur is vastgelegd in een C4-model met
+  Structurizr ([`docs/architecture/workspace.dsl`](architecture/workspace.dsl)) en
+  groeit mee met de inzichten uit de PoC.
+
+## 2. Standaarden die de keuzes sturen
+
+Een groot deel van de architectuur volgt rechtstreeks uit door Logius beheerde en
+door het Forum Standaardisatie aanbevolen standaarden. Hieronder kort: per
+standaard *welke keuze die stuurde* en *waarom die hier van toepassing is*, met
+een bronlink.
+
+| Standaard | Keuze die eruit volgt | Waarom van toepassing |
+|---|---|---|
+| [API Design Rules (ADR)](https://publicatie.centrumvoorstandaarden.nl/api/adr/) | OpenAPI-first, `/api/v1`-prefix, camelCase JSON, `application/problem+json` ([RFC 9457](https://www.rfc-editor.org/rfc/rfc9457)), HAL `_links`, `API-Version`-header; gevalideerd met de Spectral-linter | Verplichte standaard voor REST-API's bij de Nederlandse overheid |
+| [OIN-Stelsel](https://www.logius.nl/diensten/oin) | Deelnemende organisaties worden geïdentificeerd via hun OIN; het `magazijnId` dat door het systeem stroomt *is* de afzender-OIN (publiek, geen PII) | Landelijke identificatie van overheidsorganisaties; basis voor het FSC PeerID |
+| [Digikoppeling](https://www.logius.nl/diensten/digikoppeling) (REST-API, Identificatie & Authenticatie) | Magazijn-koppelvlakken als Digikoppeling REST-API; OIN uit het `subject.serialNumber` van het PKIoverheid-certificaat | Verplichte koppelvlakstandaard voor gegevensuitwisseling tussen overheden |
+| [FSC (Federated Service Connectivity)](https://fsc-standaard.nl/) | mTLS-transportlaag met ondertekende contracten als doel-architectuur; in de PoC nog plain HTTP (zie PoC-afwijkingen) | Opvolger van NLX; verplicht transport bij Digikoppeling REST-API |
+| OAuth 2.0 / OpenID Connect — NL GOV-profiel | Token-uitgifte door de Interactielaag en JWT-bearer-tokenvalidatie in de Berichten Uitvraag Service (doel-architectuur) | Standaard voor authenticatie/autorisatie bij de overheid |
+| [NL GOV CloudEvents-profiel](https://vng-realisatie.github.io/NL-GOV-profile-for-CloudEvents/) | Notificatie-forwarding via CloudEvents (structured mode, `source` als OIN-URN) | Standaardprofiel voor notificaties tussen overheidsorganisaties |
+| [Logboek Dataverwerkingen (LDV)](https://logius-standaarden.github.io/logboek-dataverwerkingen/) (NEN 7513) | Verwerkingenlogging via OpenTelemetry/OTLP voor elk component dat persoonsgegevens verwerkt | AVG/GDPR-transparantie; vastgelegd in de LDV-standaard |
+| [NeRDS](https://github.com/MinBZK/nerds) / [BIO](https://www.digitaleoverheid.nl/overzicht-van-alle-onderwerpen/cybersecurity/kaders-voor-cybersecurity/baseline-informatiebeveiliging-overheid/) / AVG | Functionele package-structuur, security-headers en -scans, geen persoonsgegevens in de PoC | Richtlijnen voor verantwoorde overheidssoftware |
+
+> De canonieke bronnen en versies horen — net als de aansluitvoorwaarden —
+> centraal in de MOZa-documentatie te worden vastgelegd. De links hierboven zijn
+> de ingang; de exacte profielversies staan als `properties` in
+> [`workspace.dsl`](architecture/workspace.dsl).
+
+## 3. Startkeuzes (techniek)
+
+- **Quarkus 3 op Java 21.** Lichtgewicht, cloud-native JVM-framework met sterke
+  OpenAPI- en testondersteuning. Dit is de standaard voor Logius.
+
+- **Kotlin — achteraf niet de juiste keuze.** We zijn met Kotlin begonnen, omdat
+  dit een evolutie is van Java, en verder op de JVM draait en compleet compatible
+  is met Java. Echter is Kotlin nu niet opgenomen in de aansluitvoorwaarden van
+  Logius. Mocht (een deel) van deze PoC overgenomen worden door Logius zal hier nog
+  een vertaalslag gedaan moeten worden. We verwachten dat dit vrij eenvoudig te doen
+  is, omdat Java en Kotlin tegelijk gebruikt kunnen worden, en een vertaling onder
+  de huidige Kotlin-tests gedaan kan worden. Gezien de PoC-status staat beheer nog
+  niet op de roadmap, dus we hebben deze migratie niet ingepland.
+
+- **Maven-monorepo.** Parent-POM met modules voor de services en gedeelde
+  libraries; één build, gedeelde conventies.
+
+- **Logisch ≠ fysiek.** De C4-containers zijn een *logische* decompositie van
+  verantwoordelijkheden, niet de fysieke deploybare eenheden. In de PoC draaien
+  meerdere logische containers in één Quarkus-proces. Zie
+  [Deployment-units](architecture/workspace-docs/02-deployment-units.md).
+
+- **PostgreSQL en Redis.** De doel-architectuur liet de opslagtechniek vrij; de
+  PoC kiest PostgreSQL (berichtenmagazijn, met een database-outbox voor publicatie)
+  en Redis (sessiecache). Onderbouwing per onderdeel staat in de
+  [plannen](plans/).
+
+## 4. Eén openstaande uitdaging: authenticatie & autorisatie over de keten
+
+De PoC wil de volledige doel-architectuur realiseren — niet slechts een
+deelverzameling. Eén samenhangend deel stellen we voorlopig uit: **authenticatie
+en autorisatie over de hele MOZa-keten**. Daarvoor is nog geen oplossingsrichting;
+zolang die er niet is, parkeren we dat deel en werken we door aan de onderdelen en
+onderzoeksvragen waar we wél controle over hebben.
+
+De nog-niet-gerealiseerde onderdelen hangen alle aan dit ene vraagstuk:
+organisatievertrouwen en -transport via FSC (mTLS, ondertekende contracten),
+token-uitgifte en -validatie (OIDC NL GOV), pseudonimisering (BSNk) en
+keten-autorisatie (AuthZEN PEP/PDP). De actuele stand staat in
+[PoC-afwijkingen](architecture/workspace-docs/03-poc-afwijkingen.md).
+
+Gebruik in pilot of productie vereist daarnaast aanvullende toetsing (o.a. BIO en
+DPIA); zie de [AI-verantwoording](ai-verantwoording.md).
+
+## Verwijzingen
+
+- [C4-model (Structurizr)](architecture/workspace.dsl) — doel-architectuur
+- [Deployment-units: logisch vs. fysiek](architecture/workspace-docs/02-deployment-units.md)
+- [PoC-afwijkingen t.o.v. de doel-architectuur](architecture/workspace-docs/03-poc-afwijkingen.md)
+- [Verantwoording inzet van generatieve AI](ai-verantwoording.md)
+- [Projectoverzicht (README)](../README.md)
+- [Issue #717 — Architectuurkeuzes vastleggen](https://github.com/MinBZK/MijnOverheidZakelijk/issues/717)

--- a/docs/architecture/workspace-docs/02-deployment-units.md
+++ b/docs/architecture/workspace-docs/02-deployment-units.md
@@ -25,9 +25,10 @@ gedeelde libraries die binnen die services meedraaien (geen eigen proces, geen n
   berichtenuitvraag draait. De facade is het enige publieke koppelvlak; de interne werking
   (Redis-cache, magazijn-aggregatie) is compile-afgedwongen onzichtbaar. Relaties die in het
   model als CDI lopen (`CDI (in-process facade)`) zijn dus in-process method-calls, geen REST.
-- **Bericht Validatie Service** en **Autorisatie Service** zijn logisch losse containers met een
-  intern REST-koppelvlak (`REST API (intern, mTLS)`), maar in de PoC zijn het in-process
-  CDI-beans binnen berichtenmagazijn. Zie [PoC-afwijkingen](03-poc-afwijkingen.md).
+- **Bericht Validatie Service** en **Autorisatie Service** zijn logisch losse containers, maar
+  draaien in-process als CDI-beans binnen berichtenmagazijn — geen losse REST-services. De
+  relaties ernaartoe lopen in het model dan ook als `CDI` (in-process method-calls), niet via
+  een intern REST-koppelvlak.
 
 De logische container-grenzen blijven in het model staan omdat ze de **doel**-decompositie
 beschrijven (en de koppelvlakken waarlangs later opgesplitst kan worden). De fysieke

--- a/docs/architecture/workspace-docs/03-poc-afwijkingen.md
+++ b/docs/architecture/workspace-docs/03-poc-afwijkingen.md
@@ -1,14 +1,20 @@
 # PoC-afwijkingen t.o.v. de doel-architectuur
 
 Het model beschrijft de doel-architectuur van het Federatief Berichtenstelsel. De
-huidige Proof of Concept implementeert daarvan een deel; sommige containers en relaties
-zijn nog niet (of anders) gerealiseerd. Deze pagina houdt die afwijkingen bij zodat het
-model leesbaar blijft als doelbeeld zonder te suggereren dat alles al gebouwd is.
+Proof of Concept werkt toe naar dat **volledige** doel — geen bewust afgebakende
+deelverzameling. Eén samenhangend deel is nog niet gerealiseerd: authenticatie en
+autorisatie over de hele keten. Daarvoor is nog geen oplossingsrichting, dus dat
+stellen we uit en werken we door aan wat we wél in de hand hebben. Deze pagina houdt
+bij wat daardoor nu nog niet gebouwd is, zodat het model leesbaar blijft als doelbeeld
+zonder te suggereren dat alles al gebouwd is.
 
-## Niet geïmplementeerd in de PoC
+## Nog niet gerealiseerd: authenticatie, autorisatie en vertrouwen over de keten
+
+Deze onderdelen zijn gemodelleerd als doelbeeld, maar wachten op een
+oplossingsrichting voor keten-brede authenticatie en autorisatie binnen MOZa.
 
 - **Interactielaag, DigiD, eHerkenning** — authenticatie en token-uitgifte (OIDC NL GOV)
-  zijn gemodelleerd maar buiten PoC-scope. Er is geen browser-/portaal-laag.
+  zijn gemodelleerd maar nog niet gerealiseerd. Er is geen browser-/portaal-laag.
 - **Token Validatie** (JWT bearer) in de Berichten Uitvraag Service is nog niet gerealiseerd.
   De ontvanger wordt in de PoC meegegeven via de `X-Ontvanger`-header (`BSN:<waarde>` /
   `RSIN:<waarde>` / OIN), niet via een gevalideerd JWT.
@@ -20,28 +26,3 @@ model leesbaar blijft als doelbeeld zonder te suggereren dat alles al gebouwd is
 - **AuthZEN PEP/PDP** — de Autorisatie Service is in het model een PEP/PDP-container; de PoC
   doet ontvanger-autorisatie centraal in-process via `opslag/BerichtAutorisatie` in
   berichtenmagazijn (één `vereisOntvanger`-check, geen externe PDP).
-
-## Anders gerealiseerd dan gemodelleerd
-
-- **Bericht Validatie & Autorisatie als in-process CDI, niet als losse REST-services.** Het
-  model toont losse containers met `REST API (intern, mTLS)`. In de PoC zijn dit CDI-beans
-  binnen berichtenmagazijn; de relaties zijn in-process method-calls. Zie
-  [Deployment-units](02-deployment-units.md). Toestemmingscontrole via de Profiel Service
-  (`fbs-common/profiel/ProfielServiceClient`) is wél geïmplementeerd.
-- **Magazijn-routering via Magazijnregister + MagazijnRouter.** In de Berichten Uitvraag
-  Service routeert een `MagazijnRouter` ophaal-/beheer-calls (bijlage-download, status-write)
-  naar het juiste magazijn-endpoint. Het `magazijnId` dat door de sessiecache stroomt ís de
-  afzender-OIN; `MagazijnRouter` zoekt de bijbehorende inschrijving op in het Magazijnregister
-  (1:1 OIN↔magazijn) en bouwt per magazijn een REST-client. Het register is config-backed
-  (`magazijnen."<OIN>".{url,naam}`); database-opslag + beheer-interface volgen later.
-- **Aanmeld-deduplicatie.** De Aanmeld Service ontdubbelt inkomende aanmeldingen idempotent
-  (`RedisAanmeldDeduplicatie`) zodat herhaalde levering van hetzelfde gepubliceerde bericht
-  de cache niet dubbel bijwerkt — een implementatiedetail dat het model bewust niet toont.
-- **Veerkracht rond magazijn-aggregatie.** De Berichtensessiecache schermt de aggregatie af
-  met een semafoor-bulkhead (`MagazijnAggregatieBulkhead`) en een per-magazijn circuit breaker
-  (`MagazijnCircuitBreaker`), zodat één traag/onbereikbaar magazijn de overige verzoeken niet
-  blokkeert. Deze componenten staan inmiddels in het model.
-- **Dataopslag = PostgreSQL.** De doel-architectuur liet de opslagtechniek vrij ("naar keuze");
-  de PoC gebruikt PostgreSQL 18 met Hibernate ORM Panache en Flyway-migraties (geen H2). De
-  Publicatie Stream is een database-outbox (`SELECT ... FOR UPDATE SKIP LOCKED`); de Retentie
-  Service ruimt soft-deleted berichten op via dezelfde lock-strategie.

--- a/docs/architecture/workspace.dsl
+++ b/docs/architecture/workspace.dsl
@@ -140,7 +140,7 @@ workspace "MOZa PoC Federatief Berichtenstelsel" "Doel-architectuur van het Fede
 
                     aanmeldService = container "Aanmeld Service" "Werkt de cache bij voor nieuwe berichten verzonden tijdens de sessie van de ontvanger" "Quarkus / Kotlin" "Service" {
                         aanmeldVerwerker = component "Aanmeld Verwerking" "Verwerkt inkomende aanmeldingen en werkt de sessiecache bij (aanmeld-write, in-sessie)" "CDI Bean"
-                        aanmeldDeduplicatie = component "Aanmeld Deduplicatie" "Ontdubbelt inkomende aanmeldingen idempotent (Redis SETNX), zodat herhaalde levering van hetzelfde gepubliceerde bericht de cache niet dubbel bijwerkt" "CDI Bean / Redis"
+                        aanmeldDeduplicatie = component "Aanmeld Deduplicatie" "Ontdubbelt inkomende aanmeldingen idempotent (Redis SET NX EX, atomaire write met TTL), zodat herhaalde levering van hetzelfde gepubliceerde bericht de cache niet dubbel bijwerkt" "CDI Bean / Redis"
 
                         aanmeldVerwerker -> aanmeldDeduplicatie "Controleert op duplicaat vóór cache-update" "CDI"
                     }

--- a/docs/architecture/workspace.dsl
+++ b/docs/architecture/workspace.dsl
@@ -61,8 +61,8 @@ workspace "MOZa PoC Federatief Berichtenstelsel" "Doel-architectuur van het Fede
                 }
                 magazijnDatastore = container "Dataopslag" "Berichtstatus, inhoud en bijlagen (0 berichtverlies)" "PostgreSQL 18 + Hibernate ORM Panache (Flyway-migraties)" "Magazijn Database"
 
-                berichtValidatie = container "Bericht Validatie Service" "Valideert berichten op technische eisen en controleert toestemming via Profiel Service" "Quarkus / Kotlin" "Magazijn Service" {
-                    validatieApi = component "Validatie API" "REST endpoint voor berichtvalidatie" "JAX-RS Resource" "Magazijn Component"
+                berichtValidatie = container "Bericht Validatie Service" "Valideert berichten op technische eisen en controleert toestemming via Profiel Service. In-process CDI binnen het berichtenmagazijn, geen losse REST-service." "Quarkus / Kotlin (in-process CDI)" "Magazijn Service" {
+                    validatieApi = component "Validatie-ingang" "Interne ingang (CDI) voor berichtvalidatie binnen het aanleverproces" "CDI Bean" "Magazijn Component"
                     validatieTechnisch = component "Technische Validatie" "Valideert PDF-type, grootte en aantal bijlagen" "CDI Bean" "Magazijn Component"
                     validatieToestemming = component "Toestemming Controle" "Controleert of de ontvanger toestemming gegeven heeft voor digitale communicatie" "CDI Bean" "Magazijn Component"
 
@@ -79,13 +79,13 @@ workspace "MOZa PoC Federatief Berichtenstelsel" "Doel-architectuur van het Fede
 
                 magazijnOphaalBeheerApi -> magazijnDatastore "Leest berichten en bijlagen; schrijft berichtstatus per gebruiker" "SQL/JDBC"
                 magazijnOpslagService -> magazijnDatastore "Schrijft berichten en bijlagen" "SQL/JDBC"
-                magazijnOpslagService -> validatieApi "Stuurt bericht ter validatie" "REST API (intern, mTLS)"
-                magazijnOpslagService -> publicatieStream "Stuurt gevalideerd bericht door" "REST API (intern, mTLS)"
+                magazijnOpslagService -> validatieApi "Stuurt bericht ter validatie" "CDI"
+                magazijnOpslagService -> publicatieStream "Stuurt gevalideerd bericht door" "CDI"
                 publicatieStream -> magazijnDatastore "Leest berichten met status 'te publiceren' en werkt status bij na succesvolle aanmelding" "SQL/JDBC"
 
-                autorisatieService = container "Autorisatie Service" "Toetst ophaal- en beheerverzoeken aan het autorisatiebeleid van de deelnemende organisatie" "Quarkus / Kotlin" "Magazijn Service"
+                autorisatieService = container "Autorisatie Service" "Toetst ophaal- en beheerverzoeken aan het autorisatiebeleid van de deelnemende organisatie. In-process CDI binnen het berichtenmagazijn, geen losse REST-service." "Quarkus / Kotlin (in-process CDI)" "Magazijn Service"
 
-                magazijnOphaalBeheerApi -> autorisatieService "Toetst autorisatie per verzoek" "REST API (intern, mTLS)"
+                magazijnOphaalBeheerApi -> autorisatieService "Toetst autorisatie per verzoek" "CDI"
 
                 retentieService = container "Retentie Service" "Geplande hard-delete-job: ruimt soft-deleted berichten op na de retentietermijn en logt de verwijdering naar het LDV-logboek. Cross-pod-veilig via SELECT ... FOR UPDATE SKIP LOCKED." "Quarkus / Kotlin (Scheduler)" "Magazijn Service"
 
@@ -138,12 +138,17 @@ workspace "MOZa PoC Federatief Berichtenstelsel" "Doel-architectuur van het Fede
                         }
                     }
 
-                    aanmeldService = container "Aanmeld Service" "Werkt de cache bij voor nieuwe berichten verzonden tijdens de sessie van de ontvanger" "Quarkus / Kotlin" "Service"
+                    aanmeldService = container "Aanmeld Service" "Werkt de cache bij voor nieuwe berichten verzonden tijdens de sessie van de ontvanger" "Quarkus / Kotlin" "Service" {
+                        aanmeldVerwerker = component "Aanmeld Verwerking" "Verwerkt inkomende aanmeldingen en werkt de sessiecache bij (aanmeld-write, in-sessie)" "CDI Bean"
+                        aanmeldDeduplicatie = component "Aanmeld Deduplicatie" "Ontdubbelt inkomende aanmeldingen idempotent (Redis SETNX), zodat herhaalde levering van hetzelfde gepubliceerde bericht de cache niet dubbel bijwerkt" "CDI Bean / Redis"
+
+                        aanmeldVerwerker -> aanmeldDeduplicatie "Controleert op duplicaat vóór cache-update" "CDI"
+                    }
 
                     magazijnregister = container "Magazijnregister" "Houdt per deelnemende organisatie (OIN) bij welk berichtenmagazijn erbij hoort — 1:1, het magazijnId ís de OIN. Nu config-backed; later database-opslag met beheer-interface." "Quarkus / Kotlin — gedeelde library (in-process)" "Interne Module"
 
                     pseudoniemService -> bsnkTransformatie "Transformeert PP naar EP per magazijn" "BSNk API (lokaal)"
-                    aanmeldService -> sessiecacheFacade "Werkt cache bij (aanmeld-write, in-sessie)" "CDI (in-process facade)"
+                    aanmeldVerwerker -> sessiecacheFacade "Werkt cache bij (aanmeld-write, in-sessie)" "CDI (in-process facade)"
                     uitvraagOphaalService -> sessiecacheFacade "Haalt berichten op" "CDI (in-process facade)"
                     uitvraagBerichtenlijst -> sessiecacheFacade "Haalt berichtenlijst op" "CDI (in-process facade)"
                     uitvraagBeheerService -> sessiecacheFacade "Werkt berichtstatus bij in cache" "CDI (in-process facade)"
@@ -251,6 +256,11 @@ workspace "MOZa PoC Federatief Berichtenstelsel" "Doel-architectuur van het Fede
         }
 
         component berichtValidatie "BerichtValidatieComponenten" "Componenten binnen de Bericht Validatie Service" {
+            include *?
+            autoLayout
+        }
+
+        component aanmeldService "AanmeldServiceComponenten" "Componenten binnen de Aanmeld Service" {
             include *?
             autoLayout
         }


### PR DESCRIPTION
## Aanleiding

Issue [#717](https://github.com/MinBZK/MijnOverheidZakelijk/issues/717): de gemaakte keuzes zijn sterk gestuurd door Logius-standaarden, maar dat is voor meelezers niet altijd duidelijk. Het C4-model toont *wat* er is, niet *waarom*. Deze PR legt de aanpak en de gemaakte keuzes vast voor architecten en meelezers.

## Wat zit erin

**Nieuw document `docs/aanpak-en-keuzes.md`**
- Hoe we de PoC aanvliegen (vertrekpunt BBO-inventarisatie, doel-architectuur als kompas, spec-driven/OpenAPI-first, AI onder menselijke regie, afstemming met Logius-architecten).
- Standaarden → keuzes: compacte tabel (ADR, OIN, Digikoppeling, FSC, OIDC NL GOV, CloudEvents, LDV/NEN 7513, NeRDS/BIO) met per standaard de keuze, de toepasbaarheid en een bronlink.
- Startkeuzes (techniek): Quarkus/Java 21, Kotlin (achteraf niet de juiste keuze), Maven-monorepo, logisch ≠ fysiek, PostgreSQL/Redis.
- Eén openstaande uitdaging: keten-brede authenticatie & autorisatie — bewust uitgesteld tot er een oplossingsrichting is. **Geen** permanente scope-grens; de PoC mikt op het volledige doel.

**C4-model gesynct met de implementatie**
- Bericht Validatie Service & Autorisatie Service zijn nu in-process CDI binnen berichtenmagazijn (geen losse REST-services); interne relaties van mTLS-REST → CDI.
- Aanmeld Service kreeg componenten Aanmeld Verwerking + Aanmeld Deduplicatie (idempotent, Redis SETNX) met eigen component-view.

**Bestaande model-docs bijgewerkt**
- `02-deployment-units.md`: validatie/autorisatie als in-process CDI.
- `03-poc-afwijkingen.md`: framing "uitgesteld" i.p.v. "buiten scope"; sectie "Anders gerealiseerd dan gemodelleerd" verwijderd nu het model met de implementatie klopt.

## Notitie

`workspace.json` (gegenereerde export) is bewust niet meegewijzigd; die wordt in dit project ook niet bij DSL-wijzigingen meegecommit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)