### PR TITLE
build(deps): codeql-action volledig naar v4.36.2 + dependabot-groepen

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,17 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      # codeql-action publiceert init/autobuild/analyze/upload-sarif als losse
+      # sub-actions onder één versie. Ze MOETEN samen bewegen: een enkele
+      # sub-action bumpen geeft een version-skew ("Loaded a configuration file
+      # for version X, but running version Y") en breekt de CodeQL-analyse.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
+      # Overige actions gebundeld in één PR, minder review-ruis.
+      github-actions:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -66,14 +66,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Initialize CodeQL
         if: needs.changes.outputs.run == 'true'
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: ${{ matrix.language }}
       - name: Autobuild
         if: needs.changes.outputs.run == 'true'
-        uses: github/codeql-action/autobuild@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       - name: Perform CodeQL Analysis
         if: needs.changes.outputs.run == 'true'
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -72,25 +72,25 @@ jobs:
       # category. De hashFiles-guard slaat upload over als een module geen rapport opleverde.
       - name: Upload SARIF — fbs-common
         if: ${{ always() && hashFiles('libraries/fbs-common/target/detekt.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: libraries/fbs-common/target/detekt.sarif
           category: detekt-fbs-common
       - name: Upload SARIF — fbs-berichtensessiecache
         if: ${{ always() && hashFiles('libraries/fbs-berichtensessiecache/target/detekt.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: libraries/fbs-berichtensessiecache/target/detekt.sarif
           category: detekt-fbs-berichtensessiecache
       - name: Upload SARIF — berichtenmagazijn
         if: ${{ always() && hashFiles('services/berichtenmagazijn/target/detekt.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: services/berichtenmagazijn/target/detekt.sarif
           category: detekt-berichtenmagazijn
       - name: Upload SARIF — berichtenuitvraag
         if: ${{ always() && hashFiles('services/berichtenuitvraag/target/detekt.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: services/berichtenuitvraag/target/detekt.sarif
           category: detekt-berichtenuitvraag

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -73,6 +73,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Aanleiding

Dependabot-PR #109 bumpte alleen `codeql-action/autobuild` naar 4.36.2, terwijl `init`/`analyze`/`upload-sarif` op 4.36.0 bleven. CodeQL vereist één versie over al zijn sub-actions; de version-skew brak de `Analyze (kotlin)`-job:

\`\`\`
We were unable to automatically build your code.
Loaded a configuration file for version '4.36.0', but running version '4.36.2'
\`\`\`

## Wijziging

- Alle acht `github/codeql-action`-refs naar **v4.36.2** (`8aad20d`) in `codeql.yml`, `detekt.yml`, `scorecard.yml`.
- Dependabot-`groups` toegevoegd voor de `github-actions`-ecosystem:
  - `codeql-action` — alle `github/codeql-action*` sub-actions bewegen voortaan als één PR (voorkomt herhaling van de skew).
  - `github-actions` — overige actions gebundeld, minder review-ruis.

Vervangt #109 (kan gesloten worden).

🤖 Generated with [Claude Code](https://claude.com/claude-code)