### PR TITLE
ci(deploy): ZAD-deploy pas na geslaagde tests/kwaliteitsgates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -175,9 +175,9 @@ jobs:
           # Exacte check-namen: Test-workflow → 'test', detekt.yml → 'detekt-gate',
           # pin-consistency.yml → 'infra-image-pins'.
           REQUIRED: 'test detekt-gate infra-image-pins'
-          # Ruim boven de typische `test`-duur (~7 min incl. Testcontainers) zodat een trage
-          # runner geen op-zich-groene build fail-closed blokkeert.
-          TIMEOUT_SECONDS: '1800'
+          # ~2× de typische `test`-duur (~7 min incl. Testcontainers) als marge voor een trage
+          # runner; fail-closed, dus liever iets ruimer dan een op-zich-groene build blokkeren.
+          TIMEOUT_SECONDS: '900'
           POLL_SECONDS: '15'
         run: |
           set -euo pipefail
@@ -221,8 +221,8 @@ jobs:
                 success) ;;
                 skipped|neutral)
                   # Alleen legitiem als de check bewust is overgeslagen (docs-only PR, via de
-                  # `changes`-gate die fail-safe naar draaien valt). Luid loggen zodat een
-                  # onbedoelde overslag auditbaar is i.p.v. stil als 'groen' doortelt.
+                  # `changes`-gate die bij een ophaal-fout juist tóch draait). Luid loggen zodat
+                  # een onbedoelde overslag auditbaar is i.p.v. stil als 'groen' doortelt.
                   echo "::warning::Verplichte check '$name' concludeerde '$conclusion' — als OK geteld (verwacht docs-only-overslag)."
                   ;;
                 *)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -150,6 +150,89 @@ jobs:
           docker build -t "$IMG" wiremock/externe-stubs
           docker push "$IMG"
 
+  # Kwaliteitspoort vóór élke ZAD-deploy: geen cluster-capaciteit (en geen review-ruis van een
+  # "geslaagde" preview) verspillen aan een revisie die de tests/kwaliteitsgates niet haalt. De
+  # functionele checks draaien in aparte workflows (Test, detekt, Pin consistency), dus we kunnen
+  # er niet via `needs` aan hangen; in plaats daarvan pollen we de check-runs op dezelfde head-SHA
+  # tot ze allemaal geslaagd (of overgeslagen) zijn. Eén rode check → gate faalt → alle deploy-jobs
+  # die hierop wachten worden overgeslagen. CodeQL en architecture bewust NIET in de set: CodeQL
+  # mag traag of tijdelijk rood zijn (bv. extractor-lag op een nieuwe Kotlin-versie) zonder de
+  # preview te blokkeren, en architecture draait alleen op docs/architecture-wijzigingen (zou
+  # anders permanent 'afwezig' blijven en de gate laten timen out).
+  gate:
+    if: github.event_name == 'push' || github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+    steps:
+      - name: Wacht tot de verplichte checks slagen
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          # PR: de branch-head (waar de sibling-workflows hun checks aan hangen). Push naar
+          # main: de push-SHA. Bij push is de pull_request-context leeg → valt terug op github.sha.
+          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Exacte check-namen: Test-workflow → 'test', detekt.yml → 'detekt-gate',
+          # pin-consistency.yml → 'infra-image-pins'.
+          REQUIRED: 'test detekt-gate infra-image-pins'
+          TIMEOUT_SECONDS: '1200'
+          POLL_SECONDS: '15'
+        run: |
+          set -euo pipefail
+          # REQUIRED komt uit de job-`env` hierboven; shellcheck ziet die bron niet en denkt
+          # ten onrechte aan een typo van de lokale `required`-array.
+          # shellcheck disable=SC2153
+          read -ra required <<< "$REQUIRED"
+          deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+
+          while :; do
+            runs=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100")
+            pending=()
+
+            for name in "${required[@]}"; do
+              # Nieuwste check-run met deze naam (een rerun levert meerdere; sorteer op started_at).
+              entry=$(jq -c --arg n "$name" \
+                '[.check_runs[] | select(.name == $n)] | sort_by(.started_at) | last // empty' <<< "$runs")
+
+              if [ -z "$entry" ]; then
+                pending+=("$name(afwezig)")
+                continue
+              fi
+
+              status=$(jq -r '.status' <<< "$entry")
+
+              if [ "$status" != "completed" ]; then
+                pending+=("$name($status)")
+                continue
+              fi
+
+              conclusion=$(jq -r '.conclusion // ""' <<< "$entry")
+
+              # skipped/neutral = geen bezwaar (bv. docs-only PR waar de test-job via `changes`
+              # is overgeslagen). Alleen een echte mislukking blokkeert de deploy.
+              case "$conclusion" in
+                success|skipped|neutral) ;;
+                *)
+                  echo "::error::Verplichte check '$name' concludeerde '$conclusion' — deploy geblokkeerd."
+                  exit 1
+                  ;;
+              esac
+            done
+
+            if [ "${#pending[@]}" -eq 0 ]; then
+              echo "Alle verplichte checks groen ($REQUIRED) op $SHA — deploy vrijgegeven."
+              exit 0
+            fi
+
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::Timeout na ${TIMEOUT_SECONDS}s — nog niet afgerond: ${pending[*]}"
+              exit 1
+            fi
+
+            echo "Wachten op: ${pending[*]} — opnieuw over ${POLL_SECONDS}s"
+            sleep "$POLL_SECONDS"
+          done
+
   # PR-preview: één job PER project zodat ze PARALLEL draaien — bij een fout falen alle drie
   # projecten tegelijk (geen fail-fast tussen losse jobs), dus alle fouten in één run
   # zichtbaar i.p.v. één-voor-één. Config geërfd van `test`. wait-for-ready staat UIT: de
