### PR TITLE
fix(security): Scorecard token-permissions + WireMock-image pin

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,10 @@ on:
   push:
     branches: [main]
 
+# Least-privilege default voor GITHUB_TOKEN: read-only op workflow-niveau; jobs die schrijven
+# (build → packages, cleanup → deployments/packages/pull-requests) declareren dat zelf.
+permissions: read-all
+
 # Eén deploy-run tegelijk per PR; een nieuwe push wacht op de lopende i.p.v. die af te
 # breken (cancel-in-progress: false) — een halverwege afgebroken ZAD-deploy kan een
 # deployment in een inconsistente staat achterlaten.

--- a/wiremock/externe-stubs/Dockerfile
+++ b/wiremock/externe-stubs/Dockerfile
@@ -6,5 +6,5 @@
 # notificatie); elk component krijgt op zijn eigen subdomein alleen zijn eigen
 # verkeer, de overige mappings staan ongebruikt mee. WireMock serveert op poort
 # 8080 en leest /home/wiremock/mappings.
-FROM wiremock/wiremock:3.13.2
+FROM wiremock/wiremock:3.13.2@sha256:fd27e46090916e85326229e5102ee169ae729059f3374549615bd20a35fee1f2
 COPY mappings /home/wiremock/mappings


### PR DESCRIPTION
## Aanleiding

Twee **oplosbare** open code-scanning-alerts (Scorecard) op het dashboard. Niet aanwezig in andere open PR's (#130 raakt alleen deploy.yml-jobs, #122 alleen dependabot.yml).

## Opgelost

- **#46 — Token-Permissions (high), `deploy.yml`:** de workflow had geen top-level `permissions`, dus kreeg `GITHUB_TOKEN` default write-rechten. Toegevoegd `permissions: read-all` op workflow-niveau (least-privilege, gelijk aan `test.yml`/`detekt.yml`/`architecture.yml`). Jobs die schrijven declareren hun rechten al zelf (build → `packages: write`, cleanup → `deployments`/`packages`/`pull-requests: write`) en overriden de top-level.
- **#47 — Pinned-Dependencies (medium), `wiremock/externe-stubs/Dockerfile`:** base-image nu by-digest gepind: `wiremock/wiremock:3.13.2@sha256:fd27e460…`.

## Bewust niet aangeraakt (niet code-oplosbaar)

- **#45 (deploy.yml cleanup-job, `deployments: write`)** en **#44 (architecture.yml deploy-job, `contents: write`)** — deze writes zijn functioneel nodig (deployment-/env-cleanup resp. gh-pages-publicatie). Ze staan al job-scoped (least-privilege op de juiste laag); Scorecard vlagt elke write, maar weghalen breekt de functie. Kandidaat om te dismissen met reden, niet om te "fixen".
- **#18 (SAST-heuristiek)** — Scorecard ziet geen SAST, maar we draaien CodeQL + detekt. Geen code-fix.

## Verificatie

- `actionlint` + YAML schoon. De `build-externe-stubs`-job pullt het gepinde image → valideert de digest live in de CI hieronder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)