### PR TITLE
ci(deploy): ZAD-redis zonder persistence documenteren

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,6 +64,13 @@ env:
   # (zie pin-consistency.yml). ClickHouse draait op het stock-image; geef het genoeg
   # geheugen via het container-limit (~2–4Gi). Logt naar bestanden in de container, niet
   # naar stdout (geen env-var verandert dat).
+  #
+  # Redis draait op ZAD zónder persistence: zet op de redis-component de runtime-env
+  # `REDIS_ARGS=--save "" --appendonly no` (in Operations Manager, net als de overige
+  # runtime-env hierboven). Het restricted SecurityContext (willekeurige non-root UID)
+  # mag niet in de image-datadir `/data` schrijven, dus RDB-snapshots falen met
+  # "Permission denied". Kan uit: de sessiecache is ephemeral en rekent nergens op
+  # persistence (idempotente RediSearch-bootstrap, TTL-entries, crash-safe vangnet-lock).
   REDIS_IMAGE: redis/redis-stack-server:7.4.0-v3
   CLICKHOUSE_IMAGE: clickhouse/clickhouse-server:26.6
   # Verse preview-provisioning (`clone-from: test` maakt nieuwe volumes + ingress aan) duurt


### PR DESCRIPTION
## Aanleiding

De Redis-pod op ZAD logt herhaaldelijk:

```
# Failed opening the temp RDB file temp-<pid>.rdb (in server root dir /data) for saving: Permission denied
```

Het RIG/ZAD-platform draait de pod met een restricted SecurityContext (willekeurige non-root UID), die niet in de image-datadir `/data` mag schrijven. Elke automatische RDB-snapshot faalt daardoor.

## Wijziging

Geen code — alleen een comment bij `REDIS_IMAGE` in `deploy.yml` die vastlegt:

- **Fix:** zet op de redis-component de runtime-env `REDIS_ARGS=--save "" --appendonly no` (in Operations Manager, net als de overige runtime-env).
- **Waarom het uit kan:** de sessiecache is ephemeral en rekent nergens op persistence — idempotente RediSearch-bootstrap (index wordt bij startup her-aangemaakt als die ontbreekt), TTL-gebaseerde entries, en een crash-safe vangnet-lock. Een leeggelopen Redis is het normale pad.

De feitelijke env moet nog éénmalig in **Operations Manager** op de `test`-deployment gezet worden (previews erven via `clone-from: test`); de `zad-actions/deploy`-action heeft geen env-input, dus dit kan niet in de repo zelf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)