@@ -160,7 +243,7 @@ jobs:
   # kan pas met een per-component health-endpoint of een Quarkus-only deployment; tot dan 'false'.
   deploy-preview-uitvraag:
     if: github.event_name == 'pull_request' && github.event.action != 'closed'
-    needs: [meta, build, build-externe-stubs]
+    needs: [meta, build, build-externe-stubs, gate]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -191,7 +274,7 @@ jobs:
 
   deploy-preview-externe-stubs:
     if: github.event_name == 'pull_request' && github.event.action != 'closed'
-    needs: [meta, build, build-externe-stubs]
+    needs: [meta, build, build-externe-stubs, gate]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -214,7 +297,7 @@ jobs:
 
   deploy-preview-magazijnen:
     if: github.event_name == 'pull_request' && github.event.action != 'closed'
-    needs: [meta, build, build-externe-stubs]
+    needs: [meta, build, build-externe-stubs, gate]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -316,7 +399,7 @@ jobs:
   # env/secrets configureer je daar in Operations Manager). Per project een eigen parallelle job.
   deploy-test-uitvraag:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [meta, build, build-externe-stubs]
+    needs: [meta, build, build-externe-stubs, gate]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -338,7 +421,7 @@ jobs:
 
   deploy-test-externe-stubs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [meta, build, build-externe-stubs]
+    needs: [meta, build, build-externe-stubs, gate]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -357,7 +440,7 @@ jobs:
 
   deploy-test-magazijnen:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [meta, build, build-externe-stubs]
+    needs: [meta, build, build-externe-stubs, gate]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -153,13 +153,13 @@ jobs:
   # Kwaliteitspoort vóór élke ZAD-deploy: geen cluster-capaciteit (en geen review-ruis van een
   # "geslaagde" preview) verspillen aan een revisie die de tests/kwaliteitsgates niet haalt. De
   # functionele checks draaien in aparte workflows (Test, detekt, Pin consistency), dus we kunnen
-  # er niet via `needs` aan hangen; in plaats daarvan pollen we de check-runs op dezelfde head-SHA
-  # tot ze allemaal geslaagd (of overgeslagen) zijn. Eén rode check → gate faalt → alle deploy-jobs
-  # die hierop wachten worden overgeslagen. CodeQL en architecture bewust NIET in de set: CodeQL
-  # mag traag of tijdelijk rood zijn (bv. extractor-lag op een nieuwe Kotlin-versie) zonder de
-  # preview te blokkeren, en architecture draait alleen op docs/architecture-wijzigingen (zou
-  # anders permanent 'afwezig' blijven en de gate laten timen out).
+  # er niet via `needs` aan hangen — vandaar dat we hun check-runs op dezelfde head-SHA pollen.
+  # CodeQL en architecture bewust NIET in de set: CodeQL mag traag of tijdelijk rood zijn (bv.
+  # extractor-lag op een nieuwe Kotlin-versie) zonder de preview te blokkeren, en architecture
+  # triggert alleen op docs/architecture-wijzigingen — op een gewone PR verschijnt er geen
+  # check-run ('afwezig'), waardoor de gate anders tot de timeout zou blijven wachten.
   gate:
+    # Niet op PR-close: dat pad is teardown/cleanup, geen deploy.
     if: github.event_name == 'push' || github.event.action != 'closed'
     runs-on: ubuntu-latest
     permissions:
@@ -175,24 +175,33 @@ jobs:
           # Exacte check-namen: Test-workflow → 'test', detekt.yml → 'detekt-gate',
           # pin-consistency.yml → 'infra-image-pins'.
           REQUIRED: 'test detekt-gate infra-image-pins'
-          TIMEOUT_SECONDS: '1200'
+          # Ruim boven de typische `test`-duur (~7 min incl. Testcontainers) zodat een trage
+          # runner geen op-zich-groene build fail-closed blokkeert.
+          TIMEOUT_SECONDS: '1800'
           POLL_SECONDS: '15'
         run: |
           set -euo pipefail
           # REQUIRED komt uit de job-`env` hierboven; shellcheck ziet die bron niet en denkt
-          # ten onrechte aan een typo van de lokale `required`-array.
+          # dat het een misspelling van de lokale `required`-array is (SC2153).
           # shellcheck disable=SC2153
           read -ra required <<< "$REQUIRED"
           deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
 
           while :; do
-            runs=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100")
             pending=()
 
             for name in "${required[@]}"; do
-              # Nieuwste check-run met deze naam (een rerun levert meerdere; sorteer op started_at).
-              entry=$(jq -c --arg n "$name" \
-                '[.check_runs[] | select(.name == $n)] | sort_by(.started_at) | last // empty' <<< "$runs")
+              # Server-side op naam filteren én alle pagina's mergen: op een drukke PR staan er
+              # (met reruns) makkelijk >100 check-runs op de SHA. Eén ongepagineerde pagina zou
+              # de nieuwste run kunnen missen en stil een oudere conclusie kiezen. Nieuwste =
+              # hoogste `id` (monotoon; `started_at` is null zolang een rerun nog queued is en
+              # zou dan verkeerd vooraan sorteren).
+              if ! entry=$(gh api --paginate \
+                    "repos/$REPO/commits/$SHA/check-runs?check_name=$name&per_page=100" \
+                    --jq '.check_runs[]' | jq -sc 'sort_by(.id) | last // empty'); then
+                echo "::warning::Ophalen van check-runs voor '$name' faalde — retry over ${POLL_SECONDS}s."
+                entry=""
+              fi
 
               if [ -z "$entry" ]; then
                 pending+=("$name(afwezig)")
@@ -208,10 +217,14 @@ jobs:
 
               conclusion=$(jq -r '.conclusion // ""' <<< "$entry")
 
-              # skipped/neutral = geen bezwaar (bv. docs-only PR waar de test-job via `changes`
-              # is overgeslagen). Alleen een echte mislukking blokkeert de deploy.
               case "$conclusion" in
-                success|skipped|neutral) ;;
+                success) ;;
+                skipped|neutral)
+                  # Alleen legitiem als de check bewust is overgeslagen (docs-only PR, via de
+                  # `changes`-gate die fail-safe naar draaien valt). Luid loggen zodat een
+                  # onbedoelde overslag auditbaar is i.p.v. stil als 'groen' doortelt.
+                  echo "::warning::Verplichte check '$name' concludeerde '$conclusion' — als OK geteld (verwacht docs-only-overslag)."
+                  ;;
                 *)
                   echo "::error::Verplichte check '$name' concludeerde '$conclusion' — deploy geblokkeerd."
                   exit 1

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -35,7 +35,16 @@ jobs:
             echo "run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          files=$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename')
+          # Fail-safe naar draaien: kan de bestandenlijst niet opgehaald worden (API-hik,
+          # rate-limit), dan de code-checks TÓCH draaien i.p.v. stil overslaan. Een overslaan-
+          # op-fout zou als 'skipped' (= succes) doortellen in de deploy-gate en ongeteste code
+          # laten deployen.
+          if ! files=$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename'); then
+            echo "::warning::Kon gewijzigde bestanden niet ophalen — code-checks draaien fail-safe."
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           echo "Gewijzigde bestanden:"
           printf '%s\n' "$files"
           if printf '%s\n' "$files" | grep -qvE '(^docs/|\.md$)'; then

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -35,10 +35,9 @@ jobs:
             echo "run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # Fail-safe naar draaien: kan de bestandenlijst niet opgehaald worden (API-hik,
-          # rate-limit), dan de code-checks TÓCH draaien i.p.v. stil overslaan. Een overslaan-
-          # op-fout zou als 'skipped' (= succes) doortellen in de deploy-gate en ongeteste code
-          # laten deployen.
+          # Fail-safe: kan de bestandenlijst niet opgehaald worden (API-hik, rate-limit), draai
+          # de code-checks dan TÓCH i.p.v. ze stil over te slaan. Een overslaan-op-fout zou als
+          # 'skipped' (= succes) doortellen in de deploy-gate en ongeteste code laten deployen.
           if ! files=$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename'); then
             echo "::warning::Kon gewijzigde bestanden niet ophalen — code-checks draaien fail-safe."
             echo "run=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,10 +36,9 @@ jobs:
             echo "run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # Fail-safe naar draaien: kan de bestandenlijst niet opgehaald worden (API-hik,
-          # rate-limit), dan de code-checks TÓCH draaien i.p.v. stil overslaan. Een overslaan-
-          # op-fout zou als 'skipped' (= succes) doortellen in de deploy-gate en ongeteste code
-          # laten deployen.
+          # Fail-safe: kan de bestandenlijst niet opgehaald worden (API-hik, rate-limit), draai
+          # de code-checks dan TÓCH i.p.v. ze stil over te slaan. Een overslaan-op-fout zou als
+          # 'skipped' (= succes) doortellen in de deploy-gate en ongeteste code laten deployen.
           if ! files=$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename'); then
             echo "::warning::Kon gewijzigde bestanden niet ophalen — code-checks draaien fail-safe."
             echo "run=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,16 @@ jobs:
             echo "run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          files=$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename')
+          # Fail-safe naar draaien: kan de bestandenlijst niet opgehaald worden (API-hik,
+          # rate-limit), dan de code-checks TÓCH draaien i.p.v. stil overslaan. Een overslaan-
+          # op-fout zou als 'skipped' (= succes) doortellen in de deploy-gate en ongeteste code
+          # laten deployen.
+          if ! files=$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename'); then
+            echo "::warning::Kon gewijzigde bestanden niet ophalen — code-checks draaien fail-safe."
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           echo "Gewijzigde bestanden:"
           printf '%s\n' "$files"
           if printf '%s\n' "$files" | grep -qvE '(^docs/|\.md$)'; then


### PR DESCRIPTION
## Aanleiding

De ZAD-deploy-jobs hingen via `needs` alleen aan de image-builds (`build`, `build-externe-stubs`), niet aan de functionele checks. Die draaien in **aparte** workflows (Test, detekt, Pin consistency), dus konden de deploy-jobs er niet aan hangen. Gevolg: een PR die de tests niet haalt, deployt tóch naar ZAD — verspilde cluster-capaciteit én een misleidend "geslaagde preview"-signaal in de review.

## Wijziging

Nieuwe **`gate`**-job die de check-runs op de head-SHA pollt tot ze geslaagd (of overgeslagen) zijn, vóór er iets deployt:

- Vereist groen: **`test`**, **`detekt-gate`**, **`infra-image-pins`**.
- Alle zes deploy-jobs (3× preview, 3× test-baseline) krijgen `needs: […, gate]`.
- Eén rode check → gate faalt → deploy-jobs worden overgeslagen.
- `skipped`/`neutral` telt als OK (bv. docs-only PR waar `test` via de `changes`-gate is overgeslagen).
- **Fail-closed:** bij timeout (20 min) of een ontbrekende check gaat de deploy niet door.

### Waarom pollen i.p.v. `needs`

`needs` werkt alleen binnen één workflow. De kwaliteitschecks zitten in losse workflows, dus de gate leest hun resultaat via de Checks-API op dezelfde commit. Inline `gh`-script (geen nieuwe externe action) — past bij de bestaande stijl (`changes`, `infra-image-pins`) en houdt het supply-chain-oppervlak klein.

### Buiten de set (bewust)

- **CodeQL (`Analyze (kotlin)`)** — mag traag of tijdelijk rood zijn (extractor-lag op een nieuwe Kotlin-versie, zie #119) zonder previews te blokkeren.
- **architecture** — draait alleen op `docs/architecture/**`-wijzigingen; zou anders permanent 'afwezig' zijn en de gate laten timen out.

## Verificatie

- `actionlint` schoon, YAML valide, shellcheck schoon (SC2153-false-positive onderdrukt met motivatie).
- Deze PR triggert zelf `deploy.yml` (bij `pull_request` gebruikt GitHub de workflow van de PR-head), dus de nieuwe gate draait live op deze PR — zichtbaar in de checks hieronder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)