### PR TITLE
ci(codeql): docs-only-gate weg zodat CodeQL op elke PR draait

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,44 +10,12 @@ on:
 
 permissions: read-all
 
+# CodeQL draait op ELKE PR, óók docs-only. De OpenSSF Scorecard SAST-check bemonstert de
+# laatste ~30 gemergede PRs en kijkt per PR of er een CodeQL-SARIF-upload was; één overgeslagen
+# analyse laat die PR ongedekt en verlaagt de check-score. CodeQL analyseert bovendien de hele
+# snapshot, niet de diff — er is geen "niks gewijzigd, snel klaar"-pad. Daarom geen docs-only-gating.
 jobs:
-  # Bepaalt of er iets buiten documentatie (docs/, *.md) is gewijzigd. De analyze-stappen
-  # zijn hieraan gegate. LET OP: de gating zit op STAP-niveau, niet op job-niveau. Analyze
-  # is een matrix-job (`language`), dus de required status check heet `Analyze (kotlin)`.
-  # Bij een job-niveau `if` dat false is, expandeert de matrix niet en rapporteert GitHub
-  # de check onder de basisnaam `Analyze` — de required context `Analyze (kotlin)` ontbreekt
-  # dan en blokkeert de PR eeuwig. Door de matrix te laten expanden en alleen de stappen te
-  # skippen, rapporteert de job als `Analyze (kotlin)` met conclusie success (alle stappen
-  # overgeslagen) bij een docs-only PR.
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      run: ${{ steps.filter.outputs.run }}
-    steps:
-      - name: Detecteer niet-documentatie wijzigingen
-        id: filter
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EVENT: ${{ github.event_name }}
-          REPO: ${{ github.repository }}
-          PR: ${{ github.event.pull_request.number }}
-        run: |
-          if [ "$EVENT" != "pull_request" ]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          files=$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename')
-          echo "Gewijzigde bestanden:"
-          printf '%s\n' "$files"
-          if printf '%s\n' "$files" | grep -qvE '(^docs/|\.md$)'; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Alleen documentatie gewijzigd — code-checks overgeslagen."
-            echo "run=false" >> "$GITHUB_OUTPUT"
-          fi
-
   analyze:
-    needs: changes
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
@@ -62,18 +30,14 @@ jobs:
         # Bijvoorbeeld / For example: ['java', 'javascript', 'python']
     steps:
       - name: Checkout repository
-        if: needs.changes.outputs.run == 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Initialize CodeQL
-        if: needs.changes.outputs.run == 'true'
         uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
       - name: Autobuild
-        if: needs.changes.outputs.run == 'true'
         uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
       - name: Perform CodeQL Analysis
-        if: needs.changes.outputs.run == 'true'
         uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Aanleiding

Code-scanning alert #18 (Scorecard SAST-check) op `main`: score 9 — `29 commits out of 30 are checked with a SAST tool`.

Oorzaak: de `changes`-gate in `codeql.yml` sloeg de CodeQL-analyse over op docs-only PRs. Scorecard telt per gemergede PR of er een CodeQL-SARIF-upload was; een overgeslagen analyse liet die ene PR ongedekt → 29/30 → score 9.

## Wijziging

- `changes`-job + step-level `if: needs.changes...` gates verwijderd.
- `Analyze (kotlin)` draait nu op elke PR (ook docs-only) → SARIF altijd geüpload → Scorecard 30/30.

CodeQL analyseert de hele code-snapshot, niet de diff — er bestaat geen "niks gewijzigd, snel klaar"-pad. Altijd draaien is de juiste oplossing; de kosten op zeldzame docs-only PRs zijn een paar minuten build.

## Branch-protection

Matrix expandeert nu altijd, dus de required check `Analyze (kotlin)` blijft aanwezig — de reden dat de oude skip op step-niveau zat (niet job-niveau) vervalt.

## Nazorg

Alert #18 verdwijnt niet direct: Scorecard scant de laatste ~30 gemergede PRs, dus de score klimt naarmate de ongedekte docs-only PR verjaart en nieuwe PRs allemaal CodeQL dragen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)