### PR TITLE
chore(deps): dependabot dagelijks i.p.v. maandelijks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,12 @@ updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "daily"
   - package-ecosystem: "docker-compose"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "daily"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "daily"


### PR DESCRIPTION
## Wijziging

Dependabot `schedule.interval` van **monthly** → **daily** voor alle drie de ecosystems (`maven`, `docker-compose`, `github-actions`).

## Waarom

- Sneller zicht op security-updates (CVE-fixes komen niet pas na max een maand binnen).
- Kleinere, frequentere bumps zijn per stuk makkelijker te reviewen dan een maandelijkse stapel.

## Samenhang

- #120 herstructureert dezelfde `dependabot.yml` (voegt `groups` toe). De wijzigingen raken verschillende regels (interval vs. groups) → geen conflict verwacht; anders rebaset de laatste triviaal.
- Met de `groups` uit #120 blijft "daily" beheersbaar: gerelateerde bumps worden gebundeld i.p.v. losse dagelijkse PR's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)