### PR TITLE
[FBS] Magazijn-provider-peer aansluiten op de FSC-federatie (#780)

### DIFF
--- a/.github/workflows/zad-deploy-peer.yml
+++ b/.github/workflows/zad-deploy-peer.yml
@@ -1,0 +1,103 @@
+# Directe ZAD-API-deploy van de provider-peer magazijn-a (#780) via de v2 Operations Manager
+# API. Roept fsc/deploy/zad/upsert-peer.sh aan (zelfde bron als de CLI). Model op repo A's
+# zad-deploy-directory.yml (MinBZK/moza-fsc-testnet), maar zonder build-job: de drie images
+# (manager-migrate, controller, inway) zijn kant-en-klare pins — deze repo bouwt ze niet zelf.
+#
+# Trigger: push naar main -> deployment `test`; PR (met path-filter) -> preview `pr-<PR-nummer>`.
+# Dekt alleen de deploy-API (deployment + componenten + images + env_vars/aliases). NIET via de
+# API (UI-only): bijlagen (cert-mount), "Publicatie op het web" (passthrough-TLS) — zie
+# fsc/deploy/zad/cert-manifest.md.
+name: zad-deploy-peer
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "fsc/deploy/zad/**"
+      - ".github/workflows/zad-deploy-peer.yml"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "fsc/deploy/zad/**"
+      - ".github/workflows/zad-deploy-peer.yml"
+
+permissions: read-all
+
+concurrency:
+  # Eén run per deployment tegelijk: PR -> pr-<n>, push -> test. Deploys niet halverwege killen
+  # (een halve ZAD-deploy laat een inconsistente staat achter).
+  group: zad-deploy-peer-${{ github.event.pull_request.number && format('pr-{0}', github.event.pull_request.number) || 'test' }}
+  cancel-in-progress: false
+
+jobs:
+  # Afgeleide waarden op één plek: deployment-naam + de MODE die uit het event volgt.
+  meta:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      deployment: ${{ steps.m.outputs.deployment }}
+    steps:
+      - id: m
+        env:
+          EVENT: ${{ github.event_name }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "pull_request" ]; then
+            deployment="pr-${PR}"
+          else
+            deployment="test"
+          fi
+          echo "deployment=${deployment}" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    needs: meta
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Upsert magazijn-a-peer via ZAD v2-API
+        env:
+          ZAD_API_KEY: ${{ secrets.ZAD_API_KEY_MAGAZIJNEN }}
+          ZAD_PROJECT: ${{ vars.ZAD_PROJECT_ID_MAGAZIJNEN || 'mpfm-w3h' }}
+          MODE: apply
+          DEPLOYMENT: ${{ needs.meta.outputs.deployment }}
+          IMAGE_TAG: v1.43.7
+        run: ./fsc/deploy/zad/upsert-peer.sh "${MODE}" "${DEPLOYMENT}" "${IMAGE_TAG}"
+
+      - name: Preview-hostnamen als PR-comment (upsert)
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          DEPLOYMENT: ${{ needs.meta.outputs.deployment }}
+          PROJECT: ${{ vars.ZAD_PROJECT_ID_MAGAZIJNEN || 'mpfm-w3h' }}
+          BASE_DOMAIN: ${{ vars.ZAD_BASE_DOMAIN || 'rig.prd1.gn2.quattro.rijksapps.nl' }}
+        run: |
+          set -euo pipefail
+          marker="<!-- fsc-peer-preview -->"
+          mgr="https://mgzmgr-${DEPLOYMENT}-${PROJECT}.${BASE_DOMAIN}"
+          ctl="https://mgzctl-${DEPLOYMENT}-${PROJECT}.${BASE_DOMAIN}"
+          inway="https://mgzinway-${DEPLOYMENT}-${PROJECT}.${BASE_DOMAIN}"
+          body="${marker}
+          ### FSC magazijn-a-peer-preview \`${DEPLOYMENT}\`
+          - mgzmgr (manager): ${mgr}
+          - mgzctl (controller): ${ctl}
+          - mgzinway (inway): ${inway}
+
+          Bijlagen (certs) en 'Publicatie op het web' zijn UI-only en dus niet automatisch gezet — zie \`fsc/deploy/zad/cert-manifest.md\`."
+          id=$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
+                --jq "map(select(.body | startswith(\"$marker\"))) | .[0].id // empty")
+          if [ -n "$id" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$id" -f body="$body" >/dev/null
+          else
+            gh api -X POST "repos/$REPO/issues/$PR/comments" -f body="$body" >/dev/null
+          fi

--- a/.github/workflows/zad-deploy-peer.yml
+++ b/.github/workflows/zad-deploy-peer.yml
@@ -3,12 +3,12 @@
 # zad-deploy-directory.yml (MinBZK/moza-fsc-testnet), maar zonder build-job: de drie images
 # (manager-migrate, controller, inway) zijn kant-en-klare pins — deze repo bouwt ze niet zelf.
 #
-# CLOBBER-VEILIG: de peer draait in een EIGEN, vaste deployment `peer`. deploy.yml (de app) raakt
-# alleen `test`/`pr-<n>` aan; verschillende deployment-namen -> ze kunnen elkaars componenten niet
-# overschrijven. Eén vaste `peer`-deployment betekent ook één aanmelding van de federatie-OIN
-# (singleton) — geen dubbele-OIN-botsing, ook al deployt dit op elke PR-push.
+# CLOBBER-VEILIG via PROJECT-ISOLATIE: de peer draait in een EIGEN ZAD-project `mpfoa-e01`, los van
+# het app-project `mpfm-w3h` dat deploy.yml beheert. Er is dus geen app-deployment om te
+# overschrijven. Binnen mpfoa-e01 draait de peer in de deployment `test` -> één aanmelding van
+# de federatie-OIN (singleton), geen dubbele-OIN-botsing, ook al deployt dit op elke PR-push.
 #
-# Trigger: elke push naar main én elke PR-synchronisatie -> deployment `peer`. (Wil je smaller:
+# Trigger: elke push naar main én elke PR-synchronisatie -> deployment `test`. (Wil je smaller:
 # voeg een `paths:`-filter toe op fsc/** + deze workflow.)
 #
 # Dekt alleen de deploy-API (deployment + componenten + images + env_vars/aliases). NIET via de
@@ -38,9 +38,11 @@ jobs:
       contents: read
       pull-requests: write
     env:
-      DEPLOYMENT: peer
-      PROJECT: ${{ vars.ZAD_PROJECT_ID_MAGAZIJNEN || 'mpfm-w3h' }}
+      DEPLOYMENT: test
+      PROJECT: ${{ vars.ZAD_PROJECT_ID_MPFOA || 'mpfoa-e01' }}
       BASE_DOMAIN: ${{ vars.ZAD_BASE_DOMAIN || 'rig.prd1.gn2.quattro.rijksapps.nl' }}
+      # De app draait in een ANDER project (mpfm-w3h); de inway-upstream wijst er cross-project heen.
+      MAGAZIJNA_PROJECT: ${{ vars.ZAD_PROJECT_ID_MAGAZIJNEN || 'mpfm-w3h' }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -49,8 +51,10 @@ jobs:
 
       - name: Upsert magazijn-a-peer via ZAD v2-API
         env:
-          ZAD_API_KEY: ${{ secrets.ZAD_API_KEY_MAGAZIJNEN }}
+          # Eigen project mpfoa-e01 => eigen API-key (NIET de magazijnen-key).
+          ZAD_API_KEY: ${{ secrets.ZAD_API_KEY_FSCORGA }}
           ZAD_PROJECT: ${{ env.PROJECT }}
+          ZAD_MAGAZIJNA_PROJECT: ${{ env.MAGAZIJNA_PROJECT }}
           IMAGE_TAG: v1.43.7
         run: ./fsc/deploy/zad/upsert-peer.sh apply "${DEPLOYMENT}" "${IMAGE_TAG}"
 

--- a/.github/workflows/zad-deploy-peer.yml
+++ b/.github/workflows/zad-deploy-peer.yml
@@ -3,60 +3,44 @@
 # zad-deploy-directory.yml (MinBZK/moza-fsc-testnet), maar zonder build-job: de drie images
 # (manager-migrate, controller, inway) zijn kant-en-klare pins — deze repo bouwt ze niet zelf.
 #
-# Trigger: push naar main -> deployment `test`; PR (met path-filter) -> preview `pr-<PR-nummer>`.
+# CLOBBER-VEILIG: de peer draait in een EIGEN, vaste deployment `peer`. deploy.yml (de app) raakt
+# alleen `test`/`pr-<n>` aan; verschillende deployment-namen -> ze kunnen elkaars componenten niet
+# overschrijven. Eén vaste `peer`-deployment betekent ook één aanmelding van de federatie-OIN
+# (singleton) — geen dubbele-OIN-botsing, ook al deployt dit op elke PR-push.
+#
+# Trigger: elke push naar main én elke PR-synchronisatie -> deployment `peer`. (Wil je smaller:
+# voeg een `paths:`-filter toe op fsc/** + deze workflow.)
+#
 # Dekt alleen de deploy-API (deployment + componenten + images + env_vars/aliases). NIET via de
 # API (UI-only): bijlagen (cert-mount), "Publicatie op het web" (passthrough-TLS) — zie
-# fsc/deploy/zad/cert-manifest.md.
+# fsc/deploy/zad/cert-manifest.md. De dienst `berichtenmagazijn` publiceren is een aparte stap
+# (verify-zad.md, stap b), geen onderdeel van deze upsert.
 name: zad-deploy-peer
 
 on:
   push:
     branches: [main]
-    paths:
-      - "fsc/deploy/zad/**"
-      - ".github/workflows/zad-deploy-peer.yml"
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - "fsc/deploy/zad/**"
-      - ".github/workflows/zad-deploy-peer.yml"
 
 permissions: read-all
 
 concurrency:
-  # Eén run per deployment tegelijk: PR -> pr-<n>, push -> test. Deploys niet halverwege killen
-  # (een halve ZAD-deploy laat een inconsistente staat achter).
-  group: zad-deploy-peer-${{ github.event.pull_request.number && format('pr-{0}', github.event.pull_request.number) || 'test' }}
+  # Eén vaste peer-deployment -> serialiseer alle runs erop (een halve ZAD-deploy laat een
+  # inconsistente staat achter; niet halverwege killen).
+  group: zad-deploy-peer
   cancel-in-progress: false
 
 jobs:
-  # Afgeleide waarden op één plek: deployment-naam + de MODE die uit het event volgt.
-  meta:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      deployment: ${{ steps.m.outputs.deployment }}
-    steps:
-      - id: m
-        env:
-          EVENT: ${{ github.event_name }}
-          PR: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          if [ "$EVENT" = "pull_request" ]; then
-            deployment="pr-${PR}"
-          else
-            deployment="test"
-          fi
-          echo "deployment=${deployment}" >> "$GITHUB_OUTPUT"
-
   deploy:
-    needs: meta
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
+    env:
+      DEPLOYMENT: peer
+      PROJECT: ${{ vars.ZAD_PROJECT_ID_MAGAZIJNEN || 'mpfm-w3h' }}
+      BASE_DOMAIN: ${{ vars.ZAD_BASE_DOMAIN || 'rig.prd1.gn2.quattro.rijksapps.nl' }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -66,34 +50,31 @@ jobs:
       - name: Upsert magazijn-a-peer via ZAD v2-API
         env:
           ZAD_API_KEY: ${{ secrets.ZAD_API_KEY_MAGAZIJNEN }}
-          ZAD_PROJECT: ${{ vars.ZAD_PROJECT_ID_MAGAZIJNEN || 'mpfm-w3h' }}
-          MODE: apply
-          DEPLOYMENT: ${{ needs.meta.outputs.deployment }}
+          ZAD_PROJECT: ${{ env.PROJECT }}
           IMAGE_TAG: v1.43.7
-        run: ./fsc/deploy/zad/upsert-peer.sh "${MODE}" "${DEPLOYMENT}" "${IMAGE_TAG}"
+        run: ./fsc/deploy/zad/upsert-peer.sh apply "${DEPLOYMENT}" "${IMAGE_TAG}"
 
-      - name: Preview-hostnamen als PR-comment (upsert)
+      - name: Peer-hostnamen als PR-comment
         if: ${{ github.event_name == 'pull_request' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
-          DEPLOYMENT: ${{ needs.meta.outputs.deployment }}
-          PROJECT: ${{ vars.ZAD_PROJECT_ID_MAGAZIJNEN || 'mpfm-w3h' }}
-          BASE_DOMAIN: ${{ vars.ZAD_BASE_DOMAIN || 'rig.prd1.gn2.quattro.rijksapps.nl' }}
         run: |
           set -euo pipefail
-          marker="<!-- fsc-peer-preview -->"
+          marker="<!-- fsc-peer-deploy -->"
           mgr="https://mgzmgr-${DEPLOYMENT}-${PROJECT}.${BASE_DOMAIN}"
           ctl="https://mgzctl-${DEPLOYMENT}-${PROJECT}.${BASE_DOMAIN}"
           inway="https://mgzinway-${DEPLOYMENT}-${PROJECT}.${BASE_DOMAIN}"
           body="${marker}
-          ### FSC magazijn-a-peer-preview \`${DEPLOYMENT}\`
+          ### FSC magazijn-a-peer (deployment \`${DEPLOYMENT}\`)
           - mgzmgr (manager): ${mgr}
           - mgzctl (controller): ${ctl}
           - mgzinway (inway): ${inway}
 
-          Bijlagen (certs) en 'Publicatie op het web' zijn UI-only en dus niet automatisch gezet — zie \`fsc/deploy/zad/cert-manifest.md\`."
+          Eigen \`${DEPLOYMENT}\`-deployment, los van de app-deployments \`test\`/\`pr-<n>\` (clobber-veilig).
+          Nog handmatig/apart: bijlagen (certs) + 'Publicatie op het web' (UI-only), en de dienst
+          \`berichtenmagazijn\` publiceren — zie \`fsc/deploy/zad/cert-manifest.md\` en \`verify-zad.md\`."
           id=$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
                 --jq "map(select(.body | startswith(\"$marker\"))) | .[0].id // empty")
           if [ -n "$id" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,10 @@ node_modules/
 
 # Tijdelijke files van import-rewrite-scripts
 *.kt.tmp
+
+# FSC-peer certificaten (privésleutels — nooit committen)
+fsc/pki/ca/
+fsc/pki/out/
+fsc/pki/internal/
+fsc/pki/zad-upload/
+fsc/deploy/local/.env

--- a/docs/plans/2026-07-08-magazijn-provider-peer-fsc-design.md
+++ b/docs/plans/2026-07-08-magazijn-provider-peer-fsc-design.md
@@ -38,6 +38,14 @@ en tonen de portal-flow **lokaal** aan (ca-cfssl + ca-certportal, cert voor de m
 is de AL functioneel gedekt zonder te blokkeren op een portal-op-ZAD; dat portal-op-ZAD is een
 repo-A-vervolg, geen onderdeel van #780.
 
+**Group-CA-herkomst (besloten):** voor de aansluiting op de échte fsc-testnet-directory moet
+magazijn-a's group-leaf ketenen naar **fsc-testnet's** group-root — niet naar een lokaal verse CA.
+Gekozen route: het group-CA-materiaal van repo A (`ca/root.pem` + `ca/intermediate.pem` + keys)
+lokaal in `fsc/pki/ca/` plaatsen en **`init-ca.sh` overslaan**; daarna alleen `issue.sh` draaien.
+De per-peer INTERNAL-CA blijft lokaal/self-signed. (`init-ca.sh` blijft de juiste keuze voor de
+geïsoleerde lokale compose-proof.) Van de directory zelf zijn géén per-peer client-certs of
+private keys nodig — trust loopt volledig via de gedeelde group-PKI.
+
 ## Scope
 
 **In scope:** de provider-peer voor **magazijn-a** (echte OIN `00000001003214345000`).
@@ -54,8 +62,9 @@ uitbreiding), txlog-hardening/e2e-verantwoording (#728), en het echte data-pad d
 | Peer-naam | `magazijn-a` | conventie repo B (geen `example-*`) |
 | Group ID | `moza-fbs-test` | repo A directory-deploy |
 | Directory-OIN | `00000000000000000010` | repo A directory-deploy |
-| ZAD-project (co-located) | `magazijnen` / `mpfm-w3h` | repo B `deploy.yml` |
-| App-component (inway-upstream) | `magazijna` | repo B `deploy.yml` |
+| ZAD-project peer | `mpfoa-e01` (eigen project) | dit ontwerp (was co-located `mpfm-w3h`) |
+| ZAD-project app | `magazijnen` / `mpfm-w3h` | repo B `deploy.yml` |
+| App-component (inway-upstream) | `magazijna` (cross-project via ingress-URL) | repo B `deploy.yml` |
 | Dienst-naam in de directory | `berichtenmagazijn` | dit ontwerp |
 | FSC-images (pin) | `v1.43.7` (manager/inway/controller/directory-ui) | repo A |
 | manager-wrapper-image | `ghcr.io/minbzk/moza-fsc-testnet/manager-migrate:<tag>` | repo A |
@@ -63,8 +72,9 @@ uitbreiding), txlog-hardening/e2e-verantwoording (#728), en het echte data-pad d
 ## Architectuur
 
 Gespiegeld op repo A's `example-provider`. Per peer een eigen set FSC-componenten; de
-magazijn-peer draait **in hetzelfde ZAD-project als de magazijn-app** (mpfm-w3h) zodat de inway
-de app via intra-project-DNS bereikt.
+magazijn-peer draait **in een eigen ZAD-project `mpfoa-e01`** (project-isolatie). De
+`magazijna`-app draait apart in `mpfm-w3h`; de inway bereikt die **cross-project via de
+ingress-URL** (https, :443), niet via intra-project-DNS.
 
 ### Componenten van de provider-peer
 
@@ -110,36 +120,38 @@ magazijn-a                                   centrale kern (directory)
 1. **Lokale compose-proof** (mirror example-provider, echte OIN + dienst `berichtenmagazijn`):
    `smoke-announce.sh` + een discover-check groen. Bewijst AC-3 en AC-4 lokaal.
 2. **ZAD** — nieuw `upsert-peer.sh` (er is nog géén peer-ZAD-deploy in repo A) + cert-attachments,
-   componenten in mpfm-w3h, inway → `magazijna`. Bewijst alle vier AC's op de echte directory.
+   componenten in `mpfoa-e01`, inway → `magazijna` (cross-project). Bewijst alle vier AC's op de echte directory.
 
 ## Acceptatiecriteria (uit #780) → dekking
 
 | AC | Gedekt door |
 |----|-------------|
-| Magazijn-peer (echte OIN) draait naast de app: manager + inway + controller + DB (ZAD, project-isolatie) | Fase 2 (ZAD-upsert in mpfm-w3h) |
+| Magazijn-peer (echte OIN) draait naast de app: manager + inway + controller + DB (ZAD, project-isolatie) | Fase 2 (ZAD-upsert in `mpfoa-e01`) |
 | Peer verkrijgt group-cert via het cert-portal van repo A | Cert-portal lokaal aangetoond + bewezen `issue.sh`+attachment-pad (zie bevinding) |
 | Peer meldt zich aan bij de directory (announce) | `smoke-announce.sh` (lokaal + ZAD) |
 | `berichtenmagazijn` gepubliceerd + vindbaar in de directory | `publish-service.sh` + discover-check (lokaal + ZAD) |
 
 ## Open punten (genoteerd, niet-blokkerend)
 
-- **Peer-topologie op ZAD (clobber-veilig):** de peer draait in een **eigen, vaste deployment
-  `peer`** binnen `mpfm-w3h`, los van de app-deployments (`test`/`pr-<n>`) die `deploy.yml`
-  beheert. Verschillende deployment-namen → geen wederzijds overschrijven van componenten. Eén
-  vaste `peer`-deployment = één aanmelding van de federatie-OIN (singleton). De inway bereikt
-  `magazijna` **cross-deployment via de ingress-URL** (`https://magazijna-<deployment>-mpfm-w3h.<base-domain>`,
-  https/:443) i.p.v. intra-deployment DNS — dit lost het oude "intra-project-DNS-vorm/poort"-punt
-  op. De `zad-deploy-peer.yml`-workflow deployt op elke PR-push naar deployment `peer`.
+- **Peer-topologie op ZAD (clobber-veilig via project-isolatie):** de peer draait in een **eigen
+  ZAD-project `mpfoa-e01`**, los van het app-project `mpfm-w3h` dat `deploy.yml` beheert. Er is dus
+  geen app-deployment om te overschrijven. Binnen `mpfoa-e01` draait de peer in de deployment
+  `test` = één aanmelding van de federatie-OIN (singleton). De inway bereikt `magazijna`
+  **cross-project via de ingress-URL** (`https://magazijna-<app-deployment>-mpfm-w3h.<base-domain>`,
+  https/:443). Eigen project betekent ook een **eigen ZAD-API-key** (`ZAD_API_KEY_FSCORGA`). De
+  raw v2-API maakt geen nieuwe deployments; `test` is doorgaans het project-default en bestaat al
+  (anders eenmalig leeg in de UI aanmaken). De `zad-deploy-peer.yml`-workflow deployt op elke
+  PR-push naar `mpfoa-e01`/`test`.
 - **Interne-mTLS SAN — OPGELOST (least-privilege).** Elk internal-cert draagt nu zijn **eigen
-  concrete** ZAD-hostnaam (`mgzmgr-peer-mpfm-w3h.<base-domain>` op de manager, `mgzctl-…` op de
+  concrete** ZAD-hostnaam (`mgzmgr-test-mpfoa-e01.<base-domain>` op de manager, `mgzctl-…` op de
   controller, `mgzinway-…` op de inway) — géén domein-brede wildcard, zodat de certs niet voor het
-  hele gedeelde Rijks-hosting-domein geldig zijn. Bewezen met `verify.sh` + `openssl`. Verhuist de
-  peer later naar de `test`-deployment, dan moeten de `-test-`-hostnamen als SAN toegevoegd worden
-  (her-uitgifte + her-upload).
+  hele gedeelde Rijks-hosting-domein geldig zijn. Bewezen met `verify.sh` + `openssl`. Verandert het
+  project of de deployment-naam, dan moeten de bijbehorende hostnamen als SAN opnieuw uitgegeven en
+  geüpload worden.
 - **Interne-mTLS poort/routering op ZAD — nog open, verifiëren bij de eerste apply.** De interne
   FSC-API's luisteren op `:9443`/`:9444`, maar een ZAD-component exposet via zijn `:443`-ingress
   precies één containerpoort (mgzctl→8080, mgzmgr/mgzinway→8443). Een call naar
-  `mgzctl-peer-mpfm-w3h.<base-domain>:443` raakt dus die éne ingress-poort, niet `:9443`. De
+  `mgzctl-test-mpfoa-e01.<base-domain>:443` raakt dus die éne ingress-poort, niet `:9443`. De
   registratiecalls (`CONTROLLER_REGISTRATION_API_ADDRESS`, `MANAGER_ADDRESS_INTERNAL`,
   `MANAGER_INTERNAL_UNAUTHENTICATED_ADDRESS`) moeten waarschijnlijk over **intra-deployment DNS +
   de echte interne poorten** lopen i.p.v. de ingress — bevestigen zodra de certs gemount zijn en

--- a/docs/plans/2026-07-08-magazijn-provider-peer-fsc-design.md
+++ b/docs/plans/2026-07-08-magazijn-provider-peer-fsc-design.md
@@ -1,0 +1,131 @@
+**Status:** Concept
+
+# Ontwerp — Magazijn-provider-peer aansluiten op de FSC-federatie (#780)
+
+> Toespitsing van **Spec B** (`moza-fsc-testnet:docs/superpowers/specs/2026-06-29-fbs-peers-onboarding-design.md`)
+> op het provider-deel, verhuisd naar repo B (`moza-poc-fbs-berichtenbox`). Verwant:
+> [Spec A](https://github.com/MinBZK/moza-fsc-testnet) (generieke infra), epic
+> [#737](https://github.com/MinBZK/MijnOverheidZakelijk/issues/737), issue
+> [#780](https://github.com/MinBZK/MijnOverheidZakelijk/issues/780).
+
+## Aanleiding
+
+`moza-fsc-testnet` (repo A) levert de generieke FSC-infra: de **directory** (group-anker), de
+group-config/CA en een neutrale `example-provider`-peer als kopieer-template. De FBS-PoC moet
+zich als **consument van die infra** aansluiten. Deze eerste stap (#780) zet de **magazijn-kant
+als aanbiedende organisatie** neer: een provider-peer (manager + inway + controller + DB) die
+co-located bij de magazijn-app draait en `berichtenmagazijn` als dienst in de directory
+publiceert.
+
+De uitvraag-consumer-peer (#725) en het omleiden van `berichtenuitvraag` via de outway (#726)
+vallen **buiten** dit ontwerp; die volgen apart onder epic #737.
+
+## Bevinding cert-portal (onderzocht vóór dit ontwerp)
+
+De AC "Peer verkrijgt group-cert via het cert-portal van repo A" veronderstelt een draaiend
+cert-portal. Onderzoek in repo A wijst uit:
+
+- De ZAD-directory-deploy (`deploy/zad/upsert-directory.sh`) rolt **alleen** `dirmgr` (manager)
+  + `dirui` (directory-ui) uit. Er is **geen** `ca-cfssl`/`ca-certportal`-component of
+  -workflow op ZAD.
+- In Spec A staat het portal-pad expliciet als *lokaal aangetoond*, en "ca-cfssl op ZAD" als
+  **open punt**.
+- Het bewezen cert-pad waarmee de directory zélf op ZAD draait is: certs lokaal genereren
+  (`pki/issue.sh`, cfssl) → `pki/zad-bundle.sh` → als **ZAD-attachment** mounten (UI-stap).
+
+**Gevolg voor dit ontwerp:** we volgen datzelfde bewezen pad (lokaal `issue.sh` + ZAD-attachment)
+en tonen de portal-flow **lokaal** aan (ca-cfssl + ca-certportal, cert voor de magazijn-OIN). Zo
+is de AL functioneel gedekt zonder te blokkeren op een portal-op-ZAD; dat portal-op-ZAD is een
+repo-A-vervolg, geen onderdeel van #780.
+
+## Scope
+
+**In scope:** de provider-peer voor **magazijn-a** (echte OIN `00000001003214345000`).
+
+**Buiten scope:** consumer/outway (#725/#726), magazijn-b (`00000001823288444000`, latere
+uitbreiding), txlog-hardening/e2e-verantwoording (#728), en het echte data-pad dóór de inway
+(#728). De bestaande `berichtenmagazijn`-app verandert niet (config-only ervoor).
+
+## Bekende parameters
+
+| Parameter | Waarde | Herkomst |
+|-----------|--------|----------|
+| Peer-OIN (= Peer ID = `magazijnId`) | `00000001003214345000` | `services/berichtenmagazijn/.../application.properties:138` |
+| Peer-naam | `magazijn-a` | conventie repo B (geen `example-*`) |
+| Group ID | `moza-fbs-test` | repo A directory-deploy |
+| Directory-OIN | `00000000000000000010` | repo A directory-deploy |
+| ZAD-project (co-located) | `magazijnen` / `mpfm-w3h` | repo B `deploy.yml` |
+| App-component (inway-upstream) | `magazijna` | repo B `deploy.yml` |
+| Dienst-naam in de directory | `berichtenmagazijn` | dit ontwerp |
+| FSC-images (pin) | `v1.43.7` (manager/inway/controller/directory-ui) | repo A |
+| manager-wrapper-image | `ghcr.io/minbzk/moza-fsc-testnet/manager-migrate:<tag>` | repo A |
+
+## Architectuur
+
+Gespiegeld op repo A's `example-provider`. Per peer een eigen set FSC-componenten; de
+magazijn-peer draait **in hetzelfde ZAD-project als de magazijn-app** (mpfm-w3h) zodat de inway
+de app via intra-project-DNS bereikt.
+
+### Componenten van de provider-peer
+
+| Component | ZAD-ref | Rol |
+|-----------|---------|-----|
+| manager | `mgzmgr` | announce bij de directory + ServicePublicationGrant; `manager-migrate`-wrapper migreert de peer-DB bij boot |
+| controller | `mgzctl` | dienst `berichtenmagazijn` aanmaken (Administration-API, `AUTHN_TYPE=none`) + beheer-UI + inway-registratie (Registration-API) |
+| inway | `mgzinway` | ingress vóór de `magazijna`-app-component (intra-project DNS); registreert bij de controller |
+| DB | ZAD managed Postgres (`postgresql-database`-service) | system-of-record manager + controller |
+
+`txlog` draait lokaal mee (mirror van example-provider) maar wordt **niet** gehard voor #780;
+volledige tx-logging is #728. Op ZAD blijft `TX_LOG_API_ADDRESS` in eerste ronde leeg/minimaal.
+
+### Certificaat-topologie (per endpoint, uit repo A)
+
+Elk endpoint (`manager`/`controller`/`inway`/`txlog`) krijgt twee ketens:
+
+- **GROUP** (extern, door de group-intermediate getekend) → `TLS_GROUP_CERT/KEY` (+ hergebruikt
+  voor `TLS_GROUP_TOKEN_*` en `TLS_GROUP_CONTRACT_*`). De OIN staat 1:1 in `serialnumber` van de
+  `csr.json`.
+- **INTERNAL** (per-peer self-signed CA) → `TLS_CERT/KEY` (+ `TLS_INTERNAL_UNAUTHENTICATED_*`),
+  voor de mTLS tussen manager ↔ controller ↔ inway.
+
+### Onboarding-flow (wat de smokes bewijzen)
+
+```text
+magazijn-a                                   centrale kern (directory)
+  controller ──CreateService(admin-API)───►  (eigen DB)
+  manager ───announce────────────────────►  directory-manager (peers.peers, :443)
+  manager ───ServicePublicationGrant─────►  directory-manager ──auto-sign──► directory (services)
+  inway ────GetService(registration-API)─►  controller
+```
+
+1. **Cert** — group-cert voor de magazijn-OIN (lokaal `issue.sh`; portal lokaal aangetoond).
+2. **Deploy** — peer-componenten naast `magazijna` (lokaal compose → ZAD-upsert).
+3. **Announce** — manager verschijnt in `peers.peers` met `manager_address` op `:443`.
+4. **Publiceren** — controller `CreateService(berichtenmagazijn, <inway-address>, <upstream>)`
+   → manager dient ServicePublicationGrant in → directory auto-signt
+   (`AUTO_SIGN_GRANTS=servicePublication`) → dienst vindbaar.
+
+## Levering — twee fasen
+
+1. **Lokale compose-proof** (mirror example-provider, echte OIN + dienst `berichtenmagazijn`):
+   `smoke-announce.sh` + een discover-check groen. Bewijst AC-3 en AC-4 lokaal.
+2. **ZAD** — nieuw `upsert-peer.sh` (er is nog géén peer-ZAD-deploy in repo A) + cert-attachments,
+   componenten in mpfm-w3h, inway → `magazijna`. Bewijst alle vier AC's op de echte directory.
+
+## Acceptatiecriteria (uit #780) → dekking
+
+| AC | Gedekt door |
+|----|-------------|
+| Magazijn-peer (echte OIN) draait naast de app: manager + inway + controller + DB (ZAD, project-isolatie) | Fase 2 (ZAD-upsert in mpfm-w3h) |
+| Peer verkrijgt group-cert via het cert-portal van repo A | Cert-portal lokaal aangetoond + bewezen `issue.sh`+attachment-pad (zie bevinding) |
+| Peer meldt zich aan bij de directory (announce) | `smoke-announce.sh` (lokaal + ZAD) |
+| `berichtenmagazijn` gepubliceerd + vindbaar in de directory | `publish-service.sh` + discover-check (lokaal + ZAD) |
+
+## Open punten (genoteerd, niet-blokkerend)
+
+- **Intra-project-DNS-vorm** van de `magazijna`-upstream in mpfm-w3h (bare servicenaam vs.
+  koppelteken-vorm) — verifiëren bij de ZAD-upsert (Fase 3).
+- **Echte magazijn-OIN in een publiek repo** — stond al in `application.properties`; akkoord,
+  hier expliciet genoteerd.
+- **Cert-portal op ZAD** — repo-A-vervolg; buiten #780.
+- **txlog-hardening / e2e-data-pad** — #728.

--- a/docs/plans/2026-07-08-magazijn-provider-peer-fsc-design.md
+++ b/docs/plans/2026-07-08-magazijn-provider-peer-fsc-design.md
@@ -130,18 +130,20 @@ magazijn-a                                   centrale kern (directory)
   `magazijna` **cross-deployment via de ingress-URL** (`https://magazijna-<deployment>-mpfm-w3h.<base-domain>`,
   https/:443) i.p.v. intra-deployment DNS — dit lost het oude "intra-project-DNS-vorm/poort"-punt
   op. De `zad-deploy-peer.yml`-workflow deployt op elke PR-push naar deployment `peer`.
-- **Interne-mTLS-adressen op ZAD (SAN + poort) — vóór de eerste `apply` oplossen.** De
-  manager↔controller↔inway-registratiecalls (`CONTROLLER_REGISTRATION_API_ADDRESS`,
-  `MANAGER_ADDRESS_INTERNAL`, `MANAGER_INTERNAL_UNAUTHENTICATED_ADDRESS`) lopen over de
-  INTERNAL-PKI en verifiëren de hostname. In `upsert-peer.sh` wijzen ze naar de ZAD-ingress-
-  hostnamen (`mgz{ctl,mgr}-$DEPLOYMENT_NAME-mpfm-w3h.<base-domain>:443`), maar (a) die naam zit
-  níét in de magazijn-a internal-cert-SANs (alleen `*.magazijn-a.fsc-test.local`), en (b) de
-  interne API's luisteren op `:9443`/`:9444`, terwijl alleen de externe/data-poorten (`:8443`)
-  passthrough krijgen. Zonder oplossing falen de registratie-handshakes bij boot (TLS-hostname-
-  mismatch en/of verkeerde poort) → de inway registreert niet en er publiceert geen dienst.
-  Repo A's directory-deploy (alleen dirmgr+dirui) oefent dit pad niet, dus het is onbewezen.
-  Oplossingsrichting: internal-cert-SANs uitbreiden met de ZAD-hostnamen (of een intra-project-
-  DNS-alias op `.fsc-test.local` gebruiken) én de interne poorten correct routeren/exposen.
+- **Interne-mTLS SAN — OPGELOST.** De internal-certs van manager/controller/inway dragen nu de
+  ZAD-wildcard-SAN `*.rig.prd1.gn2.quattro.rijksapps.nl` (naast `*.magazijn-a.fsc-test.local`),
+  zodat hostname-verificatie op de ZAD-ingress-hostnamen slaagt. Bewezen met `verify.sh` +
+  `openssl` (SAN aanwezig). Zelfde aanpak als repo A's directory-cert; dekt ook een latere
+  verhuizing naar de `test`-deployment.
+- **Interne-mTLS poort/routering op ZAD — nog open, verifiëren bij de eerste apply.** De interne
+  FSC-API's luisteren op `:9443`/`:9444`, maar een ZAD-component exposet via zijn `:443`-ingress
+  precies één containerpoort (mgzctl→8080, mgzmgr/mgzinway→8443). Een call naar
+  `mgzctl-peer-mpfm-w3h.<base-domain>:443` raakt dus die éne ingress-poort, niet `:9443`. De
+  registratiecalls (`CONTROLLER_REGISTRATION_API_ADDRESS`, `MANAGER_ADDRESS_INTERNAL`,
+  `MANAGER_INTERNAL_UNAUTHENTICATED_ADDRESS`) moeten waarschijnlijk over **intra-deployment DNS +
+  de echte interne poorten** lopen i.p.v. de ingress — bevestigen zodra de certs gemount zijn en
+  de pods booten (de mgzinway/mgzctl-logs tonen of de registratie de juiste poort bereikt). Als
+  het intra-deployment DNS wordt, verhuizen die SANs mee naar de intra-DNS-namen.
 - **Echte magazijn-OIN in een publiek repo** — stond al in `application.properties`; akkoord,
   hier expliciet genoteerd.
 - **Cert-portal op ZAD** — repo-A-vervolg; buiten #780.

--- a/docs/plans/2026-07-08-magazijn-provider-peer-fsc-design.md
+++ b/docs/plans/2026-07-08-magazijn-provider-peer-fsc-design.md
@@ -123,8 +123,13 @@ magazijn-a                                   centrale kern (directory)
 
 ## Open punten (genoteerd, niet-blokkerend)
 
-- **Intra-project-DNS-vorm** van de `magazijna`-upstream in mpfm-w3h (bare servicenaam vs.
-  koppelteken-vorm) — verifiëren bij de ZAD-upsert (Fase 3).
+- **Peer-topologie op ZAD (clobber-veilig):** de peer draait in een **eigen, vaste deployment
+  `peer`** binnen `mpfm-w3h`, los van de app-deployments (`test`/`pr-<n>`) die `deploy.yml`
+  beheert. Verschillende deployment-namen → geen wederzijds overschrijven van componenten. Eén
+  vaste `peer`-deployment = één aanmelding van de federatie-OIN (singleton). De inway bereikt
+  `magazijna` **cross-deployment via de ingress-URL** (`https://magazijna-<deployment>-mpfm-w3h.<base-domain>`,
+  https/:443) i.p.v. intra-deployment DNS — dit lost het oude "intra-project-DNS-vorm/poort"-punt
+  op. De `zad-deploy-peer.yml`-workflow deployt op elke PR-push naar deployment `peer`.
 - **Interne-mTLS-adressen op ZAD (SAN + poort) — vóór de eerste `apply` oplossen.** De
   manager↔controller↔inway-registratiecalls (`CONTROLLER_REGISTRATION_API_ADDRESS`,
   `MANAGER_ADDRESS_INTERNAL`, `MANAGER_INTERNAL_UNAUTHENTICATED_ADDRESS`) lopen over de

--- a/docs/plans/2026-07-08-magazijn-provider-peer-fsc-design.md
+++ b/docs/plans/2026-07-08-magazijn-provider-peer-fsc-design.md
@@ -153,14 +153,15 @@ magazijn-a                                   centrale kern (directory)
   `TX_LOG_API_ADDRESS` leeg is. De eerdere aanname (txlog op ZAD leeglaten tot #728) klopt dus niet;
   er draait nu een vierde component `mgztxlog` (txlog-api-image + eigen managed Postgres, internal-
   PKI mTLS), en mgzmgr/mgzinway wijzen ernaar. txlog-*hardening* / het echte data-pad blijft #728.
-- **ZAD past component-config alleen bij CREATIE toe, niet bij re-POST — OPGELOST in de aanpak.**
-  Een `TX_LOG_API_ADDRESS` die pas in een tweede deploy aan de aliases werd toegevoegd bereikte de
-  al-bestaande manager niet (bleef `tx-log-api-address not set`), terwijl config die er bij aanmaak
-  in zat wél werkte. Gevolg: (1) om de config van een bestaande component te wijzigen moet die eerst
-  in de UI verwijderd worden zodat de volgende apply 'm opnieuw aanmaakt; (2) omdat de deployment
-  vast is (`test`/`mpfoa-e01`) gebruiken we ZAD's `$DEPLOYMENT_NAME`-substitutie niet meer — bash
-  lost alle inter-component-hostnamen concreet op en zet ze in `env_vars`; alleen de managed-Postgres-
-  DSN (`$DATABASE_*`) blijft in `aliases`.
+- **Component-config liep één deploy achter — OPGELOST met een re-roll.** Onze apply deed éérst
+  `:upsert-deployment` (rolt de pods uit) en pas dáárna `POST /components` (zet env/aliases). Elke
+  run rolde dus met de config van de vórige run; een `TX_LOG_API_ADDRESS` die in de tweede deploy
+  werd gezet bereikte de manager pas een deploy later (bleef `tx-log-api-address not set`). Fix: ná
+  de component-POSTs nóg één `:upsert-deployment`, zodat de rollout met de verse config draait —
+  géén component-verwijdering nodig, dus de cert-attachments (UI-only per component) blijven staan.
+  Daarnaast: omdat de deployment vast is (`test`/`mpfoa-e01`) gebruiken we ZAD's `$DEPLOYMENT_NAME`-
+  substitutie niet meer — bash lost alle inter-component-hostnamen concreet op in `env_vars`; alleen
+  de managed-Postgres-DSN (`$DATABASE_*`) blijft in `aliases`.
 - **Interne-mTLS poort/routering op ZAD — nog open, verifiëren bij de eerste apply.** De interne
   FSC-API's luisteren op `:9443`/`:9444`, maar een ZAD-component exposet via zijn `:443`-ingress
   precies één containerpoort (mgzctl→8080, mgzmgr/mgzinway→8443). Een call naar

--- a/docs/plans/2026-07-08-magazijn-provider-peer-fsc-design.md
+++ b/docs/plans/2026-07-08-magazijn-provider-peer-fsc-design.md
@@ -148,12 +148,11 @@ magazijn-a                                   centrale kern (directory)
   hele gedeelde Rijks-hosting-domein geldig zijn. Bewezen met `verify.sh` + `openssl`. Verandert het
   project of de deployment-naam, dan moeten de bijbehorende hostnamen als SAN opnieuw uitgegeven en
   geüpload worden.
-- **ZAD past `env_vars` niet toe, alleen `aliases` — OPGELOST.** Bij de eerste echte apply crashte
-  de manager op `required flag(s) ... not set` voor exact de keys uit de `env_vars`-blob
-  (listen-addresses + alle TLS-paden), terwijl de `aliases`-keys (self-address, DSN, ...) én de
-  migratie-DSN wél aankwamen — migrate en serve delen dezelfde proces-env, dus de env_vars-waarden
-  waren aantoonbaar afwezig in de container. `upsert-peer.sh` spiegelt daarom ALLE component-config
-  in de `aliases`-blob (`MGZ*_ALIASES_FULL`); `env_vars` blijft als plain-subset staan (idempotent).
+- **txlog is verplicht voor een niet-directory manager — toegevoegd.** OpenFSC v1.43.7 faalt hard
+  op `tx-log-api-address is required when the manager does not function as the directory` als
+  `TX_LOG_API_ADDRESS` leeg is. De eerdere aanname (txlog op ZAD leeglaten tot #728) klopt dus niet;
+  er draait nu een vierde component `mgztxlog` (txlog-api-image + eigen managed Postgres, internal-
+  PKI mTLS), en mgzmgr/mgzinway wijzen ernaar. txlog-*hardening* / het echte data-pad blijft #728.
 - **Interne-mTLS poort/routering op ZAD — nog open, verifiëren bij de eerste apply.** De interne
   FSC-API's luisteren op `:9443`/`:9444`, maar een ZAD-component exposet via zijn `:443`-ingress
   precies één containerpoort (mgzctl→8080, mgzmgr/mgzinway→8443). Een call naar

--- a/docs/plans/2026-07-08-magazijn-provider-peer-fsc-design.md
+++ b/docs/plans/2026-07-08-magazijn-provider-peer-fsc-design.md
@@ -130,11 +130,12 @@ magazijn-a                                   centrale kern (directory)
   `magazijna` **cross-deployment via de ingress-URL** (`https://magazijna-<deployment>-mpfm-w3h.<base-domain>`,
   https/:443) i.p.v. intra-deployment DNS — dit lost het oude "intra-project-DNS-vorm/poort"-punt
   op. De `zad-deploy-peer.yml`-workflow deployt op elke PR-push naar deployment `peer`.
-- **Interne-mTLS SAN — OPGELOST.** De internal-certs van manager/controller/inway dragen nu de
-  ZAD-wildcard-SAN `*.rig.prd1.gn2.quattro.rijksapps.nl` (naast `*.magazijn-a.fsc-test.local`),
-  zodat hostname-verificatie op de ZAD-ingress-hostnamen slaagt. Bewezen met `verify.sh` +
-  `openssl` (SAN aanwezig). Zelfde aanpak als repo A's directory-cert; dekt ook een latere
-  verhuizing naar de `test`-deployment.
+- **Interne-mTLS SAN — OPGELOST (least-privilege).** Elk internal-cert draagt nu zijn **eigen
+  concrete** ZAD-hostnaam (`mgzmgr-peer-mpfm-w3h.<base-domain>` op de manager, `mgzctl-…` op de
+  controller, `mgzinway-…` op de inway) — géén domein-brede wildcard, zodat de certs niet voor het
+  hele gedeelde Rijks-hosting-domein geldig zijn. Bewezen met `verify.sh` + `openssl`. Verhuist de
+  peer later naar de `test`-deployment, dan moeten de `-test-`-hostnamen als SAN toegevoegd worden
+  (her-uitgifte + her-upload).
 - **Interne-mTLS poort/routering op ZAD — nog open, verifiëren bij de eerste apply.** De interne
   FSC-API's luisteren op `:9443`/`:9444`, maar een ZAD-component exposet via zijn `:443`-ingress
   precies één containerpoort (mgzctl→8080, mgzmgr/mgzinway→8443). Een call naar

--- a/docs/plans/2026-07-08-magazijn-provider-peer-fsc-design.md
+++ b/docs/plans/2026-07-08-magazijn-provider-peer-fsc-design.md
@@ -153,6 +153,14 @@ magazijn-a                                   centrale kern (directory)
   `TX_LOG_API_ADDRESS` leeg is. De eerdere aanname (txlog op ZAD leeglaten tot #728) klopt dus niet;
   er draait nu een vierde component `mgztxlog` (txlog-api-image + eigen managed Postgres, internal-
   PKI mTLS), en mgzmgr/mgzinway wijzen ernaar. txlog-*hardening* / het echte data-pad blijft #728.
+- **ZAD past component-config alleen bij CREATIE toe, niet bij re-POST — OPGELOST in de aanpak.**
+  Een `TX_LOG_API_ADDRESS` die pas in een tweede deploy aan de aliases werd toegevoegd bereikte de
+  al-bestaande manager niet (bleef `tx-log-api-address not set`), terwijl config die er bij aanmaak
+  in zat wél werkte. Gevolg: (1) om de config van een bestaande component te wijzigen moet die eerst
+  in de UI verwijderd worden zodat de volgende apply 'm opnieuw aanmaakt; (2) omdat de deployment
+  vast is (`test`/`mpfoa-e01`) gebruiken we ZAD's `$DEPLOYMENT_NAME`-substitutie niet meer — bash
+  lost alle inter-component-hostnamen concreet op en zet ze in `env_vars`; alleen de managed-Postgres-
+  DSN (`$DATABASE_*`) blijft in `aliases`.
 - **Interne-mTLS poort/routering op ZAD — nog open, verifiëren bij de eerste apply.** De interne
   FSC-API's luisteren op `:9443`/`:9444`, maar een ZAD-component exposet via zijn `:443`-ingress
   precies één containerpoort (mgzctl→8080, mgzmgr/mgzinway→8443). Een call naar

--- a/docs/plans/2026-07-08-magazijn-provider-peer-fsc-design.md
+++ b/docs/plans/2026-07-08-magazijn-provider-peer-fsc-design.md
@@ -148,6 +148,12 @@ magazijn-a                                   centrale kern (directory)
   hele gedeelde Rijks-hosting-domein geldig zijn. Bewezen met `verify.sh` + `openssl`. Verandert het
   project of de deployment-naam, dan moeten de bijbehorende hostnamen als SAN opnieuw uitgegeven en
   geüpload worden.
+- **ZAD past `env_vars` niet toe, alleen `aliases` — OPGELOST.** Bij de eerste echte apply crashte
+  de manager op `required flag(s) ... not set` voor exact de keys uit de `env_vars`-blob
+  (listen-addresses + alle TLS-paden), terwijl de `aliases`-keys (self-address, DSN, ...) én de
+  migratie-DSN wél aankwamen — migrate en serve delen dezelfde proces-env, dus de env_vars-waarden
+  waren aantoonbaar afwezig in de container. `upsert-peer.sh` spiegelt daarom ALLE component-config
+  in de `aliases`-blob (`MGZ*_ALIASES_FULL`); `env_vars` blijft als plain-subset staan (idempotent).
 - **Interne-mTLS poort/routering op ZAD — nog open, verifiëren bij de eerste apply.** De interne
   FSC-API's luisteren op `:9443`/`:9444`, maar een ZAD-component exposet via zijn `:443`-ingress
   precies één containerpoort (mgzctl→8080, mgzmgr/mgzinway→8443). Een call naar

--- a/docs/plans/2026-07-08-magazijn-provider-peer-fsc-design.md
+++ b/docs/plans/2026-07-08-magazijn-provider-peer-fsc-design.md
@@ -125,6 +125,18 @@ magazijn-a                                   centrale kern (directory)
 
 - **Intra-project-DNS-vorm** van de `magazijna`-upstream in mpfm-w3h (bare servicenaam vs.
   koppelteken-vorm) — verifiëren bij de ZAD-upsert (Fase 3).
+- **Interne-mTLS-adressen op ZAD (SAN + poort) — vóór de eerste `apply` oplossen.** De
+  manager↔controller↔inway-registratiecalls (`CONTROLLER_REGISTRATION_API_ADDRESS`,
+  `MANAGER_ADDRESS_INTERNAL`, `MANAGER_INTERNAL_UNAUTHENTICATED_ADDRESS`) lopen over de
+  INTERNAL-PKI en verifiëren de hostname. In `upsert-peer.sh` wijzen ze naar de ZAD-ingress-
+  hostnamen (`mgz{ctl,mgr}-$DEPLOYMENT_NAME-mpfm-w3h.<base-domain>:443`), maar (a) die naam zit
+  níét in de magazijn-a internal-cert-SANs (alleen `*.magazijn-a.fsc-test.local`), en (b) de
+  interne API's luisteren op `:9443`/`:9444`, terwijl alleen de externe/data-poorten (`:8443`)
+  passthrough krijgen. Zonder oplossing falen de registratie-handshakes bij boot (TLS-hostname-
+  mismatch en/of verkeerde poort) → de inway registreert niet en er publiceert geen dienst.
+  Repo A's directory-deploy (alleen dirmgr+dirui) oefent dit pad niet, dus het is onbewezen.
+  Oplossingsrichting: internal-cert-SANs uitbreiden met de ZAD-hostnamen (of een intra-project-
+  DNS-alias op `.fsc-test.local` gebruiken) én de interne poorten correct routeren/exposen.
 - **Echte magazijn-OIN in een publiek repo** — stond al in `application.properties`; akkoord,
   hier expliciet genoteerd.
 - **Cert-portal op ZAD** — repo-A-vervolg; buiten #780.

--- a/docs/plans/2026-07-08-magazijn-provider-peer-fsc-plan.md
+++ b/docs/plans/2026-07-08-magazijn-provider-peer-fsc-plan.md
@@ -1,0 +1,746 @@
+**Status:** Concept
+
+# Magazijn-provider-peer op de FSC-federatie — Implementatieplan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Een FSC provider-peer voor magazijn-a (manager + inway + controller + DB) die
+`berichtenmagazijn` als vindbare dienst in de FSC-directory publiceert — eerst lokaal bewezen
+via docker-compose, daarna uitgerold op ZAD naast de bestaande magazijn-app.
+
+**Architecture:** Kopieer-template uit repo A (`moza-fsc-testnet` `example-provider`),
+gesubstitueerd naar de echte magazijn-OIN en dienst `berichtenmagazijn`. Nieuwe artefacten in
+een `fsc/`-boom in repo B. Control-plane only (announce + dienst-publicatie); het data-pad dóór
+de inway is #728. Cert-pad: lokaal cfssl `issue.sh` + ZAD-attachment (het cert-portal draait niet
+op ZAD — zie het bijbehorende design-document).
+
+**Tech Stack:** OpenFSC (manager/inway/controller/directory-ui `v1.43.7`), cfssl (PKI), Docker
+Compose + HAProxy (lokale SNI-mesh), Postgres 17, ZAD Operations Manager v2-API (`bash` + `curl`
++ `jq`), GitHub Actions (SHA-pinned, `zad-actions`).
+
+## Global Constraints
+
+- **Peer-OIN = Peer ID = `magazijnId`:** `00000001003214345000`. Staat 1:1 in het veld
+  `serialnumber` van élke `csr.json` van deze peer. Nooit een andere waarde.
+- **Peer-naam:** `magazijn-a` (nooit `example-*`; repo B verbiedt de neutrale template-namen).
+- **Group ID:** `moza-fbs-test`. **Directory-OIN:** `00000000000000000010`.
+- **ZAD-project:** `magazijnen` / id `mpfm-w3h` (co-located met de `magazijna`-app-component).
+- **Dienst-naam:** `berichtenmagazijn`.
+- **Image-pins:** FSC-images op `v1.43.7`; manager-wrapper
+  `ghcr.io/minbzk/moza-fsc-testnet/manager-migrate:v1.43.7`. Nooit `:latest`.
+- **Bestandsnamen:** geen spaties; `kebab-case`/`snake_case` (scripts/config) of `PascalCase`
+  (bronnen). Shellscripts `set -euo pipefail`.
+- **Taal:** comments/docs Nederlands; vaste FSC-idiomen (inway, outway, announce, grant, peer)
+  Engels. Comment het *waarom*, niet het *wat*.
+- **Git:** feature branch `feature/magazijn-provider-peer-fsc`, PR (nooit direct naar `main`,
+  nooit een reviewer toevoegen; draft zolang CODEOWNERS bestaat).
+- **Geen echte persoonsgegevens/BSN** in deze onboarding; `berichtenmagazijn`-upstream is
+  control-plane (CreateService registreert alleen adres + endpoint_url).
+
+## Bronbestanden in repo A (kopieer-template)
+
+Repo B checkt repo A niet uit. Haal een bestand op met:
+
+```bash
+gh api "repos/MinBZK/moza-fsc-testnet/contents/<pad>" --jq '.content' | base64 -d > <doel>
+```
+
+Relevante paden: `pki/{init-ca.sh,issue.sh,verify.sh,zad-bundle.sh,config.json,internal-ca.json}`,
+`pki/peers/example-provider/{manager,controller,inway,txlog}/csr.json`,
+`deploy/local/{docker-compose.yaml,haproxy.cfg,postgres-init.sql,smoke-announce.sh,publish-service.sh,smoke-discover.sh,README.md}`,
+`deploy/zad/{upsert-directory.sh,manager-migrate/*}`.
+
+## Substitutie-tabel (repo A → repo B)
+
+Pas overal toe bij het kopiëren:
+
+| Repo A | Repo B |
+|--------|--------|
+| `example-provider` (naam/paden/hostnamen/aliases) | `magazijn-a` |
+| OIN `00000000000000000030` | `00000001003214345000` |
+| `example-service` | `berichtenmagazijn` |
+| `stub-upstream` als endpoint_url (lokaal) | blijft stub lokaal; op ZAD → `magazijna`-component |
+| DB-namen `fsc_example_provider` / `fsc_controller_example_provider` | `fsc_magazijn_a` / `fsc_controller_magazijn_a` |
+| consumer-services (`example-consumer`, `-org`, keycloak) | **weglaten** (buiten scope) |
+
+## File Structure (repo B, nieuw onder `fsc/`)
+
+- `fsc/pki/` — `init-ca.sh`, `issue.sh`, `verify.sh`, `zad-bundle.sh`, `config.json`,
+  `internal-ca.json`, `internal-ca` bundle, `group/` CA-materiaal (uit repo A group-config),
+  `peers/magazijn-a/{manager,controller,inway,txlog}/csr.json`. Output (`out/`, `internal/`,
+  `zad-upload/`) gitignored (privésleutels).
+- `fsc/deploy/local/` — `docker-compose.yaml`, `haproxy.cfg`, `postgres-init.sql`,
+  `smoke-announce.sh`, `publish-service.sh`, `smoke-discover.sh`, `.env.example`, `README.md`.
+- `fsc/deploy/zad/` — `upsert-peer.sh` (NIEUW), `cert-manifest.md` (attachment-runbook).
+- `.github/workflows/zad-deploy-peer.yml` — deploy-workflow (SHA-pinned).
+- `.gitignore` — regels voor `fsc/pki/{out,internal,zad-upload}` en `fsc/deploy/local/.env`.
+- `docs/plans/2026-07-08-magazijn-provider-peer-fsc-{design,plan}.md` — dit werk.
+
+---
+
+## Fase 1 — PKI voor magazijn-a
+
+### Task 1: PKI-scaffolding + CSR's met de echte OIN
+
+**Files:**
+- Create: `fsc/pki/{init-ca.sh,issue.sh,verify.sh,zad-bundle.sh,config.json,internal-ca.json}`
+- Create: `fsc/pki/group/` (root + intermediate CA-materiaal uit repo A's group-config)
+- Create: `fsc/pki/peers/magazijn-a/{manager,controller,inway,txlog}/csr.json`
+- Create: `.gitignore` (regels voor pki-output), `fsc/pki/README.md`
+
+**Interfaces:**
+- Produces: `fsc/pki/out/magazijn-a/<endpoint>/{cert,key}.pem` (GROUP-keten),
+  `fsc/pki/internal/magazijn-a/<endpoint>/{cert,key}.pem` + `internal/magazijn-a/ca/root.pem`
+  (INTERNAL-keten), na `issue.sh`. `<endpoint>` ∈ {manager, controller, inway, txlog}.
+
+- [ ] **Step 1: Haal de pki-scripts + group-CA op uit repo A**
+
+```bash
+mkdir -p fsc/pki/peers/magazijn-a
+for f in init-ca.sh issue.sh verify.sh zad-bundle.sh config.json internal-ca.json; do
+  gh api "repos/MinBZK/moza-fsc-testnet/contents/pki/$f" --jq '.content' | base64 -d > "fsc/pki/$f"
+done
+chmod +x fsc/pki/*.sh
+```
+
+Haal het group-CA-materiaal op zoals repo A het aanlevert (`pki/ca/` + group-config). Controleer
+in `fsc/pki/issue.sh` welke paden het verwacht (`ca/intermediate.pem`, `ca/intermediate-key.pem`)
+en leg dezelfde structuur onder `fsc/pki/`. Draai anders `init-ca.sh` om een test-CA te genereren.
+
+- [ ] **Step 2: Schrijf de vier `csr.json` met de echte OIN**
+
+Voor elk endpoint (`manager`, `controller`, `inway`, `txlog`) — voorbeeld `inway`
+(`fsc/pki/peers/magazijn-a/inway/csr.json`):
+
+```json
+{
+  "CN": "inway.magazijn-a.fsc-test.local",
+  "key": { "algo": "rsa", "size": 4096 },
+  "hosts": ["inway.magazijn-a.fsc-test.local"],
+  "serialnumber": "00000001003214345000",
+  "names": [{ "O": "magazijn-a", "C": "NL" }]
+}
+```
+
+Idem voor `manager`/`controller`/`txlog` (CN/hosts `<endpoint>.magazijn-a.fsc-test.local`,
+`serialnumber` = de OIN, `O` = `magazijn-a`).
+
+- [ ] **Step 3: `.gitignore` voor privésleutels**
+
+Voeg toe aan `.gitignore` (repo-root):
+
+```gitignore
+# FSC-peer certificaten (privésleutels — nooit committen)
+fsc/pki/out/
+fsc/pki/internal/
+fsc/pki/zad-upload/
+fsc/deploy/local/.env
+```
+
+- [ ] **Step 4: Genereer de certs en verifieer (dit is de "test")**
+
+```bash
+cd fsc/pki && ./issue.sh && ./verify.sh; cd -
+```
+
+Expected: `OK: group-certs in .../out, internal-certs in .../internal`, en `verify.sh` groen
+(keten valideert tegen de trust-anchor). Controleer dat de OIN in het cert zit:
+
+```bash
+openssl x509 -in fsc/pki/out/magazijn-a/inway/cert.pem -noout -subject | grep -o '00000001003214345000'
+```
+
+Expected: de OIN wordt geëchood (zit in `serialNumber` van het subject).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add fsc/pki .gitignore
+git commit -m "feat(fsc): PKI-scaffolding + CSR's magazijn-a (echte OIN)"
+```
+
+### Task 2: Cert-portal lokaal aantonen (AC-dekking "cert via cert-portal")
+
+**Files:**
+- Create: `fsc/pki/certportal-proof.md` (gedocumenteerde stappen + verificatie-commando's)
+
+**Interfaces:**
+- Consumes: `fsc/pki/` group-CA-materiaal uit Task 1.
+
+- [ ] **Step 1: Zoek repo A's portal-bewijs op als basis**
+
+```bash
+gh api "repos/MinBZK/moza-fsc-testnet/contents/docs/superpowers/specs/2026-06-29-fsc-generiek-provider-onboarding-design.md" \
+  --jq '.content' | base64 -d | sed -n '/Cert-portal-bewijs/,+8p'
+```
+
+Gebruik de `ca-cfssl` (`open-fsc-ca-cfssl-unsafe`, :8888) + `ca-certportal`
+(`open-fsc-ca-certportal`) images; de portal is een client van ca-cfssl (`--ca-host`) en tekent
+tegen dezelfde group-CA-config uit `fsc/pki/`.
+
+- [ ] **Step 2: Schrijf `certportal-proof.md`: portal starten + cert aanvragen voor de OIN**
+
+Documenteer concreet: start ca-cfssl + ca-certportal (met de `fsc/pki/` root+intermediate),
+vraag via de portal een group-cert aan voor test-OIN `00000001003214345000`, en toon dat het
+teruggegeven cert tegen de trust-anchor verifieert:
+
+```bash
+openssl verify -CAfile fsc/pki/group/root.pem <portal-cert>.pem   # Expected: OK
+openssl x509 -in <portal-cert>.pem -noout -subject | grep 00000001003214345000
+```
+
+- [ ] **Step 3: Voer de stappen uit en leg de output vast in het document**
+
+Run de gedocumenteerde stappen; plak de `openssl verify: OK`-output in `certportal-proof.md` als
+bewijs. Expected: portal geeft een geldig group-cert; `verify` = OK.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add fsc/pki/certportal-proof.md
+git commit -m "docs(fsc): cert-portal lokaal aangetoond voor magazijn-OIN"
+```
+
+---
+
+## Fase 2 — Lokale compose-proof (announce + publiceren)
+
+### Task 3: Docker-compose met directory + magazijn-a-peer
+
+**Files:**
+- Create: `fsc/deploy/local/{docker-compose.yaml,haproxy.cfg,postgres-init.sql,.env.example,README.md}`
+
+**Interfaces:**
+- Consumes: certs uit Task 1 (`fsc/pki/{out,internal}/...` gemount op `/pki:ro`).
+- Produces: draaiende containers `postgres`, `router`, `manager-directory`, `directory-ui`,
+  `migrate-magazijn-a`, `manager-magazijn-a`, `migrate-controller-magazijn-a`,
+  `controller-magazijn-a`, `txlog-magazijn-a`, `inway-magazijn-a`, `stub-upstream`, `toolbox`.
+  Service-hostnamen/aliases: `<endpoint>.magazijn-a.fsc-test.local`.
+
+- [ ] **Step 1: Haal repo A's lokale harness op**
+
+```bash
+mkdir -p fsc/deploy/local
+for f in docker-compose.yaml haproxy.cfg postgres-init.sql .env.example README.md; do
+  gh api "repos/MinBZK/moza-fsc-testnet/contents/deploy/local/$f" --jq '.content' | base64 -d \
+    > "fsc/deploy/local/$f"
+done
+```
+
+- [ ] **Step 2: Strip consumer + pas de substitutie-tabel toe**
+
+Verwijder uit `docker-compose.yaml` álle `*-example-consumer`-services, `keycloak`, en de
+`example-consumer`-aliassen/backends. Hernoem `example-provider` → `magazijn-a` overal
+(servicenamen, network-aliases, `SELF_ADDRESS`, `CONTROLLER_REGISTRATION_API_ADDRESS`,
+`MANAGER_INTERNAL_UNAUTHENTICATED_ADDRESS`, TLS-paden), en de DB-namen
+(`fsc_example_provider` → `fsc_magazijn_a`, `fsc_controller_example_provider` →
+`fsc_controller_magazijn_a`). Behoud de `manager-directory` + `directory-ui` (lokale directory om
+naar te announcen). Behoud `stub-upstream` als lokale inway-upstream (het echte data-pad is #728).
+
+Kernwaarden die per component blijven staan (mirror example-provider):
+`GROUP_ID=moza-fbs-test`, `DIRECTORY_PEER_ID=00000000000000000010`,
+`DIRECTORY_MANAGER_ADDRESS=https://directory.fsc-test.local:443`,
+manager `SELF_ADDRESS=https://magazijn-a.fsc-test.local:443`,
+inway `SELF_ADDRESS=https://inway.magazijn-a.fsc-test.local:443` + `NAME=magazijn-a-inway`,
+controller `MANAGER_ADDRESS_INTERNAL=https://manager.magazijn-a.fsc-test.local:9443` +
+`AUTHN_TYPE=none`.
+
+- [ ] **Step 3: `haproxy.cfg` — alleen directory + magazijn-a + inway-SNI**
+
+Vervang de backends door (verwijder de `ec`-backend):
+
+```haproxy
+frontend https_sni
+    bind *:443
+    tcp-request inspect-delay 5s
+    tcp-request content accept if { req_ssl_hello_type 1 }
+    use_backend dir       if { req_ssl_sni -i directory.fsc-test.local }
+    use_backend mgz       if { req_ssl_sni -i magazijn-a.fsc-test.local }
+    use_backend inway_mgz if { req_ssl_sni -i inway.magazijn-a.fsc-test.local }
+
+backend dir
+    server s1 manager-directory:8443
+backend mgz
+    server s1 manager-magazijn-a:8443
+backend inway_mgz
+    server s1 inway-magazijn-a:8443
+```
+
+Zet in de `router`-service de network-aliases: `directory.fsc-test.local`,
+`magazijn-a.fsc-test.local`, `inway.magazijn-a.fsc-test.local`.
+
+- [ ] **Step 4: Boot de stack (dit is de "test": komt alles gezond op?)**
+
+```bash
+cd fsc/deploy/local
+cp .env.example .env   # zet PKI_DIR=../../pki, HOST_UID=$(id -u), HOST_GID=$(id -g)
+docker compose up -d
+sleep 20 && docker compose ps
+cd -
+```
+
+Expected: geen container in `Exit`-status behalve de `migrate-*` (die horen `Exited (0)` te zijn
+na succesvolle migratie). `manager-directory`, `manager-magazijn-a`, `controller-magazijn-a`,
+`inway-magazijn-a` draaien.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add fsc/deploy/local
+git commit -m "feat(fsc): lokale compose-harness directory + magazijn-a-peer"
+```
+
+### Task 4: Announce-smoke groen
+
+**Files:**
+- Create: `fsc/deploy/local/smoke-announce.sh`
+
+**Interfaces:**
+- Consumes: draaiende stack uit Task 3.
+
+- [ ] **Step 1: Haal `smoke-announce.sh` op en substitueer de OIN**
+
+```bash
+gh api "repos/MinBZK/moza-fsc-testnet/contents/deploy/local/smoke-announce.sh" --jq '.content' \
+  | base64 -d > fsc/deploy/local/smoke-announce.sh && chmod +x fsc/deploy/local/smoke-announce.sh
+```
+
+Zet `PROVIDER_OIN="00000001003214345000"`, en vervang in de logs/servicenamen `example-provider`
+→ `magazijn-a` (de `docker compose logs`-servicelijst: `manager-directory`, `migrate-magazijn-a`,
+`manager-magazijn-a`). De query op `peers.peers` (kolom `id`, `manager_address LIKE '%:443'`)
+blijft ongewijzigd.
+
+- [ ] **Step 2: Draai eerst tégen een neergehaalde peer om falen te zien**
+
+```bash
+cd fsc/deploy/local && docker compose stop manager-magazijn-a
+./smoke-announce.sh; echo "exit=$?"
+```
+
+Expected: FAIL na de timeout ("niet aangemeld op :443"), exit≠0.
+
+- [ ] **Step 3: Herstart de peer en draai de smoke opnieuw (de "pass")**
+
+```bash
+docker compose start manager-magazijn-a
+./smoke-announce.sh; echo "exit=$?"; cd -
+```
+
+Expected: `OK: magazijn-a is aangemeld bij de directory (manager_address op :443).`, exit=0. De
+OIN `00000001003214345000` staat in `peers.peers`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add fsc/deploy/local/smoke-announce.sh
+git commit -m "test(fsc): announce-smoke magazijn-a groen (AC: announce)"
+```
+
+### Task 5: Dienst `berichtenmagazijn` publiceren
+
+**Files:**
+- Create: `fsc/deploy/local/publish-service.sh`
+
+**Interfaces:**
+- Consumes: draaiende stack (Task 3), announce groen (Task 4).
+- Produces: dienst `berichtenmagazijn` aangemaakt op de controller + servicePublication-contract
+  bij de manager.
+
+- [ ] **Step 1: Haal `publish-service.sh` op en substitueer**
+
+```bash
+gh api "repos/MinBZK/moza-fsc-testnet/contents/deploy/local/publish-service.sh" --jq '.content' \
+  | base64 -d > fsc/deploy/local/publish-service.sh && chmod +x fsc/deploy/local/publish-service.sh
+```
+
+Zet: `SERVICE_NAME="berichtenmagazijn"`, `PROVIDER_OIN="00000001003214345000"`,
+`DIR_OIN="00000000000000000010"`, `GROUP_ID="moza-fbs-test"`,
+`STUB_URL="http://stub-upstream:8080"` (lokaal). Vervang in cert-paden + controller/manager-URL's
+`example-provider` → `magazijn-a`. De inway-adres-grep wordt
+`https://inway\.magazijn-a\.fsc-test\.local:443`.
+
+- [ ] **Step 2: Draai de publish (idempotent) — de "test" is een succesvol contract**
+
+```bash
+cd fsc/deploy/local && ./publish-service.sh; echo "exit=$?"; cd -
+```
+
+Expected: `inway_address=https://inway.magazijn-a.fsc-test.local:443`, `aangemaakt.` (of
+`bestaat al, skip create.`), en `contract ingediend (manager signt; directory auto-accept)` met
+een `content_hash` in de respons. exit=0.
+
+- [ ] **Step 3: Draai nogmaals om idempotentie te bevestigen**
+
+```bash
+cd fsc/deploy/local && ./publish-service.sh; echo "exit=$?"; cd -
+```
+
+Expected: `bestaat al, skip create.` + `al gepubliceerd, skip contract.`, exit=0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add fsc/deploy/local/publish-service.sh
+git commit -m "feat(fsc): berichtenmagazijn publiceren op de controller + ServicePublicationGrant"
+```
+
+### Task 6: Discover-smoke — `berichtenmagazijn` vindbaar in de directory
+
+**Files:**
+- Create: `fsc/deploy/local/smoke-discover.sh`
+
+**Interfaces:**
+- Consumes: publish uit Task 5.
+
+- [ ] **Step 1: Bouw een discover-check zonder consumer-peer**
+
+De repo-A `smoke-discover.sh` bevraagt via een consumer-manager; die peer bestaat hier niet.
+Bewijs vindbaarheid in plaats daarvan direct op de directory-DB (tabel `services`), gemodelleerd
+op de announce-smoke. Maak `fsc/deploy/local/smoke-discover.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Smoke: bewijst dat de door magazijn-a gepubliceerde dienst `berichtenmagazijn` vindbaar is in
+# de directory (system-of-record). Pollt de directory-DB tot de dienst voor de magazijn-OIN
+# verschijnt. Vereist dat publish-service.sh eerst draaide.
+set -euo pipefail
+
+COMPOSE=(docker compose -f "$(dirname "$0")/docker-compose.yaml")
+PROVIDER_OIN="00000001003214345000"
+SERVICE_NAME="berichtenmagazijn"
+TIMEOUT=60
+INTERVAL=5
+
+ERRLOG=$(mktemp); trap 'rm -f "$ERRLOG"' EXIT
+
+echo "smoke-discover: wachten tot ${SERVICE_NAME} (${PROVIDER_OIN}) vindbaar is in de directory..."
+elapsed=0
+while [ "$elapsed" -lt "$TIMEOUT" ]; do
+  rows=$("${COMPOSE[@]}" exec -T postgres psql -U postgres -d fsc_directory -tA \
+    -c "SELECT name FROM services WHERE peer_id = '${PROVIDER_OIN}';" 2>"$ERRLOG" || true)
+  if printf '%s\n' "$rows" | grep -qx "$SERVICE_NAME"; then
+    echo "OK: ${SERVICE_NAME} is vindbaar in de directory."
+    "${COMPOSE[@]}" exec -T postgres psql -U postgres -d fsc_directory \
+      -c "SELECT peer_id, name FROM services;" || true
+    echo "SMOKE-DISCOVER GROEN."; exit 0
+  fi
+  sleep "$INTERVAL"; elapsed=$((elapsed + INTERVAL))
+  echo "  ...nog niet vindbaar (${elapsed}s)"
+done
+
+echo "FAIL: ${SERVICE_NAME} niet vindbaar binnen ${TIMEOUT}s (publish-service.sh gedraaid?)." >&2
+[ -s "$ERRLOG" ] && { echo "  -> laatste psql-fout:" >&2; tail -n 3 "$ERRLOG" >&2; }
+"${COMPOSE[@]}" logs --tail=50 manager-directory manager-magazijn-a controller-magazijn-a >&2 || true
+exit 1
+```
+
+> **Verifieer** eerst het echte schema van de directory `services`-tabel (kolomnamen
+> `peer_id`/`name`) met `docker compose exec postgres psql -U postgres -d fsc_directory -c '\d+ services'`
+> en pas de query aan indien afwijkend — de tabelnaam/kolom is een schema-contract.
+
+- [ ] **Step 2: Run de smoke (pass, want Task 5 publiceerde al)**
+
+```bash
+cd fsc/deploy/local && chmod +x smoke-discover.sh && ./smoke-discover.sh; echo "exit=$?"; cd -
+```
+
+Expected: `OK: berichtenmagazijn is vindbaar in de directory.` + `SMOKE-DISCOVER GROEN.`, exit=0.
+
+- [ ] **Step 3: Voeg een `run-smokes.sh`-wrapper toe (announce → publish → discover)**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+d="$(dirname "$0")"
+"$d/smoke-announce.sh"
+"$d/publish-service.sh"
+"$d/smoke-discover.sh"
+echo "ALLE SMOKES GROEN."
+```
+
+Run `./run-smokes.sh` tegen de draaiende stack. Expected: `ALLE SMOKES GROEN.`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add fsc/deploy/local/smoke-discover.sh fsc/deploy/local/run-smokes.sh
+git commit -m "test(fsc): discover-smoke berichtenmagazijn vindbaar (AC: dienst gepubliceerd)"
+```
+
+---
+
+## Fase 3 — ZAD-deploy naast de magazijn-app
+
+### Task 7: Cert-bundle voor ZAD-attachments
+
+**Files:**
+- Create: `fsc/deploy/zad/cert-manifest.md`
+- Uses: `fsc/pki/zad-bundle.sh` (uit Task 1)
+
+**Interfaces:**
+- Consumes: certs uit Task 1.
+- Produces: `fsc/pki/zad-upload/magazijn-a/` met per-bestand het beoogde pod-pad (`/etc/fsc/...`)
+  + de bijbehorende `TLS_*`-env-var (MANIFEST).
+
+- [ ] **Step 1: Bundel de magazijn-a-certs**
+
+```bash
+cd fsc/pki && ./zad-bundle.sh magazijn-a; cd -
+cat fsc/pki/zad-upload/magazijn-a/MANIFEST.md
+```
+
+Expected: `zad-upload/magazijn-a/` bevat de group- + internal-certs met een MANIFEST dat elk
+bestand koppelt aan `/etc/fsc/...` + `TLS_GROUP_*`/`TLS_*`-env-var.
+
+- [ ] **Step 2: Schrijf `cert-manifest.md` — de handmatige ZAD-attachment-runbook**
+
+Documenteer per component (`mgzmgr`, `mgzctl`, `mgzinway`) welke bestanden uit
+`zad-upload/magazijn-a/` als **bijlage** op welk pod-pad gemount worden (UI-only stap in
+Operations Manager; de v2-API dekt geen bijlagen — zoals repo A's directory-deploy). Neem de
+`TLS_*`-env-var-mapping over uit het MANIFEST.
+
+- [ ] **Step 3: Commit** (alleen het manifest-document; `zad-upload/` is gitignored)
+
+```bash
+git add fsc/deploy/zad/cert-manifest.md
+git commit -m "docs(fsc): ZAD cert-attachment-runbook magazijn-a"
+```
+
+### Task 8: `upsert-peer.sh` — provider-componenten op ZAD
+
+**Files:**
+- Create: `fsc/deploy/zad/upsert-peer.sh`
+
+**Interfaces:**
+- Consumes: `ZAD_API_KEY_MAGAZIJNEN` (env), project `mpfm-w3h`, ZAD v2-API.
+- Produces: componenten `mgzmgr` + `mgzctl` + `mgzinway` op deployment `test` (of `pr-<n>`) in
+  `mpfm-w3h`.
+
+- [ ] **Step 1: Neem `upsert-directory.sh` als skelet**
+
+```bash
+gh api "repos/MinBZK/moza-fsc-testnet/contents/deploy/zad/upsert-directory.sh" --jq '.content' \
+  | base64 -d > fsc/deploy/zad/upsert-peer.sh && chmod +x fsc/deploy/zad/upsert-peer.sh
+```
+
+Behoud de structuur: `validate|plan|apply`-modi, `component_body()` (jq),
+`poll_task()`/`post()`, de managed-Postgres-alias
+`STORAGE_POSTGRES_DSN=postgres://$DATABASE_SERVER_USER:$DATABASE_PASSWORD@$DATABASE_SERVER_HOST:5432/$DATABASE_DB?sslmode=disable`,
+en het `domain_format:"component-deployment-project"`.
+
+- [ ] **Step 2: Herdefinieer de env-blobs voor de drie provider-componenten**
+
+Zet `PROJECT="${ZAD_PROJECT:-mpfm-w3h}"`. Vervang de directory-component-bodies door drie
+provider-bodies. Spiegel de env uit de compose (Task 3) maar met ZAD-aliases
+(`SELF_ADDRESS`/adressen op `:443` via `$DEPLOYMENT_NAME`-hostnamen, managed-Postgres-DSN):
+
+- `mgzmgr` (image `manager-migrate`, poort 8443, service `["postgresql-database"]`): manager-mode
+  env — `GROUP_ID=moza-fbs-test`, `DIRECTORY_PEER_ID=00000000000000000010`,
+  `AUTO_SIGN_GRANTS=` (leeg; alleen de directory auto-signt), `TX_LOG_API_ADDRESS=` (leeg, #728),
+  `CONTROLLER_REGISTRATION_API_ADDRESS=https://mgzctl-$DEPLOYMENT_NAME-mpfm-w3h.<base-domain>:443`,
+  `LISTEN_ADDRESS_EXTERNAL=0.0.0.0:8443` + internal 9443/9444, alias
+  `SELF_ADDRESS=https://mgzmgr-$DEPLOYMENT_NAME-mpfm-w3h.<base-domain>:443`,
+  `DIRECTORY_MANAGER_ADDRESS=https://<directory-manager-host>:443`, de `TLS_*`-paden op de
+  attachment-mounts (`/etc/fsc/...`, zie Task 7).
+- `mgzctl` (image `controller:v1.43.7`, poort 8080, eigen managed DB): `AUTHN_TYPE=none`,
+  `GROUP_ID`, `DIRECTORY_PEER_ID`,
+  `MANAGER_ADDRESS_INTERNAL=https://mgzmgr-$DEPLOYMENT_NAME-mpfm-w3h.<base-domain>:443`,
+  Registration/Administration-API-poorten, `TLS_*`-internal-paden.
+- `mgzinway` (image `inway:v1.43.7`, poort 8443): `NAME=magazijn-a-inway`,
+  `SELF_ADDRESS=https://mgzinway-$DEPLOYMENT_NAME-mpfm-w3h.<base-domain>:443`,
+  `CONTROLLER_REGISTRATION_API_ADDRESS=…mgzctl…:443`,
+  `MANAGER_INTERNAL_UNAUTHENTICATED_ADDRESS=…mgzmgr…:443`, en de **upstream** naar de app:
+  `magazijna` intra-project (zie Open punt — verifieer de exacte intra-project-DNS-vorm).
+
+> **Base-domain:** `rig.prd1.gn2.quattro.rijksapps.nl` (zie repo B `deploy.yml`). Gebruik de
+> `$DEPLOYMENT_NAME`-substitutievar letterlijk (`\$` in de body) zodat previews hun eigen buren
+> raken.
+
+- [ ] **Step 3: `plan`-mode toont correcte bodies (de "test")**
+
+```bash
+ZAD_PROJECT=mpfm-w3h ./fsc/deploy/zad/upsert-peer.sh plan test v1.43.7
+```
+
+Expected: drie component-bodies (mgzmgr/mgzctl/mgzinway) met geldige JSON (jq-geparsed), correcte
+`:443`-adressen en `mpfm-w3h` in de hostnamen. Geen mutatie.
+
+- [ ] **Step 4: `validate` tegen ZAD (read-only auth-check)**
+
+```bash
+export ZAD_API_KEY="$ZAD_API_KEY_MAGAZIJNEN"
+./fsc/deploy/zad/upsert-peer.sh validate
+```
+
+Expected: `auth OK` + lijst van bestaande deployments/componenten in `mpfm-w3h` (o.a. `magazijna`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add fsc/deploy/zad/upsert-peer.sh
+git commit -m "feat(fsc): ZAD upsert-peer.sh voor magazijn-a provider-componenten"
+```
+
+### Task 9: Deploy-workflow `zad-deploy-peer.yml`
+
+**Files:**
+- Create: `.github/workflows/zad-deploy-peer.yml`
+
+**Interfaces:**
+- Consumes: `secrets.ZAD_API_KEY_MAGAZIJNEN`, `fsc/deploy/zad/upsert-peer.sh`.
+
+- [ ] **Step 1: Modelleer op repo A's `zad-deploy-directory.yml` + repo B-conventies**
+
+```bash
+gh api "repos/MinBZK/moza-fsc-testnet/contents/.github/workflows/zad-deploy-directory.yml" \
+  --jq '.content' | base64 -d > /tmp/zad-deploy-directory.yml
+```
+
+Neem over: `permissions: read-all` op workflow-niveau, path-filter op `fsc/deploy/zad/**` +
+`.github/workflows/zad-deploy-peer.yml`, PR → `pr-<nummer>` / push main → `test`, en het aanroepen
+van `upsert-peer.sh "${MODE}" "${DEPLOYMENT}" "${IMAGE_TAG}"`. **Pin alle actions op SHA**
+(consistent met repo B's bestaande workflows). Secret: `ZAD_API_KEY_MAGAZIJNEN`.
+
+- [ ] **Step 2: Valideer de workflow-syntax lokaal**
+
+```bash
+gh workflow view zad-deploy-peer.yml 2>/dev/null || python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/zad-deploy-peer.yml'))" && echo "YAML OK"
+```
+
+Expected: `YAML OK` (of `gh` toont de workflow zonder parse-fout).
+
+- [ ] **Step 3: Verifieer SHA-pinning (geen `@v`/`@main`-refs)**
+
+```bash
+grep -nE "uses:.*@(v[0-9]|main|master)" .github/workflows/zad-deploy-peer.yml && echo "FOUT: unpinned" || echo "OK: alles SHA-gepind"
+```
+
+Expected: `OK: alles SHA-gepind`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/zad-deploy-peer.yml
+git commit -m "ci(fsc): SHA-pinned deploy-workflow magazijn-provider-peer"
+```
+
+### Task 10: ZAD apply + handmatige mount-stappen
+
+**Files:**
+- Modify: `fsc/deploy/zad/cert-manifest.md` (aanvullen met de "Publicatie op het web"-stap)
+
+**Interfaces:**
+- Consumes: Task 7 (bundle), Task 8 (upsert), Task 9 (workflow).
+
+- [ ] **Step 1: Apply de componenten naar deployment `test`**
+
+```bash
+export ZAD_API_KEY="$ZAD_API_KEY_MAGAZIJNEN"
+./fsc/deploy/zad/upsert-peer.sh apply test v1.43.7
+```
+
+Expected: `HTTP 2xx` + `task ... completed` voor mgzmgr/mgzctl/mgzinway.
+
+- [ ] **Step 2: Handmatige UI-stappen (documenteer + voer uit)**
+
+In Operations Manager (`mpfm-w3h`, deployment `test`): (a) mount de cert-bijlagen op elk
+component-pod-pad per `cert-manifest.md`; (b) zet "Publicatie op het web" modus 2 (SNI-passthrough)
+op `mgzmgr` (external `:8443`) en `mgzinway` (data `:8443`), zodat het `:443`-mesh-adres klopt met
+`SELF_ADDRESS`. Vul deze stappen aan in `cert-manifest.md`.
+
+- [ ] **Step 3: Verifieer dat de pods gezond opkomen**
+
+```bash
+./fsc/deploy/zad/upsert-peer.sh validate
+```
+
+Expected: `mgzmgr`, `mgzctl`, `mgzinway` staan in `mpfm-w3h`/`test`. Controleer in de UI dat geen
+pod crash-loopt (certs correct gemount).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add fsc/deploy/zad/cert-manifest.md
+git commit -m "docs(fsc): ZAD apply-runbook magazijn-provider-peer afgerond"
+```
+
+---
+
+## Fase 4 — ZAD-verificatie tegen de echte directory
+
+### Task 11: Announce + dienst vindbaar op ZAD; app-tests groen
+
+**Files:**
+- Create: `fsc/deploy/zad/verify-zad.md` (verificatie-runbook + vastgelegde output)
+
+**Interfaces:**
+- Consumes: draaiende peer op ZAD (Task 10), de echte directory (repo A, deployment `test`).
+
+- [ ] **Step 1: Announce — magazijn-OIN in de directory op ZAD**
+
+Bevraag de directory (UI `dirui` of directory-DB via de directory-deploy) op de peer-OIN:
+
+```bash
+# via directory-ui: open https://dirui-test-mft-tp9.<base-domain>/ en zoek magazijn-a / de OIN
+# of via de directory-manager peers-API (group-cert vereist).
+```
+
+Expected: `00000001003214345000` met `manager_address` op `:443` staat als aangemelde peer.
+
+- [ ] **Step 2: Publiceer `berichtenmagazijn` op de ZAD-controller**
+
+Draai de publicatie tegen de ZAD-controller (`mgzctl`, Administration-API) + manager
+(ServicePublicationGrant) — een ZAD-variant van `publish-service.sh` met de `:443`-adressen i.p.v.
+de compose-servicenamen, of via de controller-beheer-UI. Documenteer de gekozen route in
+`verify-zad.md`.
+
+Expected: `berichtenmagazijn` aangemaakt + contract met `content_hash`; directory auto-signt.
+
+- [ ] **Step 3: Discover — dienst vindbaar in de ZAD-directory**
+
+Expected: `berichtenmagazijn` voor peer `00000001003214345000` verschijnt in de directory (UI +
+DB). Leg een screenshot/CLI-output vast in `verify-zad.md`.
+
+- [ ] **Step 4: Bestaande FBS-app-tests blijven groen (config-only geen app-wijziging)**
+
+```bash
+docker compose up -d
+./mvnw clean test -pl services/berichtenmagazijn -am
+```
+
+Expected: `BUILD SUCCESS`. (De app-code is niet gewijzigd; dit bewijst dat de FSC-toevoeging de
+build niet raakt.)
+
+- [ ] **Step 5: Commit + de vier AC's van #780 afvinken**
+
+```bash
+git add fsc/deploy/zad/verify-zad.md
+git commit -m "docs(fsc): ZAD-verificatie magazijn-provider-peer (AC's #780 gedekt)"
+```
+
+Vink in #780 af: peer draait (manager+inway+controller+DB) · cert (portal lokaal + attachment) ·
+announce · `berichtenmagazijn` vindbaar.
+
+---
+
+## Afronding
+
+- Draai `superpowers:requesting-code-review` op de branch vóór de PR.
+- Open een **draft**-PR (CODEOWNERS bestaat → nooit auto-reviewer), koppel aan #780 en epic #737
+  via de GitHub-issue-relatie.
+- Werk `CLAUDE.md` bij met de nieuwe `fsc/`-boom + `zad-actions`-project-context als dat de
+  volgende ontwikkelaar helpt (aparte, kleine commit).
+
+## Verificatie-overzicht (Definition of Done)
+
+| # | Bewijs | Hoe |
+|---|--------|-----|
+| 1 | PKI genereert magazijn-a-certs met de echte OIN | `issue.sh` + `verify.sh` + `openssl` (Task 1) |
+| 2 | Cert-portal lokaal aangetoond | `certportal-proof.md` + `openssl verify: OK` (Task 2) |
+| 3 | Peer meldt zich aan (announce) — lokaal | `smoke-announce.sh` groen (Task 4) |
+| 4 | `berichtenmagazijn` vindbaar — lokaal | `publish-service.sh` + `smoke-discover.sh` groen (Task 5-6) |
+| 5 | Peer draait op ZAD in mpfm-w3h | `upsert-peer.sh apply` + `validate` (Task 8-10) |
+| 6 | Announce + dienst vindbaar op de echte directory | `verify-zad.md` (Task 11) |
+| 7 | FBS-app-tests blijven groen | `./mvnw clean test -pl services/berichtenmagazijn -am` (Task 11) |

--- a/docs/plans/2026-07-08-magazijn-provider-peer-fsc-plan.md
+++ b/docs/plans/2026-07-08-magazijn-provider-peer-fsc-plan.md
@@ -1,5 +1,12 @@
 **Status:** Concept
 
+> **Amendement (na uitvoering):** de peer draait niet langer co-located in `mpfm-w3h`, maar in een
+> **eigen ZAD-project `mpfoa-e01`** (project-isolatie; eigen API-key `ZAD_API_KEY_FSCORGA`). De
+> `magazijna`-app blijft in `mpfm-w3h` en wordt cross-project via de ingress-URL bereikt. De
+> group-CA wordt niet met `init-ca.sh` vers gegenereerd maar uit fsc-testnet (repo A) gekopieerd
+> naar `fsc/pki/ca/`. Verwijzingen naar `mpfm-w3h` als peer-project hieronder zijn daarmee
+> achterhaald; zie het ontwerp-document (dezelfde datum) voor de actuele beslissingen.
+
 # Magazijn-provider-peer op de FSC-federatie — Implementatieplan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development

--- a/fsc/deploy/local/.env.example
+++ b/fsc/deploy/local/.env.example
@@ -1,0 +1,9 @@
+# Kopieer naar fsc/deploy/local/.env (gitignored).
+IMAGE_TAG=v1.43.7
+# Pad naar de test-CA-output (fsc/pki/). Read-only gemount op /pki in de containers.
+PKI_DIR=../../pki
+# Host-UID/GID: de cert-lezende pods draaien hiermee, zodat ze de 0600-privékeys
+# lezen via de owner-bit (keys blijven dicht). Zet op je eigen waarden:
+#   printf 'HOST_UID=%s\nHOST_GID=%s\n' "$(id -u)" "$(id -g)" >> fsc/deploy/local/.env
+HOST_UID=1000
+HOST_GID=1000

--- a/fsc/deploy/local/README.md
+++ b/fsc/deploy/local/README.md
@@ -146,10 +146,11 @@ De harness mount `fsc/pki/` read-only op `/pki`. Per endpoint (`manager`, `contr
 `<peer>` ∈ {`directory`, `magazijn-a`}. De mesh verifieert de hostname niet (auth op OIN), maar
 houd de paden consistent met `SELF_ADDRESS`/SNI.
 
-> **Let op — `directory`-peer heeft nog geen CSR's in deze repo.** `fsc/pki/peers/` bevat tot nu
-> toe alleen `magazijn-a/{manager,controller,inway,txlog}/csr.json`. Voor `manager-directory` en
-> `directory-ui` mount de compose paden onder `/pki/{out,internal}/directory/directory/...` —
-> die moeten nog worden gegenereerd (eigen `csr.json` onder `fsc/pki/peers/directory/directory/`
-> of hergebruik van repo A's group-CA-materiaal voor de directory-peer). Dit is een gat dat de
-> mens moet dichten vóór stap 1 van het draaiboek slaagt; zie ook de concerns in het bundle-
-> report.
+De directory-peer heeft eigen CSR's onder `fsc/pki/peers/directory/`: `directory/csr.json`
+(gebruikt door `manager-directory` én `directory-ui` via `/pki/{out,internal}/directory/directory/...`)
+en `manager/csr.json` (scaffolding voor een latere ZAD-directory-deploy; de lokale compose wiret
+het niet). Beide dragen de directory-OIN `00000000000000000010`. `issue.sh` negeert ongebruikte
+endpoints, dus de extra `manager`-CSR is onschadelijk.
+
+> **UITGESTELD:** de certs zelf ontbreken tot `fsc/pki/issue.sh` gedraaid is (vereist `cfssl`).
+> Zonder gegenereerde certs faalt stap 1 van het draaiboek — genereer ze eerst.

--- a/fsc/deploy/local/README.md
+++ b/fsc/deploy/local/README.md
@@ -1,0 +1,155 @@
+# Lokale FSC-harness — directory + provider-peer magazijn-a
+
+Runnable shift-left van de ZAD-deploy: een lokale FSC-directory + de provider-peer `magazijn-a`
+(manager + inway + controller + txlog + eigen DB's) + een SNI-router op `:443`. Bewijst dat
+`magazijn-a` zich aanmeldt (announce) bij de directory en dat de dienst `berichtenmagazijn`
+daarna vindbaar is (discovery). Geen afnemende peer, geen OIDC-login-voorziening —
+control-plane-only voor deze ene provider-peer. Bouwt voort op `fsc/pki/` (zie dat README voor
+het cert-contract).
+
+> ## UITGESTELD — vereist Docker + gegenereerde certs (`fsc/pki/issue.sh`)
+>
+> Deze omgeving heeft geen `docker` en geen `cfssl`. Er is dus **niets van onderstaand draaiboek
+> uitgevoerd**: de stack is niet gebooid, geen enkele smoke is groen gedraaid. Alleen de
+> artefacten (compose, haproxy.cfg, postgres-init.sql, `.env.example`, dit README, de vier
+> scripts) zijn neergezet en **statisch** gevalideerd (zie onderaan). Claim dus nergens dat de
+> stack draait of dat een smoke geslaagd is — dat moet een mens met Docker + cfssl nog doen.
+
+## Benodigdheden
+
+- **Docker** + `docker compose` (v2).
+- Gegenereerde certs uit `fsc/pki/` — draai daar eerst `./init-ca.sh`, `./issue.sh` en
+  `./verify.sh` (zie `fsc/pki/README.md`, sectie "UITGESTELD"). Zonder certs faalt elke
+  container die `/pki` mount bij boot (ontbrekend bestand).
+
+## Draaiboek — UITGESTELD, door de mens uit te voeren
+
+Alle commando's vanuit de **repo-root**, op branch `feature/magazijn-provider-peer-fsc`.
+
+```bash
+# 1. Genereer de PKI voor magazijn-a (UITGESTELD, zie fsc/pki/README.md).
+cd fsc/pki
+./init-ca.sh
+./issue.sh
+./verify.sh          # verwacht: "== ALLE ASSERTS GROEN =="
+cd -
+
+# 2. Harness-env. De cert-lezende containers draaien als JOUW UID/GID, zodat ze de
+#    0600-privékeys via de owner-bit lezen (keys blijven dicht).
+cp fsc/deploy/local/.env.example fsc/deploy/local/.env
+printf 'HOST_UID=%s\nHOST_GID=%s\n' "$(id -u)" "$(id -g)" >> fsc/deploy/local/.env
+
+# 3. Start de stack.
+docker compose -f fsc/deploy/local/docker-compose.yaml up -d
+sleep 20 && docker compose -f fsc/deploy/local/docker-compose.yaml ps
+
+# 4. Draai alle smokes (announce -> publiceren -> discovery) in één keer.
+./fsc/deploy/local/run-smokes.sh    # verwacht: "ALLE SMOKES GROEN."
+```
+
+Losse smokes (voor gerichte diagnose):
+
+```bash
+./fsc/deploy/local/smoke-announce.sh    # verwacht: "OK: magazijn-a is aangemeld ..."
+./fsc/deploy/local/publish-service.sh   # verwacht: "publish: klaar." (idempotent)
+./fsc/deploy/local/smoke-discover.sh    # verwacht: "SMOKE-DISCOVER GROEN."
+```
+
+Opruimen:
+
+```bash
+docker compose -f fsc/deploy/local/docker-compose.yaml down -v
+```
+
+> **Hosts-bestand niet nodig.** De SNI-hostnames (`directory.fsc-test.local`,
+> `magazijn-a.fsc-test.local`, `inway.magazijn-a.fsc-test.local`) resolven *binnen* het
+> docker-netwerk via de router-aliases. De UIs benader je via `localhost`-poorten hieronder.
+
+## Wat er opkomt
+
+- **postgres** — één instantie, per component een eigen database (`postgres-init.sql`):
+  `fsc_directory`, `fsc_magazijn_a`, `fsc_controller_magazijn_a`, `fsc_txlog_magazijn_a`.
+- **router** (haproxy) — SNI-passthrough op `:443` naar `manager-directory`,
+  `manager-magazijn-a` en `inway-magazijn-a`.
+- **manager-directory** + **directory-ui** (`http://localhost:8080`, geen login) — de lokale
+  FSC-directory (`AUTO_SIGN_GRANTS=servicePublication,delegatedServicePublication`).
+- **migrate-magazijn-a**, **manager-magazijn-a** — de manager van de peer (announce, token- en
+  contractendpoints).
+- **migrate-controller-magazijn-a**, **controller-magazijn-a** (`http://localhost:8090`, zonder
+  login: `AUTHN_TYPE=none`) — dienst-beheer (create service, contract-publicatie).
+- **migrate-txlog-magazijn-a**, **txlog-magazijn-a** — transactielog-API van de peer
+  (internal-PKI-mTLS).
+- **inway-magazijn-a** — registreert zich bij de controller, levert de ingress vóór
+  `stub-upstream`.
+- **stub-upstream** — neutrale HTTP-echo (`hashicorp/http-echo`) die de business-app vervangt;
+  wordt de `endpoint_url` van `berichtenmagazijn`. Het échte data-pad dóór de inway naar de
+  draaiende `berichtenmagazijn`-app is buiten scope van deze bundel.
+- **toolbox** — curl-client op het netwerk voor de mTLS-onboarding-calls (`publish-service.sh`).
+
+Geen afnemende-peer-services, geen OIDC-login-voorziening — beide zijn buiten scope voor deze
+provider-only-harness.
+
+## Smokes
+
+| Script | Bewijst |
+|--------|---------|
+| `smoke-announce.sh` | `magazijn-a` (OIN `00000001003214345000`) staat in `peers.peers` met een `manager_address` op `:443`. |
+| `publish-service.sh` | `berichtenmagazijn` is aangemaakt op de controller + gepubliceerd via een `servicePublication`-contract op de manager. Idempotent. |
+| `smoke-discover.sh` | `berichtenmagazijn` is vindbaar in de directory-catalogus voor de magazijn-OIN. |
+| `run-smokes.sh` | Draait de drie bovenstaande in volgorde. |
+
+> ### WAARSCHUWING — schema van de directory `services`-tabel niet geverifieerd
+>
+> `smoke-discover.sh` bevraagt `services` met kolommen `peer_id`/`name`. Dit schema is
+> **niet** tegen een draaiende directory-DB geverifieerd (geen Docker beschikbaar in deze
+> omgeving) — het is overgenomen naar analogie van `peers.peers` (kolom `id`) uit
+> `smoke-announce.sh`, maar dat is een aanname, geen bevestigd contract. Controleer bij de
+> eerste keer draaien:
+>
+> ```bash
+> docker compose -f fsc/deploy/local/docker-compose.yaml exec postgres \
+>   psql -U postgres -d fsc_directory -c '\d+ services'
+> ```
+>
+> en pas de `SELECT`-query in `smoke-discover.sh` aan als de kolomnamen afwijken.
+
+## Troubleshooting
+
+- **Container kan cert niet vinden** → controleer dat `fsc/pki/out/magazijn-a/<endpoint>/` en
+  `fsc/pki/internal/magazijn-a/<endpoint>/` bestaan (na `./fsc/pki/issue.sh`); paden moeten
+  matchen met de compose-env.
+- **`permission denied` op `key.pem` bij boot** → `HOST_UID`/`HOST_GID` in
+  `fsc/deploy/local/.env` matchen niet met de eigenaar van de keys. Zet ze met
+  `printf 'HOST_UID=%s\nHOST_GID=%s\n' "$(id -u)" "$(id -g)" >> fsc/deploy/local/.env` en
+  `docker compose -f fsc/deploy/local/docker-compose.yaml up -d --force-recreate`.
+- **Poort bezet** (443, 8080, 8090) → stop de conflicterende dienst of pas de `ports`/`bind`
+  in `docker-compose.yaml` / `haproxy.cfg` aan.
+- **Smoke faalt** → `docker compose -f fsc/deploy/local/docker-compose.yaml logs
+  manager-directory manager-magazijn-a controller-magazijn-a` voor de mesh-logs.
+- **`migrate-*` hangt / `database "…" does not exist`** → `postgres-init.sql` draait alleen bij
+  een **vers** volume. Bestaat er al een postgres-volume van een eerdere run? Maak de ontbrekende
+  DB eenmalig aan (`... exec -T postgres psql -U postgres -c "CREATE DATABASE <naam>;"`) of
+  `down -v && up -d` (wist alles, re-init inclusief nieuwe DB's).
+
+## Cert-contract (referentie, overgenomen uit `fsc/pki/README.md`)
+
+De harness mount `fsc/pki/` read-only op `/pki`. Per endpoint (`manager`, `controller`, `inway`,
+`txlog`) twee ketens:
+
+| Pad | Doel | Env |
+|-----|------|-----|
+| `/pki/ca/root.pem` | group-CA root (trust-anchor) | `TLS_GROUP_ROOT_CERT` |
+| `/pki/internal/<peer>/ca/root.pem` | **per-peer** internal-CA root | `TLS_ROOT_CERT`, `TLS_INTERNAL_UNAUTHENTICATED_ROOT_CERT` |
+| `/pki/out/<peer>/<endpoint>/{cert,key}.pem` | group-identity (hergebruikt voor token+contract) | `TLS_GROUP_CERT/KEY`, `TLS_GROUP_TOKEN_*`, `TLS_GROUP_CONTRACT_*` |
+| `/pki/internal/<peer>/<endpoint>/{cert,key}.pem` | internal mTLS | `TLS_CERT/KEY`, `TLS_INTERNAL_UNAUTHENTICATED_*` |
+
+`<peer>` ∈ {`directory`, `magazijn-a`}. De mesh verifieert de hostname niet (auth op OIN), maar
+houd de paden consistent met `SELF_ADDRESS`/SNI.
+
+> **Let op — `directory`-peer heeft nog geen CSR's in deze repo.** `fsc/pki/peers/` bevat tot nu
+> toe alleen `magazijn-a/{manager,controller,inway,txlog}/csr.json`. Voor `manager-directory` en
+> `directory-ui` mount de compose paden onder `/pki/{out,internal}/directory/directory/...` —
+> die moeten nog worden gegenereerd (eigen `csr.json` onder `fsc/pki/peers/directory/directory/`
+> of hergebruik van repo A's group-CA-materiaal voor de directory-peer). Dit is een gat dat de
+> mens moet dichten vóór stap 1 van het draaiboek slaagt; zie ook de concerns in het bundle-
+> report.

--- a/fsc/deploy/local/README.md
+++ b/fsc/deploy/local/README.md
@@ -98,20 +98,12 @@ provider-only-harness.
 | `smoke-discover.sh` | `berichtenmagazijn` is vindbaar in de directory-catalogus voor de magazijn-OIN. |
 | `run-smokes.sh` | Draait de drie bovenstaande in volgorde. |
 
-> ### WAARSCHUWING — schema van de directory `services`-tabel niet geverifieerd
->
-> `smoke-discover.sh` bevraagt `services` met kolommen `peer_id`/`name`. Dit schema is
-> **niet** tegen een draaiende directory-DB geverifieerd (geen Docker beschikbaar in deze
-> omgeving) — het is overgenomen naar analogie van `peers.peers` (kolom `id`) uit
-> `smoke-announce.sh`, maar dat is een aanname, geen bevestigd contract. Controleer bij de
-> eerste keer draaien:
->
-> ```bash
-> docker compose -f fsc/deploy/local/docker-compose.yaml exec postgres \
->   psql -U postgres -d fsc_directory -c '\d+ services'
-> ```
->
-> en pas de `SELECT`-query in `smoke-discover.sh` aan als de kolomnamen afwijken.
+`smoke-discover.sh` bevraagt de **mesh-API** van de eigen manager
+(`GET /v1/peers/{dir}/services?peer_id={provider}` op de Internal-API `:9443`, met het
+internal-cert), niet een directory-DB-tabel — gepubliceerde diensten worden via de mesh
+opgevraagd, niet uit een `services`-tabel gelezen. Dit spiegelt repo A's bewezen
+`smoke-publish.sh`. Announce en publish zijn lokaal groen bevonden; discover draait via deze
+mesh-API-methode.
 
 ## Troubleshooting
 

--- a/fsc/deploy/local/docker-compose.yaml
+++ b/fsc/deploy/local/docker-compose.yaml
@@ -1,0 +1,347 @@
+# Lokale FSC-harness voor peer magazijn-a: directory + provider-peer (manager/inway/controller/
+# txlog) + SNI-router. Bewijst announce en dienst-publicatie (`berichtenmagazijn`) zonder
+# productie-infra. Zie README.md voor het cert-contract en de UITGESTELDE boot-stappen (vereist
+# Docker + gegenereerde certs via `fsc/pki/issue.sh`).
+x-manager-image: &manager-image docker.io/federatedserviceconnectivity/manager:${IMAGE_TAG:-v1.43.7}
+x-manager-common-env: &manager-common-env
+  LOG_TYPE: local
+  LOG_LEVEL: debug
+  GROUP_ID: moza-fbs-test
+  DIRECTORY_PEER_ID: "00000000000000000010"
+  DIRECTORY_MANAGER_ADDRESS: https://directory.fsc-test.local:443
+  AUDITLOG_TYPE: stdout
+  DISABLE_CRL_CHECKS: "true"            # lokaal geen CRL-distributiepunt (zie README)
+  TLS_GROUP_ROOT_CERT: /pki/ca/root.pem
+
+# Gedeelde txlog-api-env (image `txlog-api`; eigen DB per peer). txlog spreekt mTLS op de
+# INTERNAL PKI (niet de group): inway/manager presenteren hun internal-cert; txlog trust de
+# per-peer internal-CA. Geen GROUP_ID (group-agnostische opslag).
+x-txlog-common-env: &txlog-common-env
+  LOG_TYPE: local
+  LOG_LEVEL: debug
+  LISTEN_ADDRESS: 0.0.0.0:9443
+  MONITORING_ADDRESS: 0.0.0.0:8081
+  # Zowel de losse POSTGRES_*-vars als de samengestelde STORAGE_POSTGRES_DSN zetten (de chart doet
+  # beide) — zo migreert/serveert txlog ongeacht welke vorm het image leest. DATABASE + DSN per peer.
+  POSTGRES_HOST: postgres
+  POSTGRES_PORT: "5432"
+  POSTGRES_USER: postgres
+  POSTGRES_PASSWORD: postgres
+  PGSSLMODE: disable
+  PGCONNECT_TIMEOUT: "10"
+
+services:
+  postgres:
+    image: postgres:17
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - ./postgres-init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      start_period: 20s     # faal-checks tellen niet mee tijdens boot
+      interval: 10s         # steady-state niet eeuwig op 3s pollen
+      timeout: 3s
+      retries: 5
+
+  router:
+    image: haproxy:2.9
+    volumes:
+      - ./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
+    networks:
+      default:
+        aliases:
+          - directory.fsc-test.local
+          - magazijn-a.fsc-test.local
+          # De inway-data-SNI hoort op de ROUTER (:443-passthrough), niet op de inway-container
+          # zelf (die luistert op :8443). Anders round-robint docker-DNS tussen router en inway
+          # en valt de helft van de calls op een dode :443.
+          - inway.magazijn-a.fsc-test.local
+    depends_on:
+      manager-directory:
+        condition: service_started
+
+  manager-directory:
+    # ZAD-artefact: wrapper-image (migrate->serve in de entrypoint). Repo A bouwt dit lokaal uit
+    # een build-context die in deze repo niet bestaat; hier daarom het kant-en-klare ghcr-image.
+    image: ghcr.io/minbzk/moza-fsc-testnet/manager-migrate:${IMAGE_TAG:-v1.43.7}
+    restart: on-failure   # migreert bij boot; herstart bij transiënte DB-race (parity met siblings)
+    # Draai als de host-UID/GID zodat de pod de 0600-privékeys leest (matching owner)
+    # i.p.v. ze open te zetten. HOST_UID/HOST_GID uit .env (zie README, stap 3).
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"
+    environment:
+      <<: *manager-common-env
+      SELF_ADDRESS: https://directory.fsc-test.local:443
+      TX_LOG_API_ADDRESS: ""                 # directory-mode: geen txlog
+      AUTO_SIGN_GRANTS: servicePublication,delegatedServicePublication
+      LISTEN_ADDRESS_EXTERNAL: 0.0.0.0:8443
+      LISTEN_ADDRESS_INTERNAL: 0.0.0.0:9443
+      LISTEN_ADDRESS_INTERNAL_UNAUTHENTICATED: 0.0.0.0:9444
+      MONITORING_ADDRESS: 0.0.0.0:8080
+      STORAGE_POSTGRES_DSN: postgres://postgres:postgres@postgres:5432/fsc_directory?sslmode=disable
+      TLS_GROUP_CERT: &dir-grp /pki/out/directory/directory/cert.pem
+      TLS_GROUP_KEY: &dir-grp-key /pki/out/directory/directory/key.pem
+      TLS_GROUP_TOKEN_CERT: *dir-grp
+      TLS_GROUP_TOKEN_KEY: *dir-grp-key
+      TLS_GROUP_CONTRACT_CERT: *dir-grp
+      TLS_GROUP_CONTRACT_KEY: *dir-grp-key
+      TLS_ROOT_CERT: &dir-introot /pki/internal/directory/ca/root.pem
+      TLS_CERT: &dir-int /pki/internal/directory/directory/cert.pem
+      TLS_KEY: &dir-int-key /pki/internal/directory/directory/key.pem
+      TLS_INTERNAL_UNAUTHENTICATED_ROOT_CERT: *dir-introot
+      TLS_INTERNAL_UNAUTHENTICATED_CERT: *dir-int
+      TLS_INTERNAL_UNAUTHENTICATED_KEY: *dir-int-key
+    volumes:
+      - "${PKI_DIR:?zet PKI_DIR in .env}:/pki:ro"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  migrate-magazijn-a:
+    image: *manager-image
+    command:
+      - /usr/local/bin/manager
+      - migrate
+      - up
+      - --postgres-dsn
+      - postgres://postgres:postgres@postgres:5432/fsc_magazijn_a?sslmode=disable
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: on-failure
+
+  manager-magazijn-a:
+    image: *manager-image
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"   # host-UID -> leest 0600-keys (zie manager-directory)
+    command:
+      - /usr/local/bin/manager
+      - serve
+    environment:
+      <<: *manager-common-env
+      SELF_ADDRESS: https://magazijn-a.fsc-test.local:443
+      # De manager bevraagt bij token-uitgifte de eigen controller naar de dienst
+      # (/v1/groups/{group}/services/{service}); zonder dit adres faalt /token met "unsupported
+      # protocol scheme". Registratie-API :9443, manager presenteert zijn internal-cert.
+      CONTROLLER_REGISTRATION_API_ADDRESS: https://controller.magazijn-a.fsc-test.local:9443
+      # Echte txlog-api (INTERNAL-PKI mTLS). De manager frontet txlog voor tx-log-queries.
+      TX_LOG_API_ADDRESS: https://txlog.magazijn-a.fsc-test.local:9443
+      LISTEN_ADDRESS_EXTERNAL: 0.0.0.0:8443
+      LISTEN_ADDRESS_INTERNAL: 0.0.0.0:9443
+      LISTEN_ADDRESS_INTERNAL_UNAUTHENTICATED: 0.0.0.0:9444
+      MONITORING_ADDRESS: 0.0.0.0:8080
+      STORAGE_POSTGRES_DSN: postgres://postgres:postgres@postgres:5432/fsc_magazijn_a?sslmode=disable
+      TLS_GROUP_CERT: &mgz-grp /pki/out/magazijn-a/manager/cert.pem
+      TLS_GROUP_KEY: &mgz-grp-key /pki/out/magazijn-a/manager/key.pem
+      TLS_GROUP_TOKEN_CERT: *mgz-grp
+      TLS_GROUP_TOKEN_KEY: *mgz-grp-key
+      TLS_GROUP_CONTRACT_CERT: *mgz-grp
+      TLS_GROUP_CONTRACT_KEY: *mgz-grp-key
+      TLS_ROOT_CERT: &mgz-introot /pki/internal/magazijn-a/ca/root.pem
+      TLS_CERT: &mgz-int /pki/internal/magazijn-a/manager/cert.pem
+      TLS_KEY: &mgz-int-key /pki/internal/magazijn-a/manager/key.pem
+      TLS_INTERNAL_UNAUTHENTICATED_ROOT_CERT: *mgz-introot
+      TLS_INTERNAL_UNAUTHENTICATED_CERT: *mgz-int
+      TLS_INTERNAL_UNAUTHENTICATED_KEY: *mgz-int-key
+    volumes:
+      - "${PKI_DIR:?zet PKI_DIR in .env}:/pki:ro"
+    networks:
+      default:
+        # Alias = de internal-cert-hostnaam, zodat de controller TLS naar :9443 valideert.
+        aliases:
+          - manager.magazijn-a.fsc-test.local
+    depends_on:
+      migrate-magazijn-a:
+        condition: service_completed_successfully
+      manager-directory:
+        condition: service_started
+
+  stub-upstream:
+    # Neutrale HTTP-echo die de business-app vervangt. Wordt de endpoint_url van
+    # berichtenmagazijn; het échte data-pad dóór de inway is niet in scope van deze bundel.
+    image: docker.io/hashicorp/http-echo:1.0
+    command: ["-listen=:8080", "-text=hello from magazijn-a stub-upstream"]
+
+  inway-magazijn-a:
+    image: docker.io/federatedserviceconnectivity/inway:${IMAGE_TAG:-v1.43.7}
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"   # host-UID -> leest 0600-keys
+    restart: on-failure                            # boot-race met controller/manager
+    command:
+      - /usr/local/bin/inway
+      - serve
+    environment:
+      LOG_TYPE: local
+      LOG_LEVEL: debug
+      GROUP_ID: moza-fbs-test
+      # geregistreerde inway-naam; SELF_ADDRESS wordt als inway_address doorgegeven bij CreateService
+      NAME: magazijn-a-inway
+      SELF_ADDRESS: https://inway.magazijn-a.fsc-test.local:443
+      LISTEN_ADDRESS: 0.0.0.0:8443
+      MONITORING_ADDRESS: 0.0.0.0:8081
+      DISABLE_CRL_CHECKS: "true"
+      # Registreert zich bij de controller via TLS op de controller-internal-cert
+      # (CN controller.magazijn-a.fsc-test.local):
+      CONTROLLER_REGISTRATION_API_ADDRESS: https://controller.magazijn-a.fsc-test.local:9443
+      # Eigen manager, internal-unauthenticated poort:
+      MANAGER_INTERNAL_UNAUTHENTICATED_ADDRESS: https://manager.magazijn-a.fsc-test.local:9444
+      # Echte txlog-api (INTERNAL-PKI mTLS). Bij een inkomende data-call logt de inway hier de
+      # transactie (direction: in) met dezelfde Fsc-Transaction-Id als de outway.
+      TX_LOG_API_ADDRESS: https://txlog.magazijn-a.fsc-test.local:9443
+      TLS_ROOT_CERT: /pki/internal/magazijn-a/ca/root.pem
+      TLS_CERT: /pki/internal/magazijn-a/inway/cert.pem
+      TLS_KEY: /pki/internal/magazijn-a/inway/key.pem
+      TLS_GROUP_ROOT_CERT: /pki/ca/root.pem
+      TLS_GROUP_CERT: /pki/out/magazijn-a/inway/cert.pem
+      TLS_GROUP_KEY: /pki/out/magazijn-a/inway/key.pem
+    volumes:
+      - "${PKI_DIR:?zet PKI_DIR in .env}:/pki:ro"
+    # NB: géén network-alias inway.magazijn-a.fsc-test.local hier — die hoort op de router
+    # (:443-SNI-passthrough, zie hierboven bij `router`). De router-backend bereikt deze
+    # container via de compose-servicenaam `inway-magazijn-a:8443`.
+    depends_on:
+      controller-magazijn-a:
+        condition: service_started
+      manager-magazijn-a:
+        condition: service_started
+      stub-upstream:
+        condition: service_started
+      txlog-magazijn-a:
+        condition: service_started
+
+  toolbox:
+    # Curl-client BINNEN het netwerk voor de mTLS-onboarding-calls (publish-service.sh).
+    # Draait als host-UID zodat het de 0600-internal-key leest.
+    image: docker.io/curlimages/curl:8.11.1
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"
+    entrypoint: ["sleep", "infinity"]
+    volumes:
+      - "${PKI_DIR:?zet PKI_DIR in .env}:/pki:ro"
+    depends_on:
+      manager-magazijn-a:
+        condition: service_started
+      controller-magazijn-a:
+        condition: service_started
+
+  directory-ui:
+    image: docker.io/federatedserviceconnectivity/directory-ui:${IMAGE_TAG:-v1.43.7}
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"   # host-UID -> leest 0600-group-key
+    ports:
+      - "127.0.0.1:8080:8080"
+    environment:
+      LOG_TYPE: local
+      LOG_LEVEL: info
+      LISTEN_ADDRESS: 0.0.0.0:8080
+      MONITORING_ADDRESS: 0.0.0.0:8081
+      # Externe directory-manager via de SNI-router op :443.
+      DIRECTORY_MANAGER_ADDRESS: https://directory.fsc-test.local:443
+      BASE_URL_PATH: /
+      TLS_GROUP_ROOT_CERT: /pki/ca/root.pem
+      TLS_GROUP_CERT: /pki/out/magazijn-a/manager/cert.pem   # lezer-peer-identiteit
+      TLS_GROUP_KEY: /pki/out/magazijn-a/manager/key.pem
+    volumes:
+      - "${PKI_DIR:?zet PKI_DIR in .env}:/pki:ro"
+    depends_on:
+      manager-directory:
+        condition: service_started
+      router:
+        condition: service_started
+
+  migrate-controller-magazijn-a:
+    image: docker.io/federatedserviceconnectivity/controller:${IMAGE_TAG:-v1.43.7}
+    command:
+      - /usr/local/bin/controller
+      - migrate
+      - up
+      - --postgres-dsn
+      - postgres://postgres:postgres@postgres:5432/fsc_controller_magazijn_a?sslmode=disable
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: on-failure
+
+  controller-magazijn-a:
+    image: docker.io/federatedserviceconnectivity/controller:${IMAGE_TAG:-v1.43.7}
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"   # host-UID -> leest 0600-internal-key
+    restart: on-failure                           # herstart bij transiënte boot-fout (DB/manager nog niet klaar)
+    ports:
+      - "127.0.0.1:8090:8080"
+    environment:
+      LOG_TYPE: local
+      LOG_LEVEL: info
+      LISTEN_ADDRESS_UI: 0.0.0.0:8080
+      LISTEN_ADDRESS_REGISTRATION_API: 0.0.0.0:9443
+      LISTEN_ADDRESS_ADMINISTRATION_API: 0.0.0.0:9444
+      MONITORING_ADDRESS: 0.0.0.0:8081
+      MANAGER_ADDRESS_INTERNAL: https://manager.magazijn-a.fsc-test.local:9443   # = internal-cert-SAN
+      GROUP_ID: moza-fbs-test
+      DIRECTORY_PEER_ID: "00000000000000000010"
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: "5432"
+      POSTGRES_DATABASE: fsc_controller_magazijn_a
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      PGSSLMODE: disable
+      STORAGE_POSTGRES_DSN: postgres://postgres:postgres@postgres:5432/fsc_controller_magazijn_a?sslmode=disable
+      # Lokaal ZONDER login (AUTHN_TYPE=none — een door OpenFSC ondersteunde modus). De
+      # controller-management (dienst publiceren, grant->sign->accept) werkt zonder loginscherm;
+      # OIDC is enkel de auth-laag ervoor en buiten scope van deze harness (geen afnemer-login hier).
+      AUTHN_TYPE: none
+      AUTHZ_TYPE: rbac
+      CSRF_PROTECTION_ENABLED: "false"
+      AUDITLOG_TYPE: stdout
+      TLS_ROOT_CERT: /pki/internal/magazijn-a/ca/root.pem
+      TLS_CERT: /pki/internal/magazijn-a/controller/cert.pem
+      TLS_KEY: /pki/internal/magazijn-a/controller/key.pem
+    volumes:
+      - "${PKI_DIR:?zet PKI_DIR in .env}:/pki:ro"
+    networks:
+      default:
+        aliases:
+          - controller.magazijn-a.fsc-test.local
+    depends_on:
+      migrate-controller-magazijn-a:
+        condition: service_completed_successfully
+      manager-magazijn-a:
+        condition: service_started
+
+  # ---- transaction-log API (per peer) ----------------------------------------------------------
+  migrate-txlog-magazijn-a:
+    image: docker.io/federatedserviceconnectivity/txlog-api:${IMAGE_TAG:-v1.43.7}
+    # `migrate up` leest de DSN ALLEEN uit --postgres-dsn (niet uit env, anders dan serve) — net als
+    # de manager/controller-migrates. Zonder de vlag verbindt migrate met een default en hangt 't.
+    command: [/usr/local/bin/txlog-api, migrate, up, --postgres-dsn,
+              "postgres://postgres:postgres@postgres:5432/fsc_txlog_magazijn_a?sslmode=disable"]
+    environment:
+      <<: *txlog-common-env
+      POSTGRES_DATABASE: fsc_txlog_magazijn_a
+      STORAGE_POSTGRES_DSN: postgres://postgres:postgres@postgres:5432/fsc_txlog_magazijn_a?sslmode=disable
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: on-failure
+
+  txlog-magazijn-a:
+    image: docker.io/federatedserviceconnectivity/txlog-api:${IMAGE_TAG:-v1.43.7}
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"   # host-UID -> leest de 0600-internal-key
+    command: [/usr/local/bin/txlog-api, serve]
+    restart: on-failure                            # boot-race met postgres/migrate
+    environment:
+      <<: *txlog-common-env
+      POSTGRES_DATABASE: fsc_txlog_magazijn_a
+      STORAGE_POSTGRES_DSN: postgres://postgres:postgres@postgres:5432/fsc_txlog_magazijn_a?sslmode=disable
+      TLS_ROOT_CERT: /pki/internal/magazijn-a/ca/root.pem
+      TLS_CERT: /pki/internal/magazijn-a/txlog/cert.pem
+      TLS_KEY: /pki/internal/magazijn-a/txlog/key.pem
+    volumes:
+      - "${PKI_DIR:?zet PKI_DIR in .env}:/pki:ro"
+    networks:
+      default:
+        aliases:
+          - txlog.magazijn-a.fsc-test.local
+    depends_on:
+      migrate-txlog-magazijn-a:
+        condition: service_completed_successfully
+
+networks:
+  default:
+    driver: bridge

--- a/fsc/deploy/local/haproxy.cfg
+++ b/fsc/deploy/local/haproxy.cfg
@@ -1,0 +1,39 @@
+# SNI-passthrough router op :443 (mode tcp = geen TLS-terminatie), analoog aan een OpenShift-
+# passthrough-Route. Routeert op SNI-hostnaam naar de juiste manager-/inway-external-poort.
+global
+    log stdout format raw local0 info
+
+# Docker's embedded DNS — laat haproxy backends runtime resolven, zodat het start ook als een
+# manager (nog) niet draait en later weer bijkomt. Zonder dit cachet haproxy de backend-IP
+# eenmalig bij boot → na een `up --force-recreate` (zie README) routeert het naar dode IP's tot
+# de router zélf herstart.
+resolvers docker
+    nameserver dns 127.0.0.11:53
+    resolve_retries 3
+    timeout resolve 1s
+    timeout retry   1s
+    hold valid      10s
+
+defaults
+    log     global
+    mode    tcp
+    option  tcplog
+    timeout connect 5s
+    timeout client  1h
+    timeout server  1h
+    default-server  init-addr none resolvers docker check
+
+frontend https_sni
+    bind *:443
+    tcp-request inspect-delay 5s
+    tcp-request content accept if { req_ssl_hello_type 1 }
+    use_backend dir       if { req_ssl_sni -i directory.fsc-test.local }
+    use_backend mgz       if { req_ssl_sni -i magazijn-a.fsc-test.local }
+    use_backend inway_mgz if { req_ssl_sni -i inway.magazijn-a.fsc-test.local }
+
+backend dir
+    server s1 manager-directory:8443
+backend mgz
+    server s1 manager-magazijn-a:8443
+backend inway_mgz
+    server s1 inway-magazijn-a:8443

--- a/fsc/deploy/local/postgres-init.sql
+++ b/fsc/deploy/local/postgres-init.sql
@@ -1,0 +1,6 @@
+-- Eén postgres, per component een eigen database (spiegelt OpenFSC: manager en
+-- controller delen geen DB — beide hebben een public.schema_migrations).
+CREATE DATABASE fsc_directory;
+CREATE DATABASE fsc_magazijn_a;
+CREATE DATABASE fsc_controller_magazijn_a;
+CREATE DATABASE fsc_txlog_magazijn_a;

--- a/fsc/deploy/local/publish-service.sh
+++ b/fsc/deploy/local/publish-service.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Onboarding: maakt de dienst berichtenmagazijn aan op de controller Administration-API en
+# publiceert 'm via een servicePublication-contract op de eigen manager Internal-API.
+# Idempotent: slaat create/publish over als ze er al zijn. Manager hasht+signt het
+# contract server-side; de directory (AUTO_SIGN_GRANTS=servicePublication) auto-accept.
+set -euo pipefail
+
+COMPOSE=(docker compose -f "$(dirname "$0")/docker-compose.yaml")
+SERVICE_NAME="berichtenmagazijn"
+PROVIDER_OIN="00000001003214345000"
+DIR_OIN="00000000000000000010"
+GROUP_ID="moza-fbs-test"                 # = GROUP_ID env-var op de manager; als de manager een directory-adres verwacht, gebruik DIRECTORY_MANAGER_ADDRESS
+STUB_URL="http://stub-upstream:8080"
+
+CERT=/pki/internal/magazijn-a/manager/cert.pem
+KEY=/pki/internal/magazijn-a/manager/key.pem
+CA=/pki/internal/magazijn-a/ca/root.pem
+CONTROLLER=https://controller.magazijn-a.fsc-test.local:9444
+MANAGER=https://manager.magazijn-a.fsc-test.local:9443
+
+# Vang curl-/toolbox-stderr op i.p.v. weg te gooien: een mTLS-/netwerk-/dode-container-fout
+# mag niet als "nog niet klaar" maskeren (spiegelt smoke-announce.sh). Surface 'm in de loop.
+ERRLOG=$(mktemp)
+trap 'rm -f "$ERRLOG"' EXIT
+
+# curl binnen de toolbox, met de internal client-cert. Stderr -> ERRLOG.
+tb() { "${COMPOSE[@]}" exec -T toolbox curl -s --fail-with-body \
+         --cert "$CERT" --key "$KEY" --cacert "$CA" "$@" 2>"$ERRLOG"; }
+
+echo "publish: wachten op inway-registratie bij de controller..."
+# inway->controller-registratie is asynchroon na boot; poll (spiegelt smoke-announce.sh)
+# i.p.v. één harde fetch, anders racet een koude start de eerste publish-run.
+INWAY_ADDR=""
+elapsed=0
+while [ "$elapsed" -lt 60 ]; do
+  # CreateService verwacht het inway-ADRES (https://...:443, = SELF_ADDRESS), niet de naam.
+  INWAY_ADDR=$(tb "$CONTROLLER/v1/inways" | grep -o 'https://inway\.magazijn-a\.fsc-test\.local:443' | head -1 || true)
+  [ -n "$INWAY_ADDR" ] && break
+  # Persistente fout (verkeerd cert-pad, dode toolbox, DNS) mag niet als "traag boot" maskeren.
+  [ -s "$ERRLOG" ] && { echo "  WARN: controller-fout: $(tail -n1 "$ERRLOG")" >&2; : >"$ERRLOG"; }
+  sleep 5; elapsed=$((elapsed + 5))
+  echo "  ...inway nog niet geregistreerd (${elapsed}s)"
+done
+[ -n "$INWAY_ADDR" ] || { echo "FAIL: geen geregistreerde inway op de controller binnen 60s." >&2; exit 1; }
+echo "  inway_address=$INWAY_ADDR"
+
+echo "publish: $SERVICE_NAME aanmaken (idempotent)..."
+if tb "$CONTROLLER/v1/services" | grep -q "\"$SERVICE_NAME\""; then
+  echo "  bestaat al, skip create."
+else
+  tb -X POST "$CONTROLLER/v1/services" -H 'Content-Type: application/json' \
+     -d "{\"name\":\"$SERVICE_NAME\",\"endpoint_url\":\"$STUB_URL\",\"inway_address\":\"$INWAY_ADDR\"}"
+  echo "  aangemaakt."
+fi
+
+echo "publish: servicePublication-contract indienen (idempotent)..."
+if tb "$MANAGER/v1/services/publications" | grep -q "\"$SERVICE_NAME\""; then
+  echo "  al gepubliceerd, skip contract."
+else
+  # UUID + timestamp zijn host-lokaal (geen container-context nodig) -> host-builtins i.p.v. toolbox-exec.
+  # UUID v4 (36 tekens): /proc is Linux-only, op macOS valt 'ie terug op uuidgen (lowercase).
+  # Als de manager 400 geeft op het iv-formaat, genereer UUID v7.
+  IV=$(cat /proc/sys/kernel/random/uuid 2>/dev/null || uuidgen | tr '[:upper:]' '[:lower:]')
+  # Docker Desktop (macOS) draait in een VM waarvan de klok op de host kan achterlopen; de manager
+  # weigert dan created_at "in the future" (HTTP 500). Backdate met een skew-marge — op Linux is de
+  # skew ~0, dus onschadelijk. Blijft persistent falen? Herstart de Docker-VM (klok resynct).
+  NBF=$(( $(date -u +%s) - 60 ))
+  NAF=$((NBF + 315360000))                 # +10 jaar
+  # --fail-with-body laat curl bij 4xx/5xx non-zero exiten MAAR print de body; vang beide zodat
+  # `set -e` ons niet vóór de diagnostiek killt en de manager-respons zichtbaar is.
+  RESP=$(tb -X POST "$MANAGER/v1/contracts" -H 'Content-Type: application/json' -d "{
+    \"contract_content\": {
+      \"iv\": \"$IV\",
+      \"group_id\": \"$GROUP_ID\",
+      \"hash_algorithm\": \"HASH_ALGORITHM_SHA3_512\",
+      \"created_at\": $NBF,
+      \"validity\": { \"not_before\": $((NBF - 60)), \"not_after\": $NAF },
+      \"grants\": [ {
+        \"type\": \"GRANT_TYPE_SERVICE_PUBLICATION\",
+        \"directory\": { \"peer_id\": \"$DIR_OIN\" },
+        \"service\": { \"peer_id\": \"$PROVIDER_OIN\", \"name\": \"$SERVICE_NAME\", \"protocol\": \"PROTOCOL_TCP_HTTP_1.1\" }
+      } ]
+    }
+  }") || { echo "FAIL: POST /v1/contracts geweigerd (iv=$IV): ${RESP:-<leeg>} $(tail -n1 "$ERRLOG" 2>/dev/null)" >&2; exit 1; }
+  # Een 2xx zónder content_hash duidt op een geweigerd formaat (iv/group_id).
+  printf '%s' "$RESP" | grep -q '"content_hash"' \
+    || { echo "FAIL: contract-respons zonder content_hash (mogelijk geweigerd iv/group_id-formaat): $RESP" >&2; exit 1; }
+  echo "  contract ingediend (manager signt; directory auto-accept): $RESP"
+fi
+echo "publish: klaar."

--- a/fsc/deploy/local/run-smokes.sh
+++ b/fsc/deploy/local/run-smokes.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+d="$(dirname "$0")"
+"$d/smoke-announce.sh"
+"$d/publish-service.sh"
+"$d/smoke-discover.sh"
+echo "ALLE SMOKES GROEN."

--- a/fsc/deploy/local/smoke-announce.sh
+++ b/fsc/deploy/local/smoke-announce.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Smoke: bewijst dat magazijn-a zich aanmeldt (announce) bij de directory ÉN dat dat via de
+# :443-SNI-mesh gaat. Pollt de directory-DB tot de magazijn-a-OIN met een manager_address op
+# :443 in peers.peers verschijnt.
+# NB: de kolomnaam `id` + tabel `peers.peers` zijn een load-bearing schema-contract.
+set -euo pipefail
+
+COMPOSE=(docker compose -f "$(dirname "$0")/docker-compose.yaml")
+PROVIDER_OIN="00000001003214345000"
+DIR_OIN="00000000000000000010"
+TIMEOUT=120
+INTERVAL=5
+
+# Vang psql-stderr op i.p.v. weg te gooien: een persistente DB-fout (auth, ontbrekende
+# kolom/tabel, dode container) mag niet als "nog niet aangemeld" maskeren — surface 'm
+# op de FAIL-paden. Loop-stderr zelf blijft stil (transiënte boot-ruis).
+ERRLOG=$(mktemp)
+trap 'rm -f "$ERRLOG"' EXIT
+
+echo "smoke: wachten tot magazijn-a ($PROVIDER_OIN) announce't bij de directory (op :443)..."
+elapsed=0
+while [ "$elapsed" -lt "$TIMEOUT" ]; do
+  rows=$("${COMPOSE[@]}" exec -T postgres \
+    psql -U postgres -d fsc_directory -tA \
+    -c "SELECT id FROM peers.peers WHERE manager_address LIKE '%:443';" 2>"$ERRLOG" || true)
+  if printf '%s\n' "$rows" | grep -qx "$PROVIDER_OIN"; then
+    echo "OK: magazijn-a is aangemeld bij de directory (manager_address op :443)."
+    echo "Aangemelde peers:"
+    "${COMPOSE[@]}" exec -T postgres \
+      psql -U postgres -d fsc_directory \
+      -c "SELECT id, name, manager_address FROM peers.peers;" || true
+    exit 0
+  fi
+  sleep "$INTERVAL"; elapsed=$((elapsed + INTERVAL))
+  echo "  ...nog niet aangemeld (${elapsed}s)"
+done
+
+echo "FAIL: magazijn-a ($PROVIDER_OIN) niet aangemeld op :443 binnen ${TIMEOUT}s." >&2
+# Positief-controle: staat de directory zélf in peers.peers? Zo niet, dan is de
+# query/DB/het schema kapot (bv. kolomnaam), niet de announce. Laat stderr hier
+# DOOR (in ERRLOG) zodat de conclusie op de échte psql-fout rust.
+if ! "${COMPOSE[@]}" exec -T postgres psql -U postgres -d fsc_directory -tA \
+     -c "SELECT id FROM peers.peers WHERE manager_address LIKE '%:443';" 2>"$ERRLOG" \
+     | grep -qx "$DIR_OIN"; then
+  echo "  -> directory self-row ($DIR_OIN op :443) ontbreekt: query/DB/schema" \
+       "(id/manager_address) kapot, niet de announce." >&2
+fi
+# Surface de laatste psql-stderr (leeg = schoon, dus echt geen announce).
+if [ -s "$ERRLOG" ]; then
+  echo "  -> laatste psql-fout:" >&2
+  tail -n 3 "$ERRLOG" >&2
+fi
+echo "Debug: logs (postgres + migrate + managers):" >&2
+"${COMPOSE[@]}" logs --tail=50 \
+  postgres manager-directory migrate-magazijn-a manager-magazijn-a >&2 || true
+exit 1

--- a/fsc/deploy/local/smoke-discover.sh
+++ b/fsc/deploy/local/smoke-discover.sh
@@ -1,33 +1,56 @@
 #!/usr/bin/env bash
-# Smoke: bewijst dat de door magazijn-a gepubliceerde dienst `berichtenmagazijn` vindbaar is in
-# de directory (system-of-record). Pollt de directory-DB tot de dienst voor de magazijn-OIN
-# verschijnt. Vereist dat publish-service.sh eerst draaide.
+# Smoke: bewijst dat de door magazijn-a gepubliceerde dienst `berichtenmagazijn` als GELDIGE
+# publicatie vindbaar is bij de directory. Pollt de manager Internal-API
+# (GET /v1/peers/{dir}/services?peer_id={provider}) — de mesh-API, NIET een directory-DB-tabel:
+# gepubliceerde diensten leven niet in een plain `services`-tabel maar worden via de mesh
+# opgevraagd (spiegelt repo A's smoke-publish.sh). Vereist dat publish-service.sh eerst draaide
+# (run-smokes.sh doet dat).
 set -euo pipefail
 
-COMPOSE=(docker compose -f "$(dirname "$0")/docker-compose.yaml")
-PROVIDER_OIN="00000001003214345000"
+HERE="$(dirname "$0")"
+COMPOSE=(docker compose -f "$HERE/docker-compose.yaml")
 SERVICE_NAME="berichtenmagazijn"
-TIMEOUT=60
-INTERVAL=5
+PROVIDER_OIN="00000001003214345000"
+DIR_OIN="00000000000000000010"
+# directory-propagatie na auto-sign is vrijwel direct; 10s volstaat na de inway-poll in publish-service.sh.
+TIMEOUT=10
+INTERVAL=2
 
-ERRLOG=$(mktemp); trap 'rm -f "$ERRLOG"' EXIT
+# De provider bevraagt de directory via zijn EIGEN manager (internal-cert) naar de eigen
+# gepubliceerde diensten. Robuuster dan de directory-DB pollen (geen tabelnaam-koppeling).
+CERT=/pki/internal/magazijn-a/manager/cert.pem
+KEY=/pki/internal/magazijn-a/manager/key.pem
+CA=/pki/internal/magazijn-a/ca/root.pem
+MANAGER=https://manager.magazijn-a.fsc-test.local:9443
 
-echo "smoke-discover: wachten tot ${SERVICE_NAME} (${PROVIDER_OIN}) vindbaar is in de directory..."
+# Vang toolbox-/curl-stderr op zodat een mTLS-/dode-container-fout niet als "nog niet vindbaar"
+# maskeert (spiegelt smoke-announce.sh).
+ERRLOG=$(mktemp)
+trap 'rm -f "$ERRLOG"' EXIT
+
+echo "smoke-discover: pollen tot ${SERVICE_NAME} vindbaar is bij de directory (mesh-API)..."
 elapsed=0
 while [ "$elapsed" -lt "$TIMEOUT" ]; do
-  rows=$("${COMPOSE[@]}" exec -T postgres psql -U postgres -d fsc_directory -tA \
-    -c "SELECT name FROM services WHERE peer_id = '${PROVIDER_OIN}';" 2>"$ERRLOG" || true)
-  if printf '%s\n' "$rows" | grep -qx "$SERVICE_NAME"; then
-    echo "OK: ${SERVICE_NAME} is vindbaar in de directory."
-    "${COMPOSE[@]}" exec -T postgres psql -U postgres -d fsc_directory \
-      -c "SELECT peer_id, name FROM services;" || true
-    echo "SMOKE-DISCOVER GROEN."; exit 0
+  out=$("${COMPOSE[@]}" exec -T toolbox curl -s \
+          --cert "$CERT" --key "$KEY" --cacert "$CA" \
+          "$MANAGER/v1/peers/$DIR_OIN/services?peer_id=$PROVIDER_OIN" 2>"$ERRLOG" || true)
+  [ -s "$ERRLOG" ] && { echo "  WARN: poll-fout: $(tail -n1 "$ERRLOG")" >&2; : >"$ERRLOG"; }
+
+  if printf '%s' "$out" | grep -q "\"$SERVICE_NAME\""; then
+    echo "OK: ${SERVICE_NAME} is gepubliceerd en vindbaar in de directory."
+    printf 'Catalogus: %s\n' "$out"
+    echo "SMOKE-DISCOVER GROEN."
+    exit 0
   fi
+
   sleep "$INTERVAL"; elapsed=$((elapsed + INTERVAL))
   echo "  ...nog niet vindbaar (${elapsed}s)"
 done
 
 echo "FAIL: ${SERVICE_NAME} niet vindbaar binnen ${TIMEOUT}s (publish-service.sh gedraaid?)." >&2
-[ -s "$ERRLOG" ] && { echo "  -> laatste psql-fout:" >&2; tail -n 3 "$ERRLOG" >&2; }
-"${COMPOSE[@]}" logs --tail=50 manager-directory manager-magazijn-a controller-magazijn-a >&2 || true
+echo "Debug: eigen publicaties (manager Internal-API) + logs:" >&2
+"${COMPOSE[@]}" exec -T toolbox curl -s --cert "$CERT" --key "$KEY" --cacert "$CA" \
+   "$MANAGER/v1/services/publications" >&2 || true
+[ -s "$ERRLOG" ] && { echo "  -> laatste poll-fout:" >&2; tail -n 3 "$ERRLOG" >&2; }
+"${COMPOSE[@]}" logs --tail=50 manager-magazijn-a manager-directory inway-magazijn-a >&2 || true
 exit 1

--- a/fsc/deploy/local/smoke-discover.sh
+++ b/fsc/deploy/local/smoke-discover.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Smoke: bewijst dat de door magazijn-a gepubliceerde dienst `berichtenmagazijn` vindbaar is in
+# de directory (system-of-record). Pollt de directory-DB tot de dienst voor de magazijn-OIN
+# verschijnt. Vereist dat publish-service.sh eerst draaide.
+set -euo pipefail
+
+COMPOSE=(docker compose -f "$(dirname "$0")/docker-compose.yaml")
+PROVIDER_OIN="00000001003214345000"
+SERVICE_NAME="berichtenmagazijn"
+TIMEOUT=60
+INTERVAL=5
+
+ERRLOG=$(mktemp); trap 'rm -f "$ERRLOG"' EXIT
+
+echo "smoke-discover: wachten tot ${SERVICE_NAME} (${PROVIDER_OIN}) vindbaar is in de directory..."
+elapsed=0
+while [ "$elapsed" -lt "$TIMEOUT" ]; do
+  rows=$("${COMPOSE[@]}" exec -T postgres psql -U postgres -d fsc_directory -tA \
+    -c "SELECT name FROM services WHERE peer_id = '${PROVIDER_OIN}';" 2>"$ERRLOG" || true)
+  if printf '%s\n' "$rows" | grep -qx "$SERVICE_NAME"; then
+    echo "OK: ${SERVICE_NAME} is vindbaar in de directory."
+    "${COMPOSE[@]}" exec -T postgres psql -U postgres -d fsc_directory \
+      -c "SELECT peer_id, name FROM services;" || true
+    echo "SMOKE-DISCOVER GROEN."; exit 0
+  fi
+  sleep "$INTERVAL"; elapsed=$((elapsed + INTERVAL))
+  echo "  ...nog niet vindbaar (${elapsed}s)"
+done
+
+echo "FAIL: ${SERVICE_NAME} niet vindbaar binnen ${TIMEOUT}s (publish-service.sh gedraaid?)." >&2
+[ -s "$ERRLOG" ] && { echo "  -> laatste psql-fout:" >&2; tail -n 3 "$ERRLOG" >&2; }
+"${COMPOSE[@]}" logs --tail=50 manager-directory manager-magazijn-a controller-magazijn-a >&2 || true
+exit 1

--- a/fsc/deploy/zad/README.md
+++ b/fsc/deploy/zad/README.md
@@ -1,9 +1,16 @@
 # ZAD-deploy — provider-peer magazijn-a
 
 ZAD-rollout van de FSC-provider-peer `magazijn-a` (manager `mgzmgr`, controller `mgzctl`, inway
-`mgzinway`) naast de bestaande app-component `magazijna` in ZAD-project `mpfm-w3h`. Bouwt voort
-op `fsc/pki/` (certs) en `fsc/deploy/local/` (lokale compose-proof van dezelfde peer); zie die
-README's voor het cert-contract resp. de lokale smokes.
+`mgzinway`) in een **eigen ZAD-project `mpfoa-e01`**. De `magazijna`-app draait apart in
+`mpfm-w3h`; de inway bereikt die cross-project via de ingress-URL. Bouwt voort op `fsc/pki/`
+(certs) en `fsc/deploy/local/` (lokale compose-proof van dezelfde peer); zie die README's voor het
+cert-contract resp. de lokale smokes.
+
+> **Group-CA komt uit repo A (fsc-testnet), niet uit `init-ca.sh`.** Om aan te sluiten op de
+> échte directory moet magazijn-a's group-leaf ketenen naar fsc-testnet's group-root. Draai
+> daarom voor ZAD **niet** `fsc/pki/init-ca.sh` (dat maakt een verse, vreemde CA); zet in plaats
+> daarvan fsc-testnet's `ca/root.pem` + `ca/intermediate.pem` (+ keys) in `fsc/pki/ca/` en draai
+> alleen `issue.sh`. Zie `fsc/pki/README.md`.
 
 > **UITGESTELD — vereist ZAD-key / cluster / certs.** Er is in deze omgeving geen
 > `ZAD_API_KEY_MAGAZIJNEN`, geen `cfssl` en geen draaiende cluster-toegang. Alleen
@@ -26,10 +33,11 @@ README's voor het cert-contract resp. de lokale smokes.
    vereist `cfssl`; zie `fsc/pki/README.md`).
 2. **Bundle** — `fsc/pki/zad-bundle.sh magazijn-a` (UITGESTELD, hierboven van afhankelijk) →
    upload-klare cert-set in `fsc/pki/zad-upload/magazijn-a/`.
-3. **Deployment `peer` éénmalig handmatig aanmaken** in de Operations Manager-UI (project
-   `mpfm-w3h`, deployment-naam `peer`) — de raw v2-API `:upsert-deployment` maakt géén NIEUWE
-   deployment aan (geeft wel 202 maar het deployment verschijnt niet); een BESTAAND deployment
-   vult dit script wél. Leeg aanmaken volstaat; de workflow zet daarna de componenten + images.
+3. **Deployment `test` moet bestaan** in project `mpfoa-e01` — de raw v2-API `:upsert-deployment`
+   maakt géén NIEUWE deployment aan (geeft wel 202 maar het deployment verschijnt niet); het UPDATET
+   alleen een bestaand deployment. `test` is doorgaans het default-deployment van een nieuw project
+   en bestaat dus al. Zo niet: maak het éénmalig handmatig (leeg) aan in de Operations Manager-UI.
+   De workflow zet daarna de componenten + images.
 4. **`upsert-peer.sh plan [deployment] [tag]`** (dry-run, wél uitvoerbaar — alleen `jq`, geen
    netwerk) — toont de deployment- + drie component-bodies zonder te muteren.
 5. **`upsert-peer.sh validate`** (UITGESTELD, vereist `ZAD_API_KEY`) — read-only auth-check tegen
@@ -44,15 +52,17 @@ README's voor het cert-contract resp. de lokale smokes.
 
 | Variabele | Default | Rol |
 |-----------|---------|-----|
-| `ZAD_API_KEY` | — (verplicht bij `apply`) | Auth tegen de ZAD v2-API. **Niet** inline zetten (`export`, niet `ZAD_API_KEY=... ./upsert-peer.sh ...` — dat komt in de shell-history). |
-| `ZAD_PROJECT` | `mpfm-w3h` | ZAD-project waarin de peer + `magazijna` draaien (verschillende deployments). |
-| `ZAD_MAGAZIJNA_DEPLOYMENT` | `test` | Deployment van de `magazijna`-app waar de inway-upstream naar wijst (cross-deployment via ingress-URL). Zet bv. `pr-140` om tegen een app-preview te testen. |
+| `ZAD_API_KEY` | — (verplicht bij `apply`) | Auth tegen de ZAD v2-API; **de key van project `mpfoa-e01`**, niet de magazijnen-key. **Niet** inline zetten (`export`, niet `ZAD_API_KEY=... ./upsert-peer.sh ...` — dat komt in de shell-history). |
+| `ZAD_PROJECT` | `mpfoa-e01` | Eigen ZAD-project van de peer (los van het app-project). |
+| `ZAD_MAGAZIJNA_PROJECT` | `mpfm-w3h` | ZAD-project waarin de `magazijna`-app draait; bron voor de cross-project inway-upstream-URL. |
+| `ZAD_MAGAZIJNA_DEPLOYMENT` | `test` | Deployment van de `magazijna`-app waar de inway-upstream naar wijst (cross-project via ingress-URL). Zet bv. `pr-140` om tegen een app-preview te testen. |
 | `ZAD_BASE` | `https://zad.rijksapp.nl` | Basis-URL van de ZAD v2 Operations Manager API. |
 | `ZAD_BASE_DOMAIN` | `rig.prd1.gn2.quattro.rijksapps.nl` | Base-domain voor de per-component mesh-hostnamen. |
 | `ZAD_MANAGER_TAG` | = het `tag`-argument | Losse override voor de manager-wrapper-tag (ghcr), los van de OpenFSC stock-tag voor controller/inway. |
 | `ZAD_DIRECTORY_MANAGER_HOST` | `dirmgr-test-mft-tp9.<base-domain>` | Repo A's directory-manager-host op ZAD — pas aan als de directory op een andere deployment/project draait. |
 | `ZAD_PG_SSLMODE` | `disable` | SSL-mode voor de managed-Postgres-DSN (intra-cluster plaintext, zoals berichtenbox-JDBC). |
-| `ZAD_MAGAZIJNA_UPSTREAM_URL` | `https://magazijna-<ZAD_MAGAZIJNA_DEPLOYMENT>-mpfm-w3h.<base-domain>` | Volledige override van de endpoint-URL naar de `magazijna`-app; standaard afgeleid uit `ZAD_MAGAZIJNA_DEPLOYMENT` (ingress-URL, https/:443). |
+| `ZAD_MAGAZIJNA_UPSTREAM_URL` | `https://magazijna-<ZAD_MAGAZIJNA_DEPLOYMENT>-<ZAD_MAGAZIJNA_PROJECT>.<base-domain>` | Volledige override van de endpoint-URL naar de `magazijna`-app; standaard afgeleid uit `ZAD_MAGAZIJNA_DEPLOYMENT` + `ZAD_MAGAZIJNA_PROJECT` (ingress-URL, https/:443). |
 
-De workflow leest de ZAD-key uit het secret `ZAD_API_KEY_MAGAZIJNEN` (niet `ZAD_API_KEY` direct —
-dat blijft de scriptinterne naam, gezet via `env:` in de workflow).
+De workflow leest de ZAD-key uit het secret `ZAD_API_KEY_FSCORGA` (de key van project `mpfoa-e01`),
+niet `ZAD_API_KEY` direct — dat blijft de scriptinterne naam, gezet via `env:` in de workflow. Zet
+in GitHub dus **een secret `ZAD_API_KEY_FSCORGA`** en (optioneel) de var `ZAD_PROJECT_ID_MPFOA`.

--- a/fsc/deploy/zad/README.md
+++ b/fsc/deploy/zad/README.md
@@ -1,0 +1,51 @@
+# ZAD-deploy — provider-peer magazijn-a
+
+ZAD-rollout van de FSC-provider-peer `magazijn-a` (manager `mgzmgr`, controller `mgzctl`, inway
+`mgzinway`) naast de bestaande app-component `magazijna` in ZAD-project `mpfm-w3h`. Bouwt voort
+op `fsc/pki/` (certs) en `fsc/deploy/local/` (lokale compose-proof van dezelfde peer); zie die
+README's voor het cert-contract resp. de lokale smokes.
+
+> **UITGESTELD — vereist ZAD-key / cluster / certs.** Er is in deze omgeving geen
+> `ZAD_API_KEY_MAGAZIJNEN`, geen `cfssl` en geen draaiende cluster-toegang. Alleen
+> `upsert-peer.sh plan` (jq-only, geen netwerk) en de YAML-lint op de workflow zijn hier
+> daadwerkelijk gedraaid — zie de bestandsheaders (`upsert-peer.sh`, `cert-manifest.md`,
+> `verify-zad.md`) voor precies welke stappen UITGESTELD zijn.
+
+## Inhoud
+
+| Bestand | Rol |
+|---------|-----|
+| `upsert-peer.sh` | `validate`/`plan`/`apply` tegen de ZAD v2 Operations Manager API — één bron voor CLI + de workflow. |
+| `cert-manifest.md` | Runbook: welk cert-bestand op welk `/etc/fsc/...`-pad, per component (UI-only bijlagen). |
+| `verify-zad.md` | Runbook: announce/publiceren/discover/app-tests ná een geslaagde apply, + de vier AC's van #780. |
+| `../../.github/workflows/zad-deploy-peer.yml` | SHA-gepinde workflow die `upsert-peer.sh apply` aanroept (push main → `test`; PR → `pr-<nummer>`). |
+
+## Volgorde
+
+1. **Certs** — `fsc/pki/init-ca.sh` → `fsc/pki/issue.sh` → `fsc/pki/verify.sh` (UITGESTELD,
+   vereist `cfssl`; zie `fsc/pki/README.md`).
+2. **Bundle** — `fsc/pki/zad-bundle.sh magazijn-a` (UITGESTELD, hierboven van afhankelijk) →
+   upload-klare cert-set in `fsc/pki/zad-upload/magazijn-a/`.
+3. **`upsert-peer.sh plan [deployment] [tag]`** (dry-run, wél uitvoerbaar — alleen `jq`, geen
+   netwerk) — toont de deployment- + drie component-bodies zonder te muteren.
+4. **`upsert-peer.sh validate`** (UITGESTELD, vereist `ZAD_API_KEY`) — read-only auth-check tegen
+   de ZAD-API.
+5. **`upsert-peer.sh apply [deployment] [tag]`** (UITGESTELD, vereist `ZAD_API_KEY`) — upsert het
+   deployment + de drie componenten, pollt de resulterende tasks.
+6. **UI-mount** (UITGESTELD, zie `cert-manifest.md`) — cert-attachments + "Publicatie op het web"
+   (passthrough-TLS) zijn UI-only; de v2-API dekt dit niet.
+7. **`verify-zad.md`** (UITGESTELD) — announce, dienst-publicatie, discover, app-tests.
+
+## Env-vars
+
+| Variabele | Default | Rol |
+|-----------|---------|-----|
+| `ZAD_API_KEY` | — (verplicht bij `apply`) | Auth tegen de ZAD v2-API. **Niet** inline zetten (`export`, niet `ZAD_API_KEY=... ./upsert-peer.sh ...` — dat komt in de shell-history). |
+| `ZAD_PROJECT` | `mpfm-w3h` | ZAD-project waarin de peer + `magazijna` draaien. |
+| `ZAD_BASE_DOMAIN` | `rig.prd1.gn2.quattro.rijksapps.nl` | Base-domain voor de per-component mesh-hostnamen. |
+| `ZAD_MANAGER_TAG` | = het `tag`-argument | Losse override voor de manager-wrapper-tag (ghcr), los van de OpenFSC stock-tag voor controller/inway. |
+| `ZAD_DIRECTORY_MANAGER_HOST` | `dirmgr-test-mft-tp9.<base-domain>` | Repo A's directory-manager-host op ZAD — pas aan als de directory op een andere deployment/project draait. |
+| `ZAD_MAGAZIJNA_UPSTREAM_URL` | `http://magazijna:8080` | Endpoint-URL van de bestaande `magazijna`-app-component; TODO verifieer de echte intra-project-DNS-vorm vóór de eerste publicatie (zie `verify-zad.md`, stap b). |
+
+De workflow leest de ZAD-key uit het secret `ZAD_API_KEY_MAGAZIJNEN` (niet `ZAD_API_KEY` direct —
+dat blijft de scriptinterne naam, gezet via `env:` in de workflow).

--- a/fsc/deploy/zad/README.md
+++ b/fsc/deploy/zad/README.md
@@ -26,9 +26,13 @@ README's voor het cert-contract resp. de lokale smokes.
    vereist `cfssl`; zie `fsc/pki/README.md`).
 2. **Bundle** — `fsc/pki/zad-bundle.sh magazijn-a` (UITGESTELD, hierboven van afhankelijk) →
    upload-klare cert-set in `fsc/pki/zad-upload/magazijn-a/`.
-3. **`upsert-peer.sh plan [deployment] [tag]`** (dry-run, wél uitvoerbaar — alleen `jq`, geen
+3. **Deployment `peer` éénmalig handmatig aanmaken** in de Operations Manager-UI (project
+   `mpfm-w3h`, deployment-naam `peer`) — de raw v2-API `:upsert-deployment` maakt géén NIEUWE
+   deployment aan (geeft wel 202 maar het deployment verschijnt niet); een BESTAAND deployment
+   vult dit script wél. Leeg aanmaken volstaat; de workflow zet daarna de componenten + images.
+4. **`upsert-peer.sh plan [deployment] [tag]`** (dry-run, wél uitvoerbaar — alleen `jq`, geen
    netwerk) — toont de deployment- + drie component-bodies zonder te muteren.
-4. **`upsert-peer.sh validate`** (UITGESTELD, vereist `ZAD_API_KEY`) — read-only auth-check tegen
+5. **`upsert-peer.sh validate`** (UITGESTELD, vereist `ZAD_API_KEY`) — read-only auth-check tegen
    de ZAD-API.
 5. **`upsert-peer.sh apply [deployment] [tag]`** (UITGESTELD, vereist `ZAD_API_KEY`) — upsert het
    deployment + de drie componenten, pollt de resulterende tasks.

--- a/fsc/deploy/zad/README.md
+++ b/fsc/deploy/zad/README.md
@@ -41,13 +41,14 @@ README's voor het cert-contract resp. de lokale smokes.
 | Variabele | Default | Rol |
 |-----------|---------|-----|
 | `ZAD_API_KEY` | — (verplicht bij `apply`) | Auth tegen de ZAD v2-API. **Niet** inline zetten (`export`, niet `ZAD_API_KEY=... ./upsert-peer.sh ...` — dat komt in de shell-history). |
-| `ZAD_PROJECT` | `mpfm-w3h` | ZAD-project waarin de peer + `magazijna` draaien. |
+| `ZAD_PROJECT` | `mpfm-w3h` | ZAD-project waarin de peer + `magazijna` draaien (verschillende deployments). |
+| `ZAD_MAGAZIJNA_DEPLOYMENT` | `test` | Deployment van de `magazijna`-app waar de inway-upstream naar wijst (cross-deployment via ingress-URL). Zet bv. `pr-140` om tegen een app-preview te testen. |
 | `ZAD_BASE` | `https://zad.rijksapp.nl` | Basis-URL van de ZAD v2 Operations Manager API. |
 | `ZAD_BASE_DOMAIN` | `rig.prd1.gn2.quattro.rijksapps.nl` | Base-domain voor de per-component mesh-hostnamen. |
 | `ZAD_MANAGER_TAG` | = het `tag`-argument | Losse override voor de manager-wrapper-tag (ghcr), los van de OpenFSC stock-tag voor controller/inway. |
 | `ZAD_DIRECTORY_MANAGER_HOST` | `dirmgr-test-mft-tp9.<base-domain>` | Repo A's directory-manager-host op ZAD — pas aan als de directory op een andere deployment/project draait. |
 | `ZAD_PG_SSLMODE` | `disable` | SSL-mode voor de managed-Postgres-DSN (intra-cluster plaintext, zoals berichtenbox-JDBC). |
-| `ZAD_MAGAZIJNA_UPSTREAM_URL` | `http://magazijna:8080` | Endpoint-URL van de bestaande `magazijna`-app-component; TODO verifieer de echte intra-project-DNS-vorm vóór de eerste publicatie (zie `verify-zad.md`, stap b). |
+| `ZAD_MAGAZIJNA_UPSTREAM_URL` | `https://magazijna-<ZAD_MAGAZIJNA_DEPLOYMENT>-mpfm-w3h.<base-domain>` | Volledige override van de endpoint-URL naar de `magazijna`-app; standaard afgeleid uit `ZAD_MAGAZIJNA_DEPLOYMENT` (ingress-URL, https/:443). |
 
 De workflow leest de ZAD-key uit het secret `ZAD_API_KEY_MAGAZIJNEN` (niet `ZAD_API_KEY` direct —
 dat blijft de scriptinterne naam, gezet via `env:` in de workflow).

--- a/fsc/deploy/zad/README.md
+++ b/fsc/deploy/zad/README.md
@@ -42,9 +42,11 @@ README's voor het cert-contract resp. de lokale smokes.
 |-----------|---------|-----|
 | `ZAD_API_KEY` | — (verplicht bij `apply`) | Auth tegen de ZAD v2-API. **Niet** inline zetten (`export`, niet `ZAD_API_KEY=... ./upsert-peer.sh ...` — dat komt in de shell-history). |
 | `ZAD_PROJECT` | `mpfm-w3h` | ZAD-project waarin de peer + `magazijna` draaien. |
+| `ZAD_BASE` | `https://zad.rijksapp.nl` | Basis-URL van de ZAD v2 Operations Manager API. |
 | `ZAD_BASE_DOMAIN` | `rig.prd1.gn2.quattro.rijksapps.nl` | Base-domain voor de per-component mesh-hostnamen. |
 | `ZAD_MANAGER_TAG` | = het `tag`-argument | Losse override voor de manager-wrapper-tag (ghcr), los van de OpenFSC stock-tag voor controller/inway. |
 | `ZAD_DIRECTORY_MANAGER_HOST` | `dirmgr-test-mft-tp9.<base-domain>` | Repo A's directory-manager-host op ZAD — pas aan als de directory op een andere deployment/project draait. |
+| `ZAD_PG_SSLMODE` | `disable` | SSL-mode voor de managed-Postgres-DSN (intra-cluster plaintext, zoals berichtenbox-JDBC). |
 | `ZAD_MAGAZIJNA_UPSTREAM_URL` | `http://magazijna:8080` | Endpoint-URL van de bestaande `magazijna`-app-component; TODO verifieer de echte intra-project-DNS-vorm vóór de eerste publicatie (zie `verify-zad.md`, stap b). |
 
 De workflow leest de ZAD-key uit het secret `ZAD_API_KEY_MAGAZIJNEN` (niet `ZAD_API_KEY` direct —

--- a/fsc/deploy/zad/cert-manifest.md
+++ b/fsc/deploy/zad/cert-manifest.md
@@ -1,0 +1,67 @@
+# Cert-attachments op ZAD — magazijn-a-peer
+
+> **UITGESTELD — vereist ZAD-key / cluster / certs.** Niets in dit document is uitgevoerd: er
+> zijn geen certs gegenereerd (`fsc/pki/issue.sh` vereist `cfssl`, niet beschikbaar in deze
+> omgeving), er is niet ingelogd op de ZAD-UI en er is niets gemount. Dit is een draaiboek voor
+> de mens, ná `fsc/pki/issue.sh` (zie `fsc/pki/README.md`) en vóór `upsert-peer.sh apply`.
+
+## Waarom UI-only
+
+De ZAD v2 Operations Manager API dekt deployment + componenten (image, env_vars, aliases,
+services) maar **geen bijlagen** — net als repo A's directory-deploy
+(`deploy/zad/upsert-directory.sh`, zie de header-comment daar). Cert-mounts op
+`/etc/fsc/...`-paden gaan dus via de ZAD-UI, per component, als losse attachment-bestanden
+(geen `combined.pem` nodig — zie `fsc/pki/zad-bundle.sh`, modus 2/passthrough).
+
+## Volgorde
+
+1. `fsc/pki/issue.sh` (UITGESTELD, vereist `cfssl`) — genereert `fsc/pki/out/magazijn-a/*` en
+   `fsc/pki/internal/magazijn-a/*`.
+2. `fsc/pki/zad-bundle.sh magazijn-a` (UITGESTELD, hierboven van afhankelijk) — verzamelt de
+   upload-klare set in `fsc/pki/zad-upload/magazijn-a/` met een eigen `MANIFEST.md`
+   (bestand → pod-pad → `TLS_*`-env-var, zie dat script voor de exacte `env_for()`-mapping).
+3. Per component (`mgzmgr`, `mgzctl`, `mgzinway`) in de ZAD-UI: bijlage toevoegen op het
+   `/etc/fsc/...`-pad uit de tabellen hieronder, met de bestandsinhoud uit stap 2's
+   upload-set. De paden zijn identiek aan de `TLS_*`-waarden die `upsert-peer.sh` al als
+   `env_vars`/`aliases` naar de component stuurt — de attachment moet dus exact op dat pad
+   gemount worden, anders faalt de container-boot met een ontbrekend-bestand-fout.
+
+## mgzmgr (manager)
+
+| Bijlage-pad (`/etc/fsc/...`) | Bronbestand (`fsc/pki/...`) | Env-var op mgzmgr |
+|-------------------------------|-------------------------------------------|--------------------|
+| `ca/root.pem` | `ca/root.pem` | `TLS_GROUP_ROOT_CERT` |
+| `out/magazijn-a/manager/cert.pem` | `out/magazijn-a/manager/cert.pem` | `TLS_GROUP_CERT`, `TLS_GROUP_TOKEN_CERT`, `TLS_GROUP_CONTRACT_CERT` |
+| `out/magazijn-a/manager/key.pem` | `out/magazijn-a/manager/key.pem` | `TLS_GROUP_KEY`, `TLS_GROUP_TOKEN_KEY`, `TLS_GROUP_CONTRACT_KEY` |
+| `internal/magazijn-a/ca/root.pem` | `internal/magazijn-a/ca/root.pem` | `TLS_ROOT_CERT`, `TLS_INTERNAL_UNAUTHENTICATED_ROOT_CERT` |
+| `internal/magazijn-a/manager/cert.pem` | `internal/magazijn-a/manager/cert.pem` | `TLS_CERT`, `TLS_INTERNAL_UNAUTHENTICATED_CERT` |
+| `internal/magazijn-a/manager/key.pem` | `internal/magazijn-a/manager/key.pem` | `TLS_KEY`, `TLS_INTERNAL_UNAUTHENTICATED_KEY` |
+
+## mgzctl (controller)
+
+| Bijlage-pad (`/etc/fsc/...`) | Bronbestand (`fsc/pki/...`) | Env-var op mgzctl |
+|-------------------------------|-------------------------------------------|--------------------|
+| `internal/magazijn-a/ca/root.pem` | `internal/magazijn-a/ca/root.pem` | `TLS_ROOT_CERT` |
+| `internal/magazijn-a/controller/cert.pem` | `internal/magazijn-a/controller/cert.pem` | `TLS_CERT` |
+| `internal/magazijn-a/controller/key.pem` | `internal/magazijn-a/controller/key.pem` | `TLS_KEY` |
+
+De controller heeft geen group-cert nodig (hij spreekt geen mesh-verkeer met andere peers, alleen
+de eigen manager op de internal-PKI) — vandaar geen `out/magazijn-a/controller/*`-rij.
+
+## mgzinway (inway)
+
+| Bijlage-pad (`/etc/fsc/...`) | Bronbestand (`fsc/pki/...`) | Env-var op mgzinway |
+|-------------------------------|-------------------------------------------|--------------------|
+| `ca/root.pem` | `ca/root.pem` | `TLS_GROUP_ROOT_CERT` |
+| `out/magazijn-a/inway/cert.pem` | `out/magazijn-a/inway/cert.pem` | `TLS_GROUP_CERT` |
+| `out/magazijn-a/inway/key.pem` | `out/magazijn-a/inway/key.pem` | `TLS_GROUP_KEY` |
+| `internal/magazijn-a/ca/root.pem` | `internal/magazijn-a/ca/root.pem` | `TLS_ROOT_CERT` |
+| `internal/magazijn-a/inway/cert.pem` | `internal/magazijn-a/inway/cert.pem` | `TLS_CERT` |
+| `internal/magazijn-a/inway/key.pem` | `internal/magazijn-a/inway/key.pem` | `TLS_KEY` |
+
+## Na het mounten
+
+Herstart (of laat ZAD herstarten na attachment-wijziging) elk component en controleer de boot-log
+op een TLS-laadfout — een fout pad of een verwisselde group/internal-cert faalt hard bij startup
+("no such file", of een handshake-fout tegen de verkeerde CA). Ga daarna verder met
+`verify-zad.md`.

--- a/fsc/deploy/zad/cert-manifest.md
+++ b/fsc/deploy/zad/cert-manifest.md
@@ -15,8 +15,12 @@ services) maar **geen bijlagen** — net als repo A's directory-deploy
 
 ## Volgorde
 
-1. `fsc/pki/issue.sh` (UITGESTELD, vereist `cfssl`) — genereert `fsc/pki/out/magazijn-a/*` en
-   `fsc/pki/internal/magazijn-a/*`.
+0. **Group-CA plaatsen (NIET `init-ca.sh`).** Voor de échte directory moet de group-leaf ketenen
+   naar fsc-testnet's group-root. Zet fsc-testnet's `ca/root.pem` + `ca/intermediate.pem` (+ keys)
+   in `fsc/pki/ca/` — draai `init-ca.sh` **niet** (dat maakt een verse, vreemde CA). De
+   INTERNAL-CA blijft wél lokaal/self-signed (die maakt `issue.sh` per-peer aan).
+1. `fsc/pki/issue.sh` (UITGESTELD, vereist `cfssl`) — genereert `fsc/pki/out/magazijn-a/*` (group,
+   getekend door fsc-testnet's intermediate) en `fsc/pki/internal/magazijn-a/*` (internal).
 2. `fsc/pki/zad-bundle.sh magazijn-a` (UITGESTELD, hierboven van afhankelijk) — verzamelt de
    upload-klare set in `fsc/pki/zad-upload/magazijn-a/` met een eigen `MANIFEST.md`
    (bestand → pod-pad → `TLS_*`-env-var, zie dat script voor de exacte `env_for()`-mapping).

--- a/fsc/deploy/zad/cert-manifest.md
+++ b/fsc/deploy/zad/cert-manifest.md
@@ -63,6 +63,17 @@ de eigen manager op de internal-PKI) — vandaar geen `out/magazijn-a/controller
 | `internal/magazijn-a/inway/cert.pem` | `internal/magazijn-a/inway/cert.pem` | `TLS_CERT` |
 | `internal/magazijn-a/inway/key.pem` | `internal/magazijn-a/inway/key.pem` | `TLS_KEY` |
 
+## mgztxlog (txlog-api)
+
+txlog spreekt uitsluitend mTLS op de INTERNAL-PKI (geen group-cert — group-agnostische opslag),
+net als in de lokale compose.
+
+| Bijlage-pad (`/etc/fsc/...`) | Bronbestand (`fsc/pki/...`) | Env-var op mgztxlog |
+|-------------------------------|-------------------------------------------|--------------------|
+| `internal/magazijn-a/ca/root.pem` | `internal/magazijn-a/ca/root.pem` | `TLS_ROOT_CERT` |
+| `internal/magazijn-a/txlog/cert.pem` | `internal/magazijn-a/txlog/cert.pem` | `TLS_CERT` |
+| `internal/magazijn-a/txlog/key.pem` | `internal/magazijn-a/txlog/key.pem` | `TLS_KEY` |
+
 ## Na het mounten
 
 Herstart (of laat ZAD herstarten na attachment-wijziging) elk component en controleer de boot-log

--- a/fsc/deploy/zad/upsert-peer.sh
+++ b/fsc/deploy/zad/upsert-peer.sh
@@ -4,11 +4,17 @@
 # deploy/zad/upsert-directory.sh (MinBZK/moza-fsc-testnet) — zelfde validate/plan/apply-vorm, één
 # bron voor CLI + de workflow zad-deploy-peer.yml.
 #
-# Model: PR = eigen deployment `pr-<PR-nummer>`; main -> deployment `test`. `:upsert-deployment`
-# zet per component de {reference,image} en maakt/updatet het deployment; POST /components
-# verrijkt elke component met env_vars/port/services/aliases. Anders dan de directory-upsert
-# ondersteunt dit script GEEN cloneFrom: elke apply herschrijft alle drie de provider-componenten
-# voor de opgegeven deployment.
+# Model: de peer draait in een eigen deployment (default `peer`). `:upsert-deployment` zet per
+# component de {reference,image} en maakt/updatet het deployment; POST /components verrijkt elke
+# component met env_vars/port/services/aliases.
+#
+# BELANGRIJK — cloneFrom is VERPLICHT om een NIEUWE deployment aan te maken: een `:upsert-deployment`
+# zónder cloneFrom geeft wel HTTP 202 maar creëert géén nieuwe deployment (bewezen: de deployment
+# verscheen niet in /deployments). Alle bestaande deployments zijn via clone-from ontstaan. We
+# clonen daarom van `test` (ZAD_PEER_CLONE_FROM), met forceClone=false zodat een re-run een reeds
+# bestaande `peer` NIET terugzet (idempotent; onze mgz-componenten blijven staan). Neveneffect: de
+# eerste clone brengt de app-componenten (clickhouse/magazijna/magazijnb) mee in `peer` — onschadelijk
+# en los te trimmen; de inway-upstream wijst standaard naar de stabiele `test`-magazijna.
 # NIET via de API (UI-only): bijlagen (cert-mount) + "Publicatie op het web" (passthrough-TLS) —
 # zie cert-manifest.md.
 #
@@ -44,6 +50,7 @@ PROJECT="${ZAD_PROJECT:-mpfm-w3h}"
 BASE="${ZAD_BASE:-https://zad.rijksapp.nl}"
 BASE_DOMAIN="${ZAD_BASE_DOMAIN:-rig.prd1.gn2.quattro.rijksapps.nl}"
 PG_SSLMODE="${ZAD_PG_SSLMODE:-disable}"          # managed DB intra-cluster: plaintext (zoals berichtenbox-JDBC)
+CLONE_FROM="${ZAD_PEER_CLONE_FROM:-test}"        # bron-deployment om `peer` van te clonen (verplicht om nieuw aan te maken)
 
 case "${MODE}" in validate|plan|apply) ;; *) echo "mode = validate | plan | apply"; exit 1 ;; esac
 case "${DEPLOYMENT}" in ""|*[!a-z0-9-]*) echo "ongeldige deployment: '${DEPLOYMENT}'"; exit 1 ;; esac
@@ -166,10 +173,11 @@ component_body() {  # $1=name $2=image $3=port $4=env  [$5=services_json=[]]  [$
      + (if $aliases == "" then {} else {aliases:$aliases} end)'
 }
 
-DEPLOY_BODY="$(jq -n --arg d "${DEPLOYMENT}" \
+DEPLOY_BODY="$(jq -n --arg d "${DEPLOYMENT}" --arg cf "${CLONE_FROM}" \
   --arg mgr "${MANAGER_IMAGE}" --arg ctl "${CONTROLLER_IMAGE}" --arg inway "${INWAY_IMAGE}" \
   '{deploymentName:$d, domain_format:"component-deployment-project",
-    components:[{reference:"mgzmgr", image:$mgr}, {reference:"mgzctl", image:$ctl}, {reference:"mgzinway", image:$inway}]}')"
+    components:[{reference:"mgzmgr", image:$mgr}, {reference:"mgzctl", image:$ctl}, {reference:"mgzinway", image:$inway}]}
+   + (if $cf=="" then {} else {cloneFrom:$cf, forceClone:false} end)')"
 
 MGZMGR_BODY="$(component_body mgzmgr "${MANAGER_IMAGE}" 8443 "${MGZMGR_ENV}" '["postgresql-database"]' "${MGZMGR_ALIASES}")"
 MGZCTL_BODY="$(component_body mgzctl "${CONTROLLER_IMAGE}" 8080 "${MGZCTL_ENV}" '["postgresql-database"]' "${MGZCTL_ALIASES}")"

--- a/fsc/deploy/zad/upsert-peer.sh
+++ b/fsc/deploy/zad/upsert-peer.sh
@@ -71,13 +71,15 @@ MGZINWAY_HOST='mgzinway-$DEPLOYMENT_NAME-'"${PROJECT}.${BASE_DOMAIN}"
 # directory-host is; override met ZAD_DIRECTORY_MANAGER_HOST als de directory elders draait.
 DIRECTORY_MANAGER_HOST="${ZAD_DIRECTORY_MANAGER_HOST:-dirmgr-test-mft-tp9.${BASE_DOMAIN}}"
 
-# TODO(verifieer intra-project-DNS-vorm van magazijna in mpfm-w3h): bare servicenaam vs.
-# koppelteken-vorm (bv. "magazijna" of "magazijna-<deployment>-mpfm-w3h"). Dit is GEEN inway-
-# env-var (OpenFSC kent geen "upstream" op de inway zelf) maar de endpoint_url die bij de
-# service-publicatie op de mgzctl Administration-API wordt meegegeven — analoog aan
-# fsc/deploy/local/publish-service.sh se STUB_URL, maar dan de bestaande magazijna-app-component
-# intra-project i.p.v. de lokale stub. Zie verify-zad.md, stap (b).
-MAGAZIJNA_UPSTREAM_URL="${ZAD_MAGAZIJNA_UPSTREAM_URL:-http://magazijna:8080}"
+# De peer draait in een EIGEN deployment (`peer`, clobber-veilig los van deploy.yml's
+# `test`/`pr-<n>`), dus de inway bereikt de magazijna-app-component cross-deployment via de
+# ZAD-ingress-URL (https, :443 — de ingress mapt naar de app-containerpoort; geen poort in de
+# URL). Default = de stabiele `test`-deployment van de app; override met ZAD_MAGAZIJNA_DEPLOYMENT
+# (bv. een PR-preview `pr-140`) of volledig met ZAD_MAGAZIJNA_UPSTREAM_URL. Dit is GEEN inway-
+# env-var (OpenFSC kent geen "upstream" op de inway) maar de endpoint_url die bij de service-
+# publicatie op de mgzctl Administration-API wordt meegegeven — zie verify-zad.md, stap (b).
+MAGAZIJNA_DEPLOYMENT="${ZAD_MAGAZIJNA_DEPLOYMENT:-test}"
+MAGAZIJNA_UPSTREAM_URL="${ZAD_MAGAZIJNA_UPSTREAM_URL:-https://magazijna-${MAGAZIJNA_DEPLOYMENT}-${PROJECT}.${BASE_DOMAIN}}"
 
 # --- env-blobs (KEY=value, newline-sep, plain). TLS_*-paden = de bijlage-mounts (UI, ontwerp A). ---
 MGZMGR_ENV="$(printf '%s\n' \
@@ -181,7 +183,7 @@ if [ "${MODE}" = plan ]; then
   echo "### component mgzinway (inway)"; echo "${MGZINWAY_BODY}"
   echo "Hostnamen (deployment '${DEPLOYMENT}'): mgzmgr=${MGZMGR_HOST_DISPLAY} mgzctl=${MGZCTL_HOST_DISPLAY} mgzinway=${MGZINWAY_HOST_DISPLAY}"
   echo "Directory-manager (repo A, extern): ${DIRECTORY_MANAGER_HOST}"
-  echo "Upstream naar de app (TODO verifieer intra-project-DNS-vorm van magazijna): ${MAGAZIJNA_UPSTREAM_URL}"
+  echo "Upstream naar de app (ingress-URL, cross-deployment): ${MAGAZIJNA_UPSTREAM_URL}"
   exit 0
 fi
 

--- a/fsc/deploy/zad/upsert-peer.sh
+++ b/fsc/deploy/zad/upsert-peer.sh
@@ -8,13 +8,12 @@
 # component de {reference,image} en maakt/updatet het deployment; POST /components verrijkt elke
 # component met env_vars/port/services/aliases.
 #
-# BELANGRIJK — cloneFrom is VERPLICHT om een NIEUWE deployment aan te maken: een `:upsert-deployment`
-# zónder cloneFrom geeft wel HTTP 202 maar creëert géén nieuwe deployment (bewezen: de deployment
-# verscheen niet in /deployments). Alle bestaande deployments zijn via clone-from ontstaan. We
-# clonen daarom van `test` (ZAD_PEER_CLONE_FROM), met forceClone=false zodat een re-run een reeds
-# bestaande `peer` NIET terugzet (idempotent; onze mgz-componenten blijven staan). Neveneffect: de
-# eerste clone brengt de app-componenten (clickhouse/magazijna/magazijnb) mee in `peer` — onschadelijk
-# en los te trimmen; de inway-upstream wijst standaard naar de stabiele `test`-magazijna.
+# BELANGRIJK — het `peer`-deployment moet ÉÉNMALIG handmatig (leeg) worden aangemaakt in de
+# Operations Manager-UI. Een `:upsert-deployment` zónder cloneFrom geeft wel HTTP 202 maar creëert
+# géén NIEUWE deployment (bewezen: `peer` verscheen niet in /deployments). Een BESTAAND (leeg)
+# deployment wordt door `:upsert-deployment` + `POST /components` wél gevuld/geüpdatet — dat is dit
+# script. cloneFrom is optioneel (ZAD_PEER_CLONE_FROM) maar afgeraden: clonen van bv. `test` sleept
+# de app-images (clickhouse/magazijna/magazijnb) mee in `peer`.
 # NIET via de API (UI-only): bijlagen (cert-mount) + "Publicatie op het web" (passthrough-TLS) —
 # zie cert-manifest.md.
 #
@@ -50,7 +49,7 @@ PROJECT="${ZAD_PROJECT:-mpfm-w3h}"
 BASE="${ZAD_BASE:-https://zad.rijksapp.nl}"
 BASE_DOMAIN="${ZAD_BASE_DOMAIN:-rig.prd1.gn2.quattro.rijksapps.nl}"
 PG_SSLMODE="${ZAD_PG_SSLMODE:-disable}"          # managed DB intra-cluster: plaintext (zoals berichtenbox-JDBC)
-CLONE_FROM="${ZAD_PEER_CLONE_FROM:-test}"        # bron-deployment om `peer` van te clonen (verplicht om nieuw aan te maken)
+CLONE_FROM="${ZAD_PEER_CLONE_FROM:-}"            # leeg = geen clone; `peer` wordt éénmalig handmatig (leeg) aangemaakt
 
 case "${MODE}" in validate|plan|apply) ;; *) echo "mode = validate | plan | apply"; exit 1 ;; esac
 case "${DEPLOYMENT}" in ""|*[!a-z0-9-]*) echo "ongeldige deployment: '${DEPLOYMENT}'"; exit 1 ;; esac

--- a/fsc/deploy/zad/upsert-peer.sh
+++ b/fsc/deploy/zad/upsert-peer.sh
@@ -20,11 +20,10 @@
 # $DEPLOYMENT_NAME (letterlijk, ZAD-substitutievar) wordt gebruikt voor de per-deployment
 # hostnamen van mgzmgr/mgzctl/mgzinway, zodat één (project-brede) component-definitie in elke
 # deployment (test, pr-...) de juiste hostnaam krijgt — zie de MGZ*_HOST-opbouw hieronder.
-# AANNAME (niet geverifieerd — validate/apply zijn UITGESTELD): ZAD substitueert $DEPLOYMENT_NAME
-# zowel in `env_vars` als in `aliases`; component-onderlinge adressen (bv. CONTROLLER_REGISTRATION_
-# API_ADDRESS op mgzmgr) staan daarom in `env_vars`, analoog aan hoe repo A's directory-upsert dat
-# al deed voor de eigen SELF_ADDRESS/DIRECTORY_MANAGER_ADDRESS (die wél in `aliases` staan, omdat
-# ze zowel $DEPLOYMENT_NAME als — voor de DSN — $DATABASE_* nodig hebben).
+# ZAD substitueert $DEPLOYMENT_NAME en $DATABASE_* UITSLUITEND in `aliases`, niet in `env_vars`
+# (zie repo A's upsert-directory.sh). Elke waarde die zo'n substitutievar bevat — ook
+# component-onderlinge adressen zoals CONTROLLER_REGISTRATION_API_ADDRESS op mgzmgr — hoort dus
+# in `aliases`; alleen waarden zonder substitutievar horen in `env_vars`.
 #
 # Usage:
 #   export ZAD_API_KEY=...                          # niet inline (echo't anders)
@@ -87,7 +86,6 @@ MGZMGR_ENV="$(printf '%s\n' \
   "DIRECTORY_PEER_ID=00000000000000000010" \
   "TX_LOG_API_ADDRESS=" \
   "AUTO_SIGN_GRANTS=" \
-  "CONTROLLER_REGISTRATION_API_ADDRESS=https://${MGZCTL_HOST}:443" \
   "LISTEN_ADDRESS_EXTERNAL=0.0.0.0:8443" \
   "LISTEN_ADDRESS_INTERNAL=0.0.0.0:9443" \
   "LISTEN_ADDRESS_INTERNAL_UNAUTHENTICATED=0.0.0.0:9444" \
@@ -114,6 +112,7 @@ MGZMGR_ENV="$(printf '%s\n' \
 MGZMGR_ALIASES="$(printf '%s\n' \
   "SELF_ADDRESS=https://${MGZMGR_HOST}:443" \
   "DIRECTORY_MANAGER_ADDRESS=https://${DIRECTORY_MANAGER_HOST}:443" \
+  "CONTROLLER_REGISTRATION_API_ADDRESS=https://${MGZCTL_HOST}:443" \
   "STORAGE_POSTGRES_DSN=postgres://\$DATABASE_SERVER_USER:\$DATABASE_PASSWORD@\$DATABASE_SERVER_HOST:5432/\$DATABASE_DB?sslmode=${PG_SSLMODE}")"
 
 MGZCTL_ENV="$(printf '%s\n' \
@@ -123,7 +122,6 @@ MGZCTL_ENV="$(printf '%s\n' \
   "AUTHN_TYPE=none" \
   "AUTHZ_TYPE=rbac" \
   "CSRF_PROTECTION_ENABLED=false" \
-  "MANAGER_ADDRESS_INTERNAL=https://${MGZMGR_HOST}:443" \
   "LISTEN_ADDRESS_UI=0.0.0.0:8080" \
   "LISTEN_ADDRESS_REGISTRATION_API=0.0.0.0:9443" \
   "LISTEN_ADDRESS_ADMINISTRATION_API=0.0.0.0:9444" \
@@ -132,15 +130,14 @@ MGZCTL_ENV="$(printf '%s\n' \
   "TLS_CERT=/etc/fsc/internal/magazijn-a/controller/cert.pem" \
   "TLS_KEY=/etc/fsc/internal/magazijn-a/controller/key.pem")"
 # mgzctl heeft een eigen managed Postgres (los van mgzmgr's DB) -> eigen DSN-alias.
-MGZCTL_ALIASES="STORAGE_POSTGRES_DSN=postgres://\$DATABASE_SERVER_USER:\$DATABASE_PASSWORD@\$DATABASE_SERVER_HOST:5432/\$DATABASE_DB?sslmode=${PG_SSLMODE}"
+MGZCTL_ALIASES="$(printf '%s\n' \
+  "MANAGER_ADDRESS_INTERNAL=https://${MGZMGR_HOST}:443" \
+  "STORAGE_POSTGRES_DSN=postgres://\$DATABASE_SERVER_USER:\$DATABASE_PASSWORD@\$DATABASE_SERVER_HOST:5432/\$DATABASE_DB?sslmode=${PG_SSLMODE}")"
 
 MGZINWAY_ENV="$(printf '%s\n' \
   "LOG_TYPE=live" "LOG_LEVEL=info" \
   "NAME=magazijn-a-inway" \
   "GROUP_ID=moza-fbs-test" \
-  "SELF_ADDRESS=https://${MGZINWAY_HOST}:443" \
-  "CONTROLLER_REGISTRATION_API_ADDRESS=https://${MGZCTL_HOST}:443" \
-  "MANAGER_INTERNAL_UNAUTHENTICATED_ADDRESS=https://${MGZMGR_HOST}:443" \
   "TX_LOG_API_ADDRESS=" \
   "LISTEN_ADDRESS=0.0.0.0:8443" \
   "MONITORING_ADDRESS=0.0.0.0:8081" \
@@ -151,8 +148,12 @@ MGZINWAY_ENV="$(printf '%s\n' \
   "TLS_ROOT_CERT=/etc/fsc/internal/magazijn-a/ca/root.pem" \
   "TLS_CERT=/etc/fsc/internal/magazijn-a/inway/cert.pem" \
   "TLS_KEY=/etc/fsc/internal/magazijn-a/inway/key.pem")"
-# Geen managed DB, geen zelf-adres met $DATABASE_*-substitutie nodig -> geen aliases.
-MGZINWAY_ALIASES=""
+# Geen managed DB, dus geen $DATABASE_*-substitutie nodig; wel drie mesh-adressen met
+# $DEPLOYMENT_NAME -> die horen in aliases (env_vars expandeert geen ZAD-substitutievars).
+MGZINWAY_ALIASES="$(printf '%s\n' \
+  "SELF_ADDRESS=https://${MGZINWAY_HOST}:443" \
+  "CONTROLLER_REGISTRATION_API_ADDRESS=https://${MGZCTL_HOST}:443" \
+  "MANAGER_INTERNAL_UNAUTHENTICATED_ADDRESS=https://${MGZMGR_HOST}:443")"
 
 # component-body (AddComponentRequest) via jq -> correcte JSON-escaping.
 component_body() {  # $1=name $2=image $3=port $4=env  [$5=services_json=[]]  [$6=aliases=""]

--- a/fsc/deploy/zad/upsert-peer.sh
+++ b/fsc/deploy/zad/upsert-peer.sh
@@ -1,19 +1,23 @@
 #!/usr/bin/env bash
 # Zet de provider-peer magazijn-a (manager+controller+inway) op ZAD via de v2 Operations Manager
-# API, naast de bestaande app-component `magazijna` in project mpfm-w3h. Gebaseerd op repo A's
-# deploy/zad/upsert-directory.sh (MinBZK/moza-fsc-testnet) — zelfde validate/plan/apply-vorm, één
-# bron voor CLI + de workflow zad-deploy-peer.yml.
+# API in een EIGEN ZAD-project `mpfoa-e01`. De `magazijna`-app draait apart in `mpfm-w3h`; de inway
+# bereikt die cross-project via de ingress-URL (ZAD_MAGAZIJNA_PROJECT/-UPSTREAM_URL). Gebaseerd op
+# repo A's deploy/zad/upsert-directory.sh (MinBZK/moza-fsc-testnet) — zelfde validate/plan/apply-
+# vorm, één bron voor CLI + de workflow zad-deploy-peer.yml.
 #
-# Model: de peer draait in een eigen deployment (default `peer`). `:upsert-deployment` zet per
-# component de {reference,image} en maakt/updatet het deployment; POST /components verrijkt elke
-# component met env_vars/port/services/aliases.
+# Eigen project = eigen ZAD-API-key: ZAD_API_KEY hoort bij `mpfoa-e01`, NIET de magazijnen-key.
 #
-# BELANGRIJK — het `peer`-deployment moet ÉÉNMALIG handmatig (leeg) worden aangemaakt in de
-# Operations Manager-UI. Een `:upsert-deployment` zónder cloneFrom geeft wel HTTP 202 maar creëert
-# géén NIEUWE deployment (bewezen: `peer` verscheen niet in /deployments). Een BESTAAND (leeg)
-# deployment wordt door `:upsert-deployment` + `POST /components` wél gevuld/geüpdatet — dat is dit
-# script. cloneFrom is optioneel (ZAD_PEER_CLONE_FROM) maar afgeraden: clonen van bv. `test` sleept
-# de app-images (clickhouse/magazijna/magazijnb) mee in `peer`.
+# Model: de peer draait in de deployment `test` van het eigen project. Doordat het een eigen project
+# is, is er geen app-deployment om te overschrijven (project-isolatie i.p.v. deployment-isolatie).
+# `:upsert-deployment` zet per component de {reference,image} en updatet het deployment;
+# POST /components verrijkt elke component met env_vars/port/services/aliases.
+#
+# BELANGRIJK — `:upsert-deployment` maakt géén NIEUW deployment aan (geeft wel HTTP 202, maar het
+# deployment verschijnt niet in /deployments); het UPDATET alleen een bestaand deployment. `test` is
+# doorgaans het default-deployment van een nieuw ZAD-project en bestaat dus al — dit script vult het.
+# Bestaat het (nog) niet, maak het dan éénmalig handmatig (leeg) aan in de Operations Manager-UI.
+# cloneFrom is optioneel (ZAD_PEER_CLONE_FROM) maar afgeraden: clonen van bv. de app sleept de
+# app-images (clickhouse/magazijna/magazijnb) mee.
 # NIET via de API (UI-only): bijlagen (cert-mount) + "Publicatie op het web" (passthrough-TLS) —
 # zie cert-manifest.md.
 #
@@ -35,21 +39,22 @@
 #   ./fsc/deploy/zad/upsert-peer.sh validate                       # read-only auth-check
 #   ./fsc/deploy/zad/upsert-peer.sh plan   [deployment] [tag]       # toont bodies, muteert niet
 #   ./fsc/deploy/zad/upsert-peer.sh apply  [deployment] [tag]       # muteert + pollt tasks
-# Env: ZAD_API_KEY (verplicht bij apply), ZAD_PROJECT (mpfm-w3h), ZAD_BASE (zad.rijksapp.nl),
-#      ZAD_BASE_DOMAIN (rig.prd1...), ZAD_MANAGER_TAG (ghcr manager-tag, default = tag),
-#      ZAD_DIRECTORY_MANAGER_HOST (repo A's directory-manager-host op ZAD), ZAD_PG_SSLMODE (disable),
-#      ZAD_MAGAZIJNA_UPSTREAM_URL (endpoint_url van de app-component, zie TODO bij mgzinway).
+# Env: ZAD_API_KEY (verplicht bij apply; key van project mpfoa-e01), ZAD_PROJECT (mpfoa-e01),
+#      ZAD_BASE (zad.rijksapp.nl), ZAD_BASE_DOMAIN (rig.prd1...), ZAD_MANAGER_TAG (ghcr manager-tag,
+#      default = tag), ZAD_DIRECTORY_MANAGER_HOST (repo A's directory-manager-host op ZAD),
+#      ZAD_PG_SSLMODE (disable), ZAD_MAGAZIJNA_PROJECT (mpfm-w3h, waar de app draait),
+#      ZAD_MAGAZIJNA_UPSTREAM_URL (endpoint_url van de app-component, cross-project ingress-URL).
 set -euo pipefail
 
 MODE="${1:?usage: upsert-peer.sh <validate|plan|apply> [deployment=test] [tag=v1.43.7]}"
 DEPLOYMENT="${2:-test}"
 IMAGE_TAG="${3:-v1.43.7}"                        # OpenFSC stock-tag (controller/inway; default voor de manager-wrapper)
 MANAGER_TAG="${ZAD_MANAGER_TAG:-${IMAGE_TAG}}"   # manager-migrate (ghcr) kan een eigen tag hebben
-PROJECT="${ZAD_PROJECT:-mpfm-w3h}"
+PROJECT="${ZAD_PROJECT:-mpfoa-e01}"
 BASE="${ZAD_BASE:-https://zad.rijksapp.nl}"
 BASE_DOMAIN="${ZAD_BASE_DOMAIN:-rig.prd1.gn2.quattro.rijksapps.nl}"
 PG_SSLMODE="${ZAD_PG_SSLMODE:-disable}"          # managed DB intra-cluster: plaintext (zoals berichtenbox-JDBC)
-CLONE_FROM="${ZAD_PEER_CLONE_FROM:-}"            # leeg = geen clone; `peer` wordt éénmalig handmatig (leeg) aangemaakt
+CLONE_FROM="${ZAD_PEER_CLONE_FROM:-}"            # leeg = geen clone; `test` bestaat doorgaans al als project-default
 
 case "${MODE}" in validate|plan|apply) ;; *) echo "mode = validate | plan | apply"; exit 1 ;; esac
 case "${DEPLOYMENT}" in ""|*[!a-z0-9-]*) echo "ongeldige deployment: '${DEPLOYMENT}'"; exit 1 ;; esac
@@ -77,15 +82,17 @@ MGZINWAY_HOST='mgzinway-$DEPLOYMENT_NAME-'"${PROJECT}.${BASE_DOMAIN}"
 # directory-host is; override met ZAD_DIRECTORY_MANAGER_HOST als de directory elders draait.
 DIRECTORY_MANAGER_HOST="${ZAD_DIRECTORY_MANAGER_HOST:-dirmgr-test-mft-tp9.${BASE_DOMAIN}}"
 
-# De peer draait in een EIGEN deployment (`peer`, clobber-veilig los van deploy.yml's
-# `test`/`pr-<n>`), dus de inway bereikt de magazijna-app-component cross-deployment via de
-# ZAD-ingress-URL (https, :443 — de ingress mapt naar de app-containerpoort; geen poort in de
-# URL). Default = de stabiele `test`-deployment van de app; override met ZAD_MAGAZIJNA_DEPLOYMENT
-# (bv. een PR-preview `pr-140`) of volledig met ZAD_MAGAZIJNA_UPSTREAM_URL. Dit is GEEN inway-
-# env-var (OpenFSC kent geen "upstream" op de inway) maar de endpoint_url die bij de service-
-# publicatie op de mgzctl Administration-API wordt meegegeven — zie verify-zad.md, stap (b).
+# De peer draait in een EIGEN project (`mpfoa-e01`); de magazijna-app draait in `mpfm-w3h`. De inway
+# bereikt de app dus CROSS-PROJECT via de ZAD-ingress-URL (https, :443 — de ingress mapt naar de
+# app-containerpoort; geen poort in de URL). De upstream-URL is daarom afgeleid van het APP-project
+# (ZAD_MAGAZIJNA_PROJECT, NIET het peer-PROJECT) + de app-deployment. Default-app-deployment =
+# `test`; override met ZAD_MAGAZIJNA_DEPLOYMENT (bv. een PR-preview `pr-140`) of volledig met
+# ZAD_MAGAZIJNA_UPSTREAM_URL. Dit is GEEN inway-env-var (OpenFSC kent geen "upstream" op de inway)
+# maar de endpoint_url die bij de service-publicatie op de mgzctl Administration-API wordt
+# meegegeven — zie verify-zad.md, stap (b).
+MAGAZIJNA_PROJECT="${ZAD_MAGAZIJNA_PROJECT:-mpfm-w3h}"
 MAGAZIJNA_DEPLOYMENT="${ZAD_MAGAZIJNA_DEPLOYMENT:-test}"
-MAGAZIJNA_UPSTREAM_URL="${ZAD_MAGAZIJNA_UPSTREAM_URL:-https://magazijna-${MAGAZIJNA_DEPLOYMENT}-${PROJECT}.${BASE_DOMAIN}}"
+MAGAZIJNA_UPSTREAM_URL="${ZAD_MAGAZIJNA_UPSTREAM_URL:-https://magazijna-${MAGAZIJNA_DEPLOYMENT}-${MAGAZIJNA_PROJECT}.${BASE_DOMAIN}}"
 
 # --- env-blobs (KEY=value, newline-sep, plain). TLS_*-paden = de bijlage-mounts (UI, ontwerp A). ---
 MGZMGR_ENV="$(printf '%s\n' \

--- a/fsc/deploy/zad/upsert-peer.sh
+++ b/fsc/deploy/zad/upsert-peer.sh
@@ -21,18 +21,20 @@
 # NIET via de API (UI-only): bijlagen (cert-mount) + "Publicatie op het web" (passthrough-TLS) —
 # zie cert-manifest.md.
 #
-# DB: elke component met een eigen managed Postgres (mgzmgr, mgzctl) krijgt zijn STORAGE_POSTGRES_DSN
-# via ZAD-substitutievars ($DATABASE_*), in de `aliases`-body — die vars zijn pas bij deploy-tijd
-# bekend en kunnen dus niet in bash worden opgelost. txlog is in deze bundel bewust NIET meegenomen
-# (TX_LOG_API_ADDRESS staat leeg op mgzmgr/mgzinway — txlog-hardening is later werk).
+# DB: elke component met een eigen managed Postgres (mgzmgr, mgzctl, mgztxlog) krijgt zijn
+# STORAGE_POSTGRES_DSN via ZAD-substitutievars ($DATABASE_*), in de `aliases`-body — die vars zijn
+# pas bij deploy-tijd bekend en kunnen dus niet in bash worden opgelost. Dat is het ENIGE dat in
+# aliases hoeft.
 #
-# $DEPLOYMENT_NAME (letterlijk, ZAD-substitutievar) wordt gebruikt voor de per-deployment
-# hostnamen van mgzmgr/mgzctl/mgzinway, zodat één (project-brede) component-definitie in elke
-# deployment (test, pr-...) de juiste hostnaam krijgt — zie de MGZ*_HOST-opbouw hieronder.
-# ZAD substitueert $DEPLOYMENT_NAME en $DATABASE_* UITSLUITEND in `aliases`, niet in `env_vars`
-# (zie repo A's upsert-directory.sh). Elke waarde die zo'n substitutievar bevat — ook
-# component-onderlinge adressen zoals CONTROLLER_REGISTRATION_API_ADDRESS op mgzmgr — hoort dus
-# in `aliases`; alleen waarden zonder substitutievar horen in `env_vars`.
+# BELANGRIJK — ZAD past component-config (env_vars/aliases) alleen bij COMPONENT-CREATIE toe, niet
+# bij een re-POST op een bestaande component (bewezen: een tx-log-adres dat pas in een tweede deploy
+# aan de aliases werd toegevoegd bereikte de al-bestaande manager niet). Wijzig je de config van een
+# bestaande component, verwijder 'm dan eerst in de UI zodat de volgende apply 'm opnieuw aanmaakt.
+#
+# De deployment is VAST (test/mpfoa-e01), dus we hebben ZAD's $DEPLOYMENT_NAME-substitutie niet
+# nodig: bash lost alle inter-component-hostnamen concreet op (MGZ*_HOST_DISPLAY) en zet ze in
+# `env_vars`. Zo leunen de adressen niet op aliases-substitutie. Alleen de DSN ($DATABASE_*) blijft
+# in `aliases`.
 #
 # Usage:
 #   export ZAD_API_KEY=...                          # niet inline (echo't anders)
@@ -67,18 +69,14 @@ CONTROLLER_IMAGE="docker.io/federatedserviceconnectivity/controller:${IMAGE_TAG}
 INWAY_IMAGE="docker.io/federatedserviceconnectivity/inway:${IMAGE_TAG}"
 TXLOG_IMAGE="docker.io/federatedserviceconnectivity/txlog-api:${IMAGE_TAG}"
 
-# Display-hostnamen (déze deployment, voor de mens-leesbare plan-/apply-output).
+# Concrete hostnamen voor déze (vaste) deployment — zowel voor de plan-/apply-output als, direct,
+# voor de inter-component-adressen in de env_vars-blobs. Geen $DEPLOYMENT_NAME-substitutie: de
+# deployment is vast (test/mpfoa-e01), dus bash lost de hostnaam op en we leunen niet op ZAD's
+# aliases-substitutie (die alleen bij component-creatie wordt toegepast, niet bij een re-POST).
 MGZMGR_HOST_DISPLAY="mgzmgr-${DEPLOYMENT}-${PROJECT}.${BASE_DOMAIN}"
 MGZCTL_HOST_DISPLAY="mgzctl-${DEPLOYMENT}-${PROJECT}.${BASE_DOMAIN}"
 MGZINWAY_HOST_DISPLAY="mgzinway-${DEPLOYMENT}-${PROJECT}.${BASE_DOMAIN}"
 MGZTXLOG_HOST_DISPLAY="mgztxlog-${DEPLOYMENT}-${PROJECT}.${BASE_DOMAIN}"
-
-# Deployment-agnostische hostnamen voor in de component-bodies: ZAD vult $DEPLOYMENT_NAME per
-# deployment in (test, pr-...) -> hoort in env_vars/aliases, niet in bash opgelost.
-MGZMGR_HOST='mgzmgr-$DEPLOYMENT_NAME-'"${PROJECT}.${BASE_DOMAIN}"
-MGZCTL_HOST='mgzctl-$DEPLOYMENT_NAME-'"${PROJECT}.${BASE_DOMAIN}"
-MGZINWAY_HOST='mgzinway-$DEPLOYMENT_NAME-'"${PROJECT}.${BASE_DOMAIN}"
-MGZTXLOG_HOST='mgztxlog-$DEPLOYMENT_NAME-'"${PROJECT}.${BASE_DOMAIN}"
 
 # Repo A's directory-deployment op ZAD (project mft-tp9, deployment "test" — zie upsert-directory.sh
 # se defaults). TODO(verifieer bij de echte apply): bevestig dat dit nog steeds de actieve
@@ -120,17 +118,18 @@ MGZMGR_ENV="$(printf '%s\n' \
   "TLS_KEY=/etc/fsc/internal/magazijn-a/manager/key.pem" \
   "TLS_INTERNAL_UNAUTHENTICATED_ROOT_CERT=/etc/fsc/internal/magazijn-a/ca/root.pem" \
   "TLS_INTERNAL_UNAUTHENTICATED_CERT=/etc/fsc/internal/magazijn-a/manager/cert.pem" \
-  "TLS_INTERNAL_UNAUTHENTICATED_KEY=/etc/fsc/internal/magazijn-a/manager/key.pem")"
-
-# Aliases = env-vars met ZAD-substitutievars ($DEPLOYMENT_NAME voor de eigen hostnaam, $DATABASE_*
-# voor de managed Postgres). \$ houdt ze letterlijk (ZAD vult ze per deployment in, niet de shell).
-# :443 = de mesh-poort (ingress SNI-passthrough -> pod :8443); OpenFSC eist een expliciete poort in
-# het manager-adres (zie upsert-directory.sh), dus niet weglaten.
-MGZMGR_ALIASES="$(printf '%s\n' \
-  "SELF_ADDRESS=https://${MGZMGR_HOST}:443" \
+  "TLS_INTERNAL_UNAUTHENTICATED_KEY=/etc/fsc/internal/magazijn-a/manager/key.pem" \
+  "SELF_ADDRESS=https://${MGZMGR_HOST_DISPLAY}:443" \
   "DIRECTORY_MANAGER_ADDRESS=https://${DIRECTORY_MANAGER_HOST}:443" \
-  "CONTROLLER_REGISTRATION_API_ADDRESS=https://${MGZCTL_HOST}:443" \
-  "TX_LOG_API_ADDRESS=https://${MGZTXLOG_HOST}:443" \
+  "CONTROLLER_REGISTRATION_API_ADDRESS=https://${MGZCTL_HOST_DISPLAY}:443" \
+  "TX_LOG_API_ADDRESS=https://${MGZTXLOG_HOST_DISPLAY}:443")"
+
+# Aliases = ALLEEN wat een ZAD-substitutievar ($DATABASE_*) nodig heeft: de managed-Postgres-DSN,
+# want die creds zijn pas bij deploy-tijd bekend. \$ houdt ze letterlijk (ZAD vult ze in, niet de
+# shell). De inter-component-adressen staan hierboven concreet in env_vars — geen $DEPLOYMENT_NAME
+# nodig want de deployment is vast, en zo hoeven ze niet op ZAD's aliases-substitutie te leunen.
+# :443 = de mesh-poort (ingress SNI-passthrough -> pod :8443); OpenFSC eist een expliciete poort.
+MGZMGR_ALIASES="$(printf '%s\n' \
   "STORAGE_POSTGRES_DSN=postgres://\$DATABASE_SERVER_USER:\$DATABASE_PASSWORD@\$DATABASE_SERVER_HOST:5432/\$DATABASE_DB?sslmode=${PG_SSLMODE}")"
 
 MGZCTL_ENV="$(printf '%s\n' \
@@ -146,10 +145,10 @@ MGZCTL_ENV="$(printf '%s\n' \
   "MONITORING_ADDRESS=0.0.0.0:8081" \
   "TLS_ROOT_CERT=/etc/fsc/internal/magazijn-a/ca/root.pem" \
   "TLS_CERT=/etc/fsc/internal/magazijn-a/controller/cert.pem" \
-  "TLS_KEY=/etc/fsc/internal/magazijn-a/controller/key.pem")"
+  "TLS_KEY=/etc/fsc/internal/magazijn-a/controller/key.pem" \
+  "MANAGER_ADDRESS_INTERNAL=https://${MGZMGR_HOST_DISPLAY}:443")"
 # mgzctl heeft een eigen managed Postgres (los van mgzmgr's DB) -> eigen DSN-alias.
 MGZCTL_ALIASES="$(printf '%s\n' \
-  "MANAGER_ADDRESS_INTERNAL=https://${MGZMGR_HOST}:443" \
   "STORAGE_POSTGRES_DSN=postgres://\$DATABASE_SERVER_USER:\$DATABASE_PASSWORD@\$DATABASE_SERVER_HOST:5432/\$DATABASE_DB?sslmode=${PG_SSLMODE}")"
 
 MGZINWAY_ENV="$(printf '%s\n' \
@@ -164,14 +163,14 @@ MGZINWAY_ENV="$(printf '%s\n' \
   "TLS_GROUP_KEY=/etc/fsc/out/magazijn-a/inway/key.pem" \
   "TLS_ROOT_CERT=/etc/fsc/internal/magazijn-a/ca/root.pem" \
   "TLS_CERT=/etc/fsc/internal/magazijn-a/inway/cert.pem" \
-  "TLS_KEY=/etc/fsc/internal/magazijn-a/inway/key.pem")"
-# Geen managed DB, dus geen $DATABASE_*-substitutie nodig; wel drie mesh-adressen met
-# $DEPLOYMENT_NAME -> die horen in aliases (env_vars expandeert geen ZAD-substitutievars).
-MGZINWAY_ALIASES="$(printf '%s\n' \
-  "SELF_ADDRESS=https://${MGZINWAY_HOST}:443" \
-  "CONTROLLER_REGISTRATION_API_ADDRESS=https://${MGZCTL_HOST}:443" \
-  "MANAGER_INTERNAL_UNAUTHENTICATED_ADDRESS=https://${MGZMGR_HOST}:443" \
-  "TX_LOG_API_ADDRESS=https://${MGZTXLOG_HOST}:443")"
+  "TLS_KEY=/etc/fsc/internal/magazijn-a/inway/key.pem" \
+  "SELF_ADDRESS=https://${MGZINWAY_HOST_DISPLAY}:443" \
+  "CONTROLLER_REGISTRATION_API_ADDRESS=https://${MGZCTL_HOST_DISPLAY}:443" \
+  "MANAGER_INTERNAL_UNAUTHENTICATED_ADDRESS=https://${MGZMGR_HOST_DISPLAY}:443" \
+  "TX_LOG_API_ADDRESS=https://${MGZTXLOG_HOST_DISPLAY}:443")"
+# Geen managed DB en geen $DATABASE_*-substitutie -> geen aliases nodig (alle adressen staan
+# concreet in env_vars hierboven).
+MGZINWAY_ALIASES=""
 
 # txlog-api (mirror van fsc/deploy/local): eigen managed Postgres, mTLS op de INTERNAL-PKI (geen
 # group-cert, geen GROUP_ID — group-agnostische opslag). De manager/inway loggen hier transacties;

--- a/fsc/deploy/zad/upsert-peer.sh
+++ b/fsc/deploy/zad/upsert-peer.sh
@@ -241,5 +241,20 @@ post "mgzmgr"   "/components" "${MGZMGR_BODY}"
 post "mgzctl"   "/components" "${MGZCTL_BODY}"
 post "mgzinway" "/components" "${MGZINWAY_BODY}"
 
+# Diagnose: bevestig wat er ná de apply daadwerkelijk als deployment `${DEPLOYMENT}` bestaat
+# (een 202 op :upsert-deployment betekent "geaccepteerd", niet per se "zichtbaar als deployment").
+echo "== staat na apply: deployment '${DEPLOYMENT}' =="
+if curl -sS "${hdr[@]}" -o "${resp}" "${API}/deployments"; then
+  if jq -e --arg d "${DEPLOYMENT}" '.deployments[]? | select(.name==$d)' "${resp}" >/dev/null 2>&1; then
+    echo "  gevonden:"
+    jq -r --arg d "${DEPLOYMENT}" '.deployments[]? | select(.name==$d)
+      | "  name=\(.name) status=\(.status // "?") issues=\(.issues // "?") componenten=\([.components[]?.reference] | join(","))"' "${resp}"
+  else
+    echo "  NIET in /deployments — deployment '${DEPLOYMENT}' bestaat (nog) niet ondanks 202." >&2
+    echo "  alle deployments:" >&2
+    jq -r '.deployments[]? | "    - \(.name) [\(.status // "?")]"' "${resp}" >&2 || true
+  fi
+fi
+
 echo "Klaar. Nog handmatig (UI): bijlagen (certs op /etc/fsc/...) + Publicatie op het web modus 2 op mgzmgr."
 echo "Hostnamen: mgzmgr=${MGZMGR_HOST_DISPLAY} mgzctl=${MGZCTL_HOST_DISPLAY} mgzinway=${MGZINWAY_HOST_DISPLAY}"

--- a/fsc/deploy/zad/upsert-peer.sh
+++ b/fsc/deploy/zad/upsert-peer.sh
@@ -32,13 +32,7 @@
 # ZAD substitueert $DEPLOYMENT_NAME en $DATABASE_* UITSLUITEND in `aliases`, niet in `env_vars`
 # (zie repo A's upsert-directory.sh). Elke waarde die zo'n substitutievar bevat — ook
 # component-onderlinge adressen zoals CONTROLLER_REGISTRATION_API_ADDRESS op mgzmgr — hoort dus
-# in `aliases`.
-#
-# STERKER NOG: op deze componenten past ZAD de `env_vars`-blob helemaal NIET toe (bewezen: de
-# manager crashte op `required flag(s) ... not set` voor exact de env_vars-keys, terwijl de
-# aliases-keys wél aankwamen). Daarom wordt vlak vóór de component-body ALLE config (ENV + de
-# substitutie-aliases) in de aliases-blob samengevoegd — zie MGZ*_ALIASES_FULL. De losse *_ENV-
-# blokken hieronder blijven de plain (substitutie-vrije) waarden; die worden in aliases gespiegeld.
+# in `aliases`; alleen waarden zonder substitutievar horen in `env_vars`.
 #
 # Usage:
 #   export ZAD_API_KEY=...                          # niet inline (echo't anders)
@@ -71,17 +65,20 @@ case "${MANAGER_TAG}" in ""|*[!A-Za-z0-9._-]*) echo "ongeldige ZAD_MANAGER_TAG: 
 MANAGER_IMAGE="ghcr.io/minbzk/moza-fsc-testnet/manager-migrate:${MANAGER_TAG}"
 CONTROLLER_IMAGE="docker.io/federatedserviceconnectivity/controller:${IMAGE_TAG}"
 INWAY_IMAGE="docker.io/federatedserviceconnectivity/inway:${IMAGE_TAG}"
+TXLOG_IMAGE="docker.io/federatedserviceconnectivity/txlog-api:${IMAGE_TAG}"
 
 # Display-hostnamen (déze deployment, voor de mens-leesbare plan-/apply-output).
 MGZMGR_HOST_DISPLAY="mgzmgr-${DEPLOYMENT}-${PROJECT}.${BASE_DOMAIN}"
 MGZCTL_HOST_DISPLAY="mgzctl-${DEPLOYMENT}-${PROJECT}.${BASE_DOMAIN}"
 MGZINWAY_HOST_DISPLAY="mgzinway-${DEPLOYMENT}-${PROJECT}.${BASE_DOMAIN}"
+MGZTXLOG_HOST_DISPLAY="mgztxlog-${DEPLOYMENT}-${PROJECT}.${BASE_DOMAIN}"
 
 # Deployment-agnostische hostnamen voor in de component-bodies: ZAD vult $DEPLOYMENT_NAME per
 # deployment in (test, pr-...) -> hoort in env_vars/aliases, niet in bash opgelost.
 MGZMGR_HOST='mgzmgr-$DEPLOYMENT_NAME-'"${PROJECT}.${BASE_DOMAIN}"
 MGZCTL_HOST='mgzctl-$DEPLOYMENT_NAME-'"${PROJECT}.${BASE_DOMAIN}"
 MGZINWAY_HOST='mgzinway-$DEPLOYMENT_NAME-'"${PROJECT}.${BASE_DOMAIN}"
+MGZTXLOG_HOST='mgztxlog-$DEPLOYMENT_NAME-'"${PROJECT}.${BASE_DOMAIN}"
 
 # Repo A's directory-deployment op ZAD (project mft-tp9, deployment "test" — zie upsert-directory.sh
 # se defaults). TODO(verifieer bij de echte apply): bevestig dat dit nog steeds de actieve
@@ -105,7 +102,6 @@ MGZMGR_ENV="$(printf '%s\n' \
   "LOG_TYPE=live" "LOG_LEVEL=info" "AUDITLOG_TYPE=stdout" \
   "GROUP_ID=moza-fbs-test" \
   "DIRECTORY_PEER_ID=00000000000000000010" \
-  "TX_LOG_API_ADDRESS=" \
   "AUTO_SIGN_GRANTS=" \
   "LISTEN_ADDRESS_EXTERNAL=0.0.0.0:8443" \
   "LISTEN_ADDRESS_INTERNAL=0.0.0.0:9443" \
@@ -134,6 +130,7 @@ MGZMGR_ALIASES="$(printf '%s\n' \
   "SELF_ADDRESS=https://${MGZMGR_HOST}:443" \
   "DIRECTORY_MANAGER_ADDRESS=https://${DIRECTORY_MANAGER_HOST}:443" \
   "CONTROLLER_REGISTRATION_API_ADDRESS=https://${MGZCTL_HOST}:443" \
+  "TX_LOG_API_ADDRESS=https://${MGZTXLOG_HOST}:443" \
   "STORAGE_POSTGRES_DSN=postgres://\$DATABASE_SERVER_USER:\$DATABASE_PASSWORD@\$DATABASE_SERVER_HOST:5432/\$DATABASE_DB?sslmode=${PG_SSLMODE}")"
 
 MGZCTL_ENV="$(printf '%s\n' \
@@ -159,7 +156,6 @@ MGZINWAY_ENV="$(printf '%s\n' \
   "LOG_TYPE=live" "LOG_LEVEL=info" \
   "NAME=magazijn-a-inway" \
   "GROUP_ID=moza-fbs-test" \
-  "TX_LOG_API_ADDRESS=" \
   "LISTEN_ADDRESS=0.0.0.0:8443" \
   "MONITORING_ADDRESS=0.0.0.0:8081" \
   "DISABLE_CRL_CHECKS=true" \
@@ -174,7 +170,22 @@ MGZINWAY_ENV="$(printf '%s\n' \
 MGZINWAY_ALIASES="$(printf '%s\n' \
   "SELF_ADDRESS=https://${MGZINWAY_HOST}:443" \
   "CONTROLLER_REGISTRATION_API_ADDRESS=https://${MGZCTL_HOST}:443" \
-  "MANAGER_INTERNAL_UNAUTHENTICATED_ADDRESS=https://${MGZMGR_HOST}:443")"
+  "MANAGER_INTERNAL_UNAUTHENTICATED_ADDRESS=https://${MGZMGR_HOST}:443" \
+  "TX_LOG_API_ADDRESS=https://${MGZTXLOG_HOST}:443")"
+
+# txlog-api (mirror van fsc/deploy/local): eigen managed Postgres, mTLS op de INTERNAL-PKI (geen
+# group-cert, geen GROUP_ID — group-agnostische opslag). De manager/inway loggen hier transacties;
+# OpenFSC eist een niet-lege TX_LOG_API_ADDRESS voor een niet-directory manager. txlog-hardening /
+# het echte data-pad is #728; dit is de minimale draaiende endpoint zodat de manager boot.
+MGZTXLOG_ENV="$(printf '%s\n' \
+  "LOG_TYPE=live" "LOG_LEVEL=info" \
+  "LISTEN_ADDRESS=0.0.0.0:8443" \
+  "MONITORING_ADDRESS=0.0.0.0:8081" \
+  "TLS_ROOT_CERT=/etc/fsc/internal/magazijn-a/ca/root.pem" \
+  "TLS_CERT=/etc/fsc/internal/magazijn-a/txlog/cert.pem" \
+  "TLS_KEY=/etc/fsc/internal/magazijn-a/txlog/key.pem")"
+MGZTXLOG_ALIASES="$(printf '%s\n' \
+  "STORAGE_POSTGRES_DSN=postgres://\$DATABASE_SERVER_USER:\$DATABASE_PASSWORD@\$DATABASE_SERVER_HOST:5432/\$DATABASE_DB?sslmode=${PG_SSLMODE}")"
 
 # component-body (AddComponentRequest) via jq -> correcte JSON-escaping.
 component_body() {  # $1=name $2=image $3=port $4=env  [$5=services_json=[]]  [$6=aliases=""]
@@ -187,24 +198,15 @@ component_body() {  # $1=name $2=image $3=port $4=env  [$5=services_json=[]]  [$
 
 DEPLOY_BODY="$(jq -n --arg d "${DEPLOYMENT}" --arg cf "${CLONE_FROM}" \
   --arg mgr "${MANAGER_IMAGE}" --arg ctl "${CONTROLLER_IMAGE}" --arg inway "${INWAY_IMAGE}" \
+  --arg txlog "${TXLOG_IMAGE}" \
   '{deploymentName:$d, domain_format:"component-deployment-project",
-    components:[{reference:"mgzmgr", image:$mgr}, {reference:"mgzctl", image:$ctl}, {reference:"mgzinway", image:$inway}]}
+    components:[{reference:"mgzmgr", image:$mgr}, {reference:"mgzctl", image:$ctl}, {reference:"mgzinway", image:$inway}, {reference:"mgztxlog", image:$txlog}]}
    + (if $cf=="" then {} else {cloneFrom:$cf, forceClone:false} end)')"
 
-# ZAD past op deze componenten wél de `aliases`-blob toe, maar NIET de `env_vars`-blob: de manager
-# crashte met `required flag(s) ... not set` voor exact de env_vars-keys (listen-addresses + alle
-# TLS-paden), terwijl de aliases-keys (self-address, DSN, ...) én de migratie-DSN wél aankwamen —
-# migrate en serve delen dezelfde proces-env, dus de env_vars-waarden waren simpelweg afwezig.
-# Daarom ALLE config in aliases spiegelen. De plain ENV-helft heeft geen $-substitutievars en gaat
-# verbatim mee; de *_ALIASES-helft bevat de $DEPLOYMENT_NAME/$DATABASE_*-waarden die ZAD expandeert.
-# env_vars houden we als plain-subset (idempotent; mocht ZAD 'm elders tóch toepassen).
-MGZMGR_ALIASES_FULL="$(printf '%s\n%s' "${MGZMGR_ENV}" "${MGZMGR_ALIASES}")"
-MGZCTL_ALIASES_FULL="$(printf '%s\n%s' "${MGZCTL_ENV}" "${MGZCTL_ALIASES}")"
-MGZINWAY_ALIASES_FULL="$(printf '%s\n%s' "${MGZINWAY_ENV}" "${MGZINWAY_ALIASES}")"
-
-MGZMGR_BODY="$(component_body mgzmgr "${MANAGER_IMAGE}" 8443 "${MGZMGR_ENV}" '["postgresql-database"]' "${MGZMGR_ALIASES_FULL}")"
-MGZCTL_BODY="$(component_body mgzctl "${CONTROLLER_IMAGE}" 8080 "${MGZCTL_ENV}" '["postgresql-database"]' "${MGZCTL_ALIASES_FULL}")"
-MGZINWAY_BODY="$(component_body mgzinway "${INWAY_IMAGE}" 8443 "${MGZINWAY_ENV}" '[]' "${MGZINWAY_ALIASES_FULL}")"
+MGZMGR_BODY="$(component_body mgzmgr "${MANAGER_IMAGE}" 8443 "${MGZMGR_ENV}" '["postgresql-database"]' "${MGZMGR_ALIASES}")"
+MGZCTL_BODY="$(component_body mgzctl "${CONTROLLER_IMAGE}" 8080 "${MGZCTL_ENV}" '["postgresql-database"]' "${MGZCTL_ALIASES}")"
+MGZINWAY_BODY="$(component_body mgzinway "${INWAY_IMAGE}" 8443 "${MGZINWAY_ENV}" '[]' "${MGZINWAY_ALIASES}")"
+MGZTXLOG_BODY="$(component_body mgztxlog "${TXLOG_IMAGE}" 8443 "${MGZTXLOG_ENV}" '["postgresql-database"]' "${MGZTXLOG_ALIASES}")"
 
 # ---- plan: toon alleen ----
 if [ "${MODE}" = plan ]; then
@@ -212,7 +214,8 @@ if [ "${MODE}" = plan ]; then
   echo "### component mgzmgr (manager + managed Postgres)"; echo "${MGZMGR_BODY}"
   echo "### component mgzctl (controller + managed Postgres)"; echo "${MGZCTL_BODY}"
   echo "### component mgzinway (inway)"; echo "${MGZINWAY_BODY}"
-  echo "Hostnamen (deployment '${DEPLOYMENT}'): mgzmgr=${MGZMGR_HOST_DISPLAY} mgzctl=${MGZCTL_HOST_DISPLAY} mgzinway=${MGZINWAY_HOST_DISPLAY}"
+  echo "### component mgztxlog (txlog-api + managed Postgres)"; echo "${MGZTXLOG_BODY}"
+  echo "Hostnamen (deployment '${DEPLOYMENT}'): mgzmgr=${MGZMGR_HOST_DISPLAY} mgzctl=${MGZCTL_HOST_DISPLAY} mgzinway=${MGZINWAY_HOST_DISPLAY} mgztxlog=${MGZTXLOG_HOST_DISPLAY}"
   echo "Directory-manager (repo A, extern): ${DIRECTORY_MANAGER_HOST}"
   echo "Upstream naar de app (ingress-URL, cross-deployment): ${MAGAZIJNA_UPSTREAM_URL}"
   exit 0
@@ -271,6 +274,7 @@ echo "== componenten aanmaken =="
 post "mgzmgr"   "/components" "${MGZMGR_BODY}"
 post "mgzctl"   "/components" "${MGZCTL_BODY}"
 post "mgzinway" "/components" "${MGZINWAY_BODY}"
+post "mgztxlog" "/components" "${MGZTXLOG_BODY}"
 
 # Diagnose: bevestig wat er ná de apply daadwerkelijk als deployment `${DEPLOYMENT}` bestaat
 # (een 202 op :upsert-deployment betekent "geaccepteerd", niet per se "zichtbaar als deployment").
@@ -288,4 +292,4 @@ if curl -sS "${hdr[@]}" -o "${resp}" "${API}/deployments"; then
 fi
 
 echo "Klaar. Nog handmatig (UI): bijlagen (certs op /etc/fsc/...) + Publicatie op het web modus 2 op mgzmgr."
-echo "Hostnamen: mgzmgr=${MGZMGR_HOST_DISPLAY} mgzctl=${MGZCTL_HOST_DISPLAY} mgzinway=${MGZINWAY_HOST_DISPLAY}"
+echo "Hostnamen: mgzmgr=${MGZMGR_HOST_DISPLAY} mgzctl=${MGZCTL_HOST_DISPLAY} mgzinway=${MGZINWAY_HOST_DISPLAY} mgztxlog=${MGZTXLOG_HOST_DISPLAY}"

--- a/fsc/deploy/zad/upsert-peer.sh
+++ b/fsc/deploy/zad/upsert-peer.sh
@@ -269,11 +269,18 @@ if [ "${MODE}" = validate ]; then echo "validate OK (read-only, niets gemuteerd)
 echo "== upsert deployment '${DEPLOYMENT}' =="
 post "deployment" "/:upsert-deployment" "${DEPLOY_BODY}"
 
-echo "== componenten aanmaken =="
+echo "== componenten aanmaken/bijwerken =="
 post "mgzmgr"   "/components" "${MGZMGR_BODY}"
 post "mgzctl"   "/components" "${MGZCTL_BODY}"
 post "mgzinway" "/components" "${MGZINWAY_BODY}"
 post "mgztxlog" "/components" "${MGZTXLOG_BODY}"
+
+# De EERSTE :upsert-deployment (hierboven) rolt de pods uit MET de config van de vórige run — de
+# POST /components hierna zet de nieuwe env pas ná die rollout. Doe daarom NOG één :upsert-deployment
+# zodat de pods opnieuw uitrollen met de zojuist gezette component-config (anders loopt de env één
+# deploy achter). Zo hoeven bestaande componenten NIET verwijderd te worden (cert-attachments blijven).
+echo "== deployment opnieuw uitrollen met verse component-config =="
+post "deployment (re-roll)" "/:upsert-deployment" "${DEPLOY_BODY}"
 
 # Diagnose: bevestig wat er ná de apply daadwerkelijk als deployment `${DEPLOYMENT}` bestaat
 # (een 202 op :upsert-deployment betekent "geaccepteerd", niet per se "zichtbaar als deployment").

--- a/fsc/deploy/zad/upsert-peer.sh
+++ b/fsc/deploy/zad/upsert-peer.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# Zet de provider-peer magazijn-a (manager+controller+inway) op ZAD via de v2 Operations Manager
+# API, naast de bestaande app-component `magazijna` in project mpfm-w3h. Gebaseerd op repo A's
+# deploy/zad/upsert-directory.sh (MinBZK/moza-fsc-testnet) — zelfde validate/plan/apply-vorm, één
+# bron voor CLI + de workflow zad-deploy-peer.yml.
+#
+# Model: PR = eigen deployment `pr-<PR-nummer>`; main -> deployment `test`. `:upsert-deployment`
+# zet per component de {reference,image} en maakt/updatet het deployment; POST /components
+# verrijkt elke component met env_vars/port/services/aliases. Anders dan de directory-upsert
+# ondersteunt dit script GEEN cloneFrom: elke apply herschrijft alle drie de provider-componenten
+# voor de opgegeven deployment.
+# NIET via de API (UI-only): bijlagen (cert-mount) + "Publicatie op het web" (passthrough-TLS) —
+# zie cert-manifest.md.
+#
+# DB: elke component met een eigen managed Postgres (mgzmgr, mgzctl) krijgt zijn STORAGE_POSTGRES_DSN
+# via ZAD-substitutievars ($DATABASE_*), in de `aliases`-body — die vars zijn pas bij deploy-tijd
+# bekend en kunnen dus niet in bash worden opgelost. txlog is in deze bundel bewust NIET meegenomen
+# (TX_LOG_API_ADDRESS staat leeg op mgzmgr/mgzinway — txlog-hardening is later werk).
+#
+# $DEPLOYMENT_NAME (letterlijk, ZAD-substitutievar) wordt gebruikt voor de per-deployment
+# hostnamen van mgzmgr/mgzctl/mgzinway, zodat één (project-brede) component-definitie in elke
+# deployment (test, pr-...) de juiste hostnaam krijgt — zie de MGZ*_HOST-opbouw hieronder.
+# AANNAME (niet geverifieerd — validate/apply zijn UITGESTELD): ZAD substitueert $DEPLOYMENT_NAME
+# zowel in `env_vars` als in `aliases`; component-onderlinge adressen (bv. CONTROLLER_REGISTRATION_
+# API_ADDRESS op mgzmgr) staan daarom in `env_vars`, analoog aan hoe repo A's directory-upsert dat
+# al deed voor de eigen SELF_ADDRESS/DIRECTORY_MANAGER_ADDRESS (die wél in `aliases` staan, omdat
+# ze zowel $DEPLOYMENT_NAME als — voor de DSN — $DATABASE_* nodig hebben).
+#
+# Usage:
+#   export ZAD_API_KEY=...                          # niet inline (echo't anders)
+#   ./fsc/deploy/zad/upsert-peer.sh validate                       # read-only auth-check
+#   ./fsc/deploy/zad/upsert-peer.sh plan   [deployment] [tag]       # toont bodies, muteert niet
+#   ./fsc/deploy/zad/upsert-peer.sh apply  [deployment] [tag]       # muteert + pollt tasks
+# Env: ZAD_API_KEY (verplicht bij apply), ZAD_PROJECT (mpfm-w3h), ZAD_BASE (zad.rijksapp.nl),
+#      ZAD_BASE_DOMAIN (rig.prd1...), ZAD_MANAGER_TAG (ghcr manager-tag, default = tag),
+#      ZAD_DIRECTORY_MANAGER_HOST (repo A's directory-manager-host op ZAD), ZAD_PG_SSLMODE (disable),
+#      ZAD_MAGAZIJNA_UPSTREAM_URL (endpoint_url van de app-component, zie TODO bij mgzinway).
+set -euo pipefail
+
+MODE="${1:?usage: upsert-peer.sh <validate|plan|apply> [deployment=test] [tag=v1.43.7]}"
+DEPLOYMENT="${2:-test}"
+IMAGE_TAG="${3:-v1.43.7}"                        # OpenFSC stock-tag (controller/inway; default voor de manager-wrapper)
+MANAGER_TAG="${ZAD_MANAGER_TAG:-${IMAGE_TAG}}"   # manager-migrate (ghcr) kan een eigen tag hebben
+PROJECT="${ZAD_PROJECT:-mpfm-w3h}"
+BASE="${ZAD_BASE:-https://zad.rijksapp.nl}"
+BASE_DOMAIN="${ZAD_BASE_DOMAIN:-rig.prd1.gn2.quattro.rijksapps.nl}"
+PG_SSLMODE="${ZAD_PG_SSLMODE:-disable}"          # managed DB intra-cluster: plaintext (zoals berichtenbox-JDBC)
+
+case "${MODE}" in validate|plan|apply) ;; *) echo "mode = validate | plan | apply"; exit 1 ;; esac
+case "${DEPLOYMENT}" in ""|*[!a-z0-9-]*) echo "ongeldige deployment: '${DEPLOYMENT}'"; exit 1 ;; esac
+case "${IMAGE_TAG}" in ""|*[!A-Za-z0-9._-]*) echo "ongeldige image_tag: '${IMAGE_TAG}'"; exit 1 ;; esac
+case "${MANAGER_TAG}" in ""|*[!A-Za-z0-9._-]*) echo "ongeldige ZAD_MANAGER_TAG: '${MANAGER_TAG}'"; exit 1 ;; esac
+[ "${MODE}" = apply ] && : "${ZAD_API_KEY:?zet ZAD_API_KEY in je env}"
+
+MANAGER_IMAGE="ghcr.io/minbzk/moza-fsc-testnet/manager-migrate:${MANAGER_TAG}"
+CONTROLLER_IMAGE="docker.io/federatedserviceconnectivity/controller:${IMAGE_TAG}"
+INWAY_IMAGE="docker.io/federatedserviceconnectivity/inway:${IMAGE_TAG}"
+
+# Display-hostnamen (déze deployment, voor de mens-leesbare plan-/apply-output).
+MGZMGR_HOST_DISPLAY="mgzmgr-${DEPLOYMENT}-${PROJECT}.${BASE_DOMAIN}"
+MGZCTL_HOST_DISPLAY="mgzctl-${DEPLOYMENT}-${PROJECT}.${BASE_DOMAIN}"
+MGZINWAY_HOST_DISPLAY="mgzinway-${DEPLOYMENT}-${PROJECT}.${BASE_DOMAIN}"
+
+# Deployment-agnostische hostnamen voor in de component-bodies: ZAD vult $DEPLOYMENT_NAME per
+# deployment in (test, pr-...) -> hoort in env_vars/aliases, niet in bash opgelost.
+MGZMGR_HOST='mgzmgr-$DEPLOYMENT_NAME-'"${PROJECT}.${BASE_DOMAIN}"
+MGZCTL_HOST='mgzctl-$DEPLOYMENT_NAME-'"${PROJECT}.${BASE_DOMAIN}"
+MGZINWAY_HOST='mgzinway-$DEPLOYMENT_NAME-'"${PROJECT}.${BASE_DOMAIN}"
+
+# Repo A's directory-deployment op ZAD (project mft-tp9, deployment "test" — zie upsert-directory.sh
+# se defaults). TODO(verifieer bij de echte apply): bevestig dat dit nog steeds de actieve
+# directory-host is; override met ZAD_DIRECTORY_MANAGER_HOST als de directory elders draait.
+DIRECTORY_MANAGER_HOST="${ZAD_DIRECTORY_MANAGER_HOST:-dirmgr-test-mft-tp9.${BASE_DOMAIN}}"
+
+# TODO(verifieer intra-project-DNS-vorm van magazijna in mpfm-w3h): bare servicenaam vs.
+# koppelteken-vorm (bv. "magazijna" of "magazijna-<deployment>-mpfm-w3h"). Dit is GEEN inway-
+# env-var (OpenFSC kent geen "upstream" op de inway zelf) maar de endpoint_url die bij de
+# service-publicatie op de mgzctl Administration-API wordt meegegeven — analoog aan
+# fsc/deploy/local/publish-service.sh se STUB_URL, maar dan de bestaande magazijna-app-component
+# intra-project i.p.v. de lokale stub. Zie verify-zad.md, stap (b).
+MAGAZIJNA_UPSTREAM_URL="${ZAD_MAGAZIJNA_UPSTREAM_URL:-http://magazijna:8080}"
+
+# --- env-blobs (KEY=value, newline-sep, plain). TLS_*-paden = de bijlage-mounts (UI, ontwerp A). ---
+MGZMGR_ENV="$(printf '%s\n' \
+  "LOG_TYPE=live" "LOG_LEVEL=info" "AUDITLOG_TYPE=stdout" \
+  "GROUP_ID=moza-fbs-test" \
+  "DIRECTORY_PEER_ID=00000000000000000010" \
+  "TX_LOG_API_ADDRESS=" \
+  "AUTO_SIGN_GRANTS=" \
+  "CONTROLLER_REGISTRATION_API_ADDRESS=https://${MGZCTL_HOST}:443" \
+  "LISTEN_ADDRESS_EXTERNAL=0.0.0.0:8443" \
+  "LISTEN_ADDRESS_INTERNAL=0.0.0.0:9443" \
+  "LISTEN_ADDRESS_INTERNAL_UNAUTHENTICATED=0.0.0.0:9444" \
+  "MONITORING_ADDRESS=0.0.0.0:8080" \
+  "DISABLE_CRL_CHECKS=true" \
+  "TLS_GROUP_ROOT_CERT=/etc/fsc/ca/root.pem" \
+  "TLS_GROUP_CERT=/etc/fsc/out/magazijn-a/manager/cert.pem" \
+  "TLS_GROUP_KEY=/etc/fsc/out/magazijn-a/manager/key.pem" \
+  "TLS_GROUP_TOKEN_CERT=/etc/fsc/out/magazijn-a/manager/cert.pem" \
+  "TLS_GROUP_TOKEN_KEY=/etc/fsc/out/magazijn-a/manager/key.pem" \
+  "TLS_GROUP_CONTRACT_CERT=/etc/fsc/out/magazijn-a/manager/cert.pem" \
+  "TLS_GROUP_CONTRACT_KEY=/etc/fsc/out/magazijn-a/manager/key.pem" \
+  "TLS_ROOT_CERT=/etc/fsc/internal/magazijn-a/ca/root.pem" \
+  "TLS_CERT=/etc/fsc/internal/magazijn-a/manager/cert.pem" \
+  "TLS_KEY=/etc/fsc/internal/magazijn-a/manager/key.pem" \
+  "TLS_INTERNAL_UNAUTHENTICATED_ROOT_CERT=/etc/fsc/internal/magazijn-a/ca/root.pem" \
+  "TLS_INTERNAL_UNAUTHENTICATED_CERT=/etc/fsc/internal/magazijn-a/manager/cert.pem" \
+  "TLS_INTERNAL_UNAUTHENTICATED_KEY=/etc/fsc/internal/magazijn-a/manager/key.pem")"
+
+# Aliases = env-vars met ZAD-substitutievars ($DEPLOYMENT_NAME voor de eigen hostnaam, $DATABASE_*
+# voor de managed Postgres). \$ houdt ze letterlijk (ZAD vult ze per deployment in, niet de shell).
+# :443 = de mesh-poort (ingress SNI-passthrough -> pod :8443); OpenFSC eist een expliciete poort in
+# het manager-adres (zie upsert-directory.sh), dus niet weglaten.
+MGZMGR_ALIASES="$(printf '%s\n' \
+  "SELF_ADDRESS=https://${MGZMGR_HOST}:443" \
+  "DIRECTORY_MANAGER_ADDRESS=https://${DIRECTORY_MANAGER_HOST}:443" \
+  "STORAGE_POSTGRES_DSN=postgres://\$DATABASE_SERVER_USER:\$DATABASE_PASSWORD@\$DATABASE_SERVER_HOST:5432/\$DATABASE_DB?sslmode=${PG_SSLMODE}")"
+
+MGZCTL_ENV="$(printf '%s\n' \
+  "LOG_TYPE=live" "LOG_LEVEL=info" "AUDITLOG_TYPE=stdout" \
+  "GROUP_ID=moza-fbs-test" \
+  "DIRECTORY_PEER_ID=00000000000000000010" \
+  "AUTHN_TYPE=none" \
+  "AUTHZ_TYPE=rbac" \
+  "CSRF_PROTECTION_ENABLED=false" \
+  "MANAGER_ADDRESS_INTERNAL=https://${MGZMGR_HOST}:443" \
+  "LISTEN_ADDRESS_UI=0.0.0.0:8080" \
+  "LISTEN_ADDRESS_REGISTRATION_API=0.0.0.0:9443" \
+  "LISTEN_ADDRESS_ADMINISTRATION_API=0.0.0.0:9444" \
+  "MONITORING_ADDRESS=0.0.0.0:8081" \
+  "TLS_ROOT_CERT=/etc/fsc/internal/magazijn-a/ca/root.pem" \
+  "TLS_CERT=/etc/fsc/internal/magazijn-a/controller/cert.pem" \
+  "TLS_KEY=/etc/fsc/internal/magazijn-a/controller/key.pem")"
+# mgzctl heeft een eigen managed Postgres (los van mgzmgr's DB) -> eigen DSN-alias.
+MGZCTL_ALIASES="STORAGE_POSTGRES_DSN=postgres://\$DATABASE_SERVER_USER:\$DATABASE_PASSWORD@\$DATABASE_SERVER_HOST:5432/\$DATABASE_DB?sslmode=${PG_SSLMODE}"
+
+MGZINWAY_ENV="$(printf '%s\n' \
+  "LOG_TYPE=live" "LOG_LEVEL=info" \
+  "NAME=magazijn-a-inway" \
+  "GROUP_ID=moza-fbs-test" \
+  "SELF_ADDRESS=https://${MGZINWAY_HOST}:443" \
+  "CONTROLLER_REGISTRATION_API_ADDRESS=https://${MGZCTL_HOST}:443" \
+  "MANAGER_INTERNAL_UNAUTHENTICATED_ADDRESS=https://${MGZMGR_HOST}:443" \
+  "TX_LOG_API_ADDRESS=" \
+  "LISTEN_ADDRESS=0.0.0.0:8443" \
+  "MONITORING_ADDRESS=0.0.0.0:8081" \
+  "DISABLE_CRL_CHECKS=true" \
+  "TLS_GROUP_ROOT_CERT=/etc/fsc/ca/root.pem" \
+  "TLS_GROUP_CERT=/etc/fsc/out/magazijn-a/inway/cert.pem" \
+  "TLS_GROUP_KEY=/etc/fsc/out/magazijn-a/inway/key.pem" \
+  "TLS_ROOT_CERT=/etc/fsc/internal/magazijn-a/ca/root.pem" \
+  "TLS_CERT=/etc/fsc/internal/magazijn-a/inway/cert.pem" \
+  "TLS_KEY=/etc/fsc/internal/magazijn-a/inway/key.pem")"
+# Geen managed DB, geen zelf-adres met $DATABASE_*-substitutie nodig -> geen aliases.
+MGZINWAY_ALIASES=""
+
+# component-body (AddComponentRequest) via jq -> correcte JSON-escaping.
+component_body() {  # $1=name $2=image $3=port $4=env  [$5=services_json=[]]  [$6=aliases=""]
+  jq -n --arg name "$1" --arg image "$2" --argjson port "$3" --arg env "$4" \
+        --argjson services "${5:-[]}" --arg aliases "${6:-}" --arg dep "${DEPLOYMENT}" \
+    '{name:$name, image:$image, port:$port, env_vars:$env, deployment_names:[$dep]}
+     + (if ($services|length) > 0 then {services:$services} else {} end)
+     + (if $aliases == "" then {} else {aliases:$aliases} end)'
+}
+
+DEPLOY_BODY="$(jq -n --arg d "${DEPLOYMENT}" \
+  --arg mgr "${MANAGER_IMAGE}" --arg ctl "${CONTROLLER_IMAGE}" --arg inway "${INWAY_IMAGE}" \
+  '{deploymentName:$d, domain_format:"component-deployment-project",
+    components:[{reference:"mgzmgr", image:$mgr}, {reference:"mgzctl", image:$ctl}, {reference:"mgzinway", image:$inway}]}')"
+
+MGZMGR_BODY="$(component_body mgzmgr "${MANAGER_IMAGE}" 8443 "${MGZMGR_ENV}" '["postgresql-database"]' "${MGZMGR_ALIASES}")"
+MGZCTL_BODY="$(component_body mgzctl "${CONTROLLER_IMAGE}" 8080 "${MGZCTL_ENV}" '["postgresql-database"]' "${MGZCTL_ALIASES}")"
+MGZINWAY_BODY="$(component_body mgzinway "${INWAY_IMAGE}" 8443 "${MGZINWAY_ENV}" '[]' "${MGZINWAY_ALIASES}")"
+
+# ---- plan: toon alleen ----
+if [ "${MODE}" = plan ]; then
+  echo "### deployment (:upsert-deployment)"; echo "${DEPLOY_BODY}"
+  echo "### component mgzmgr (manager + managed Postgres)"; echo "${MGZMGR_BODY}"
+  echo "### component mgzctl (controller + managed Postgres)"; echo "${MGZCTL_BODY}"
+  echo "### component mgzinway (inway)"; echo "${MGZINWAY_BODY}"
+  echo "Hostnamen (deployment '${DEPLOYMENT}'): mgzmgr=${MGZMGR_HOST_DISPLAY} mgzctl=${MGZCTL_HOST_DISPLAY} mgzinway=${MGZINWAY_HOST_DISPLAY}"
+  echo "Directory-manager (repo A, extern): ${DIRECTORY_MANAGER_HOST}"
+  echo "Upstream naar de app (TODO verifieer intra-project-DNS-vorm van magazijna): ${MAGAZIJNA_UPSTREAM_URL}"
+  exit 0
+fi
+
+API="${BASE}/api/v2/projects/${PROJECT}"
+resp="$(mktemp)"; trap 'rm -f "${resp}"' EXIT
+hdr=(-H "X-API-Key: ${ZAD_API_KEY}")
+
+poll_task() {  # $1=task_id
+  local id="$1" i status
+  for i in $(seq 1 45); do
+    # --fail: HTTP 4xx/5xx op de tasks-API mag niet als "nog bezig" (status=null) tellen; retry.
+    if ! curl -sS --fail "${hdr[@]}" "${BASE}/api/tasks/${id}" -o "${resp}"; then
+      echo "  task ${id}: tasks-API HTTP-fout (poging ${i}/45) — retry" >&2
+      sleep 2; continue
+    fi
+    status="$(jq -r '.status' "${resp}")"
+    case "${status}" in
+      completed) echo "  task ${id}: completed"; return 0 ;;
+      failed)    echo "  task ${id}: FAILED -> $(jq -r '.error_message // .result.error' "${resp}")" >&2; return 1 ;;
+      *)         sleep 2 ;;
+    esac
+  done
+  echo "  task ${id}: nog bezig na ~90s (async ArgoCD-sync) — niet geblokkeerd, check later met 'validate'." >&2
+  return 0
+}
+
+post() {  # $1=label $2=path $3=body
+  echo "POST ${2}  (${1})"
+  local code; code="$(curl -sS "${hdr[@]}" -H 'Content-Type: application/json' \
+    -X POST --data "${3}" -o "${resp}" -w '%{http_code}' "${API}${2}")"
+  echo "  -> HTTP ${code}"
+  case "${code}" in 2*) ;; *) jq . "${resp}" 2>/dev/null || cat "${resp}"; return 1 ;; esac
+  local tid; tid="$(jq -r '.task_id // empty' "${resp}")"
+  # if/then/else zodat poll_task's non-zero (FAILED-task) propageert i.p.v. gemaskeerd door `|| {…}`.
+  if [ -n "${tid}" ]; then
+    poll_task "${tid}"
+  else
+    jq . "${resp}"
+  fi
+}
+
+# ---- apply ----
+echo "== validate =="
+code="$(curl -sS "${hdr[@]}" -o "${resp}" -w '%{http_code}' "${API}/deployments")"
+[ "${code}" = 200 ] || { echo "auth/connectie faalt (HTTP ${code})"; cat "${resp}"; exit 1; }
+echo "auth OK — deployments + componenten:"
+jq -r '.deployments[]? | "  - \(.name): \([.components[]?.reference] | join(", "))"' "${resp}" 2>/dev/null || true
+if [ "${MODE}" = validate ]; then echo "validate OK (read-only, niets gemuteerd)."; exit 0; fi
+
+echo "== upsert deployment '${DEPLOYMENT}' =="
+post "deployment" "/:upsert-deployment" "${DEPLOY_BODY}"
+
+echo "== componenten aanmaken =="
+post "mgzmgr"   "/components" "${MGZMGR_BODY}"
+post "mgzctl"   "/components" "${MGZCTL_BODY}"
+post "mgzinway" "/components" "${MGZINWAY_BODY}"
+
+echo "Klaar. Nog handmatig (UI): bijlagen (certs op /etc/fsc/...) + Publicatie op het web modus 2 op mgzmgr."
+echo "Hostnamen: mgzmgr=${MGZMGR_HOST_DISPLAY} mgzctl=${MGZCTL_HOST_DISPLAY} mgzinway=${MGZINWAY_HOST_DISPLAY}"

--- a/fsc/deploy/zad/upsert-peer.sh
+++ b/fsc/deploy/zad/upsert-peer.sh
@@ -32,7 +32,13 @@
 # ZAD substitueert $DEPLOYMENT_NAME en $DATABASE_* UITSLUITEND in `aliases`, niet in `env_vars`
 # (zie repo A's upsert-directory.sh). Elke waarde die zo'n substitutievar bevat — ook
 # component-onderlinge adressen zoals CONTROLLER_REGISTRATION_API_ADDRESS op mgzmgr — hoort dus
-# in `aliases`; alleen waarden zonder substitutievar horen in `env_vars`.
+# in `aliases`.
+#
+# STERKER NOG: op deze componenten past ZAD de `env_vars`-blob helemaal NIET toe (bewezen: de
+# manager crashte op `required flag(s) ... not set` voor exact de env_vars-keys, terwijl de
+# aliases-keys wél aankwamen). Daarom wordt vlak vóór de component-body ALLE config (ENV + de
+# substitutie-aliases) in de aliases-blob samengevoegd — zie MGZ*_ALIASES_FULL. De losse *_ENV-
+# blokken hieronder blijven de plain (substitutie-vrije) waarden; die worden in aliases gespiegeld.
 #
 # Usage:
 #   export ZAD_API_KEY=...                          # niet inline (echo't anders)
@@ -185,9 +191,20 @@ DEPLOY_BODY="$(jq -n --arg d "${DEPLOYMENT}" --arg cf "${CLONE_FROM}" \
     components:[{reference:"mgzmgr", image:$mgr}, {reference:"mgzctl", image:$ctl}, {reference:"mgzinway", image:$inway}]}
    + (if $cf=="" then {} else {cloneFrom:$cf, forceClone:false} end)')"
 
-MGZMGR_BODY="$(component_body mgzmgr "${MANAGER_IMAGE}" 8443 "${MGZMGR_ENV}" '["postgresql-database"]' "${MGZMGR_ALIASES}")"
-MGZCTL_BODY="$(component_body mgzctl "${CONTROLLER_IMAGE}" 8080 "${MGZCTL_ENV}" '["postgresql-database"]' "${MGZCTL_ALIASES}")"
-MGZINWAY_BODY="$(component_body mgzinway "${INWAY_IMAGE}" 8443 "${MGZINWAY_ENV}" '[]' "${MGZINWAY_ALIASES}")"
+# ZAD past op deze componenten wél de `aliases`-blob toe, maar NIET de `env_vars`-blob: de manager
+# crashte met `required flag(s) ... not set` voor exact de env_vars-keys (listen-addresses + alle
+# TLS-paden), terwijl de aliases-keys (self-address, DSN, ...) én de migratie-DSN wél aankwamen —
+# migrate en serve delen dezelfde proces-env, dus de env_vars-waarden waren simpelweg afwezig.
+# Daarom ALLE config in aliases spiegelen. De plain ENV-helft heeft geen $-substitutievars en gaat
+# verbatim mee; de *_ALIASES-helft bevat de $DEPLOYMENT_NAME/$DATABASE_*-waarden die ZAD expandeert.
+# env_vars houden we als plain-subset (idempotent; mocht ZAD 'm elders tóch toepassen).
+MGZMGR_ALIASES_FULL="$(printf '%s\n%s' "${MGZMGR_ENV}" "${MGZMGR_ALIASES}")"
+MGZCTL_ALIASES_FULL="$(printf '%s\n%s' "${MGZCTL_ENV}" "${MGZCTL_ALIASES}")"
+MGZINWAY_ALIASES_FULL="$(printf '%s\n%s' "${MGZINWAY_ENV}" "${MGZINWAY_ALIASES}")"
+
+MGZMGR_BODY="$(component_body mgzmgr "${MANAGER_IMAGE}" 8443 "${MGZMGR_ENV}" '["postgresql-database"]' "${MGZMGR_ALIASES_FULL}")"
+MGZCTL_BODY="$(component_body mgzctl "${CONTROLLER_IMAGE}" 8080 "${MGZCTL_ENV}" '["postgresql-database"]' "${MGZCTL_ALIASES_FULL}")"
+MGZINWAY_BODY="$(component_body mgzinway "${INWAY_IMAGE}" 8443 "${MGZINWAY_ENV}" '[]' "${MGZINWAY_ALIASES_FULL}")"
 
 # ---- plan: toon alleen ----
 if [ "${MODE}" = plan ]; then

--- a/fsc/deploy/zad/verify-zad.md
+++ b/fsc/deploy/zad/verify-zad.md
@@ -42,9 +42,9 @@ create-service + servicePublication-contract-flow, maar tegen de mgzctl Administ
   group-PKI, zie `cert-manifest.md`).
 - **UI**: via de mgzctl-beheer-UI (`LISTEN_ADDRESS_UI`, `AUTHN_TYPE=none`) een dienst aanmaken
   met naam `berichtenmagazijn`, `endpoint_url` = de waarde uit `upsert-peer.sh`'s
-  `MAGAZIJNA_UPSTREAM_URL` (TODO: intra-project-DNS-vorm van `magazijna` in `mpfm-w3h`
-  bevestigen — bare servicenaam vs. koppelteken-vorm, zie de `upsert-peer.sh`-header) en
-  `inway_address` = de geregistreerde mgzinway `SELF_ADDRESS`.
+  `MAGAZIJNA_UPSTREAM_URL` (de ingress-URL van de app cross-deployment, bv.
+  `https://magazijna-test-mpfm-w3h.<base-domain>`) en `inway_address` = de geregistreerde
+  mgzinway `SELF_ADDRESS`.
 
 Verwacht: de contract-respons bevat `content_hash` (manager signt) en de directory (
 `AUTO_SIGN_GRANTS=servicePublication,delegatedServicePublication` op de directory-manager, buiten

--- a/fsc/deploy/zad/verify-zad.md
+++ b/fsc/deploy/zad/verify-zad.md
@@ -1,0 +1,79 @@
+# Verificatie ná apply — magazijn-a-peer op ZAD
+
+> **UITGESTELD — vereist ZAD-key / cluster / certs.** Dit draaiboek is niet uitgevoerd: er is
+> geen `ZAD_API_KEY_MAGAZIJNEN` in deze omgeving, geen draaiende peer op ZAD, en de cert-bundle
+> is niet gegenereerd. Claim nergens dat de peer draait of dat `apply` geslaagd is — dit document
+> beschrijft wat een mens ná een geslaagde `upsert-peer.sh apply` + cert-attachments (zie
+> `cert-manifest.md`) nog moet controleren.
+
+## Volgorde
+
+1. `upsert-peer.sh apply` gedraaid (UITGESTELD) → deployment + drie componenten bestaan in
+   project `mpfm-w3h`.
+2. Cert-attachments gemount (UITGESTELD, zie `cert-manifest.md`) + "Publicatie op het web"
+   (passthrough-TLS, modus 2) op mgzmgr/mgzinway ingesteld in de ZAD-UI.
+3. Componenten herstart en boot-logs foutloos (zie `cert-manifest.md`, laatste sectie).
+
+## (a) Announce — magazijn-OIN vindbaar in de directory
+
+**UITGESTELD.** Verwacht gedrag (analoog aan `fsc/deploy/local/smoke-announce.sh`, maar tegen de
+ZAD-directory-DB i.p.v. de lokale compose-postgres):
+
+```bash
+# Via de mgzmgr-mesh-host (:443), met de group-cert als client-cert:
+curl -sS --cert <group-cert> --key <group-key> --cacert <group-root> \
+  "https://<dirmgr-host-op-ZAD>/v1/peers" | jq '.[] | select(.id == "00000001003214345000")'
+```
+
+Verwacht: één entry met `id: "00000001003214345000"` en een `manager_address` die eindigt op
+`:443` en het mgzmgr-hostpatroon (`mgzmgr-<deployment>-mpfm-w3h.<base-domain>`) bevat.
+
+Alternatief (UI): log in op de directory-UI (repo A's `dirui`-component) en zoek de peer op OIN.
+
+## (b) `berichtenmagazijn` publiceren op de ZAD-controller
+
+**UITGESTELD.** `:443`-variant van `fsc/deploy/local/publish-service.sh`: dezelfde
+create-service + servicePublication-contract-flow, maar tegen de mgzctl Administration-API op
+`:443` (mesh) i.p.v. de lokale toolbox-container op de internal-PKI. Twee routes:
+
+- **Script**: kopieer `publish-service.sh` se logica, vervang `$CONTROLLER`/`$MANAGER` door de
+  ZAD mesh-hosts (`https://mgzctl-<deployment>-mpfm-w3h.<base-domain>:443` resp. mgzmgr) en het
+  cert/key/CA door de group-cert-attachments (niet de internal-cert — de mesh-call loopt over de
+  group-PKI, zie `cert-manifest.md`).
+- **UI**: via de mgzctl-beheer-UI (`LISTEN_ADDRESS_UI`, `AUTHN_TYPE=none`) een dienst aanmaken
+  met naam `berichtenmagazijn`, `endpoint_url` = de waarde uit `upsert-peer.sh`'s
+  `MAGAZIJNA_UPSTREAM_URL` (TODO: intra-project-DNS-vorm van `magazijna` in `mpfm-w3h`
+  bevestigen — bare servicenaam vs. koppelteken-vorm, zie de `upsert-peer.sh`-header) en
+  `inway_address` = de geregistreerde mgzinway `SELF_ADDRESS`.
+
+Verwacht: de contract-respons bevat `content_hash` (manager signt) en de directory (
+`AUTO_SIGN_GRANTS=servicePublication,delegatedServicePublication` op de directory-manager, buiten
+deze bundel) accepteert automatisch.
+
+## (c) Discover — dienst vindbaar
+
+**UITGESTELD.** Analoog aan `fsc/deploy/local/smoke-discover.sh`, tegen de ZAD-directory-DB of
+via de directory-UI: `berichtenmagazijn` moet als dienst van OIN `00000001003214345000` in de
+catalogus staan.
+
+## (d) Bestaande FBS-app-tests groen
+
+```bash
+./mvnw clean test -pl services/berichtenmagazijn -am
+```
+
+**UITGESTELD in de zin dat dit nog niet ná een echte ZAD-apply is herdraaid** — deze commando's
+draaien onafhankelijk van de FSC-peer (de app-tests raken geen FSC-componenten). Neem ze hier op
+zodat de operator na de ZAD-rollout expliciet nogmaals bevestigt dat de bestaande suite groen
+blijft (geen regressie via gedeelde config/env).
+
+## Acceptatiecriteria (#780) — afvinklijst
+
+- [ ] Magazijn-peer (echte OIN) draait naast de app: manager + inway + controller + DB (ZAD,
+      project-isolatie)
+- [ ] Peer verkrijgt group-cert via het cert-portal van repo A
+- [ ] Peer meldt zich aan bij de directory (announce)
+- [ ] `berichtenmagazijn` gepubliceerd + vindbaar in de directory
+
+Elk vinkje vereist een mens met ZAD-toegang, gegenereerde certs en een draaiende peer — geen van
+de vier is in deze bundel afgevinkt.

--- a/fsc/deploy/zad/verify-zad.md
+++ b/fsc/deploy/zad/verify-zad.md
@@ -9,7 +9,7 @@
 ## Volgorde
 
 1. `upsert-peer.sh apply` gedraaid (UITGESTELD) → deployment + drie componenten bestaan in
-   project `mpfm-w3h`.
+   project `mpfoa-e01`.
 2. Cert-attachments gemount (UITGESTELD, zie `cert-manifest.md`) + "Publicatie op het web"
    (passthrough-TLS, modus 2) op mgzmgr/mgzinway ingesteld in de ZAD-UI.
 3. Componenten herstart en boot-logs foutloos (zie `cert-manifest.md`, laatste sectie).
@@ -26,7 +26,7 @@ curl -sS --cert <group-cert> --key <group-key> --cacert <group-root> \
 ```
 
 Verwacht: één entry met `id: "00000001003214345000"` en een `manager_address` die eindigt op
-`:443` en het mgzmgr-hostpatroon (`mgzmgr-<deployment>-mpfm-w3h.<base-domain>`) bevat.
+`:443` en het mgzmgr-hostpatroon (`mgzmgr-<deployment>-mpfoa-e01.<base-domain>`) bevat.
 
 Alternatief (UI): log in op de directory-UI (repo A's `dirui`-component) en zoek de peer op OIN.
 
@@ -37,7 +37,7 @@ create-service + servicePublication-contract-flow, maar tegen de mgzctl Administ
 `:443` (mesh) i.p.v. de lokale toolbox-container op de internal-PKI. Twee routes:
 
 - **Script**: kopieer `publish-service.sh` se logica, vervang `$CONTROLLER`/`$MANAGER` door de
-  ZAD mesh-hosts (`https://mgzctl-<deployment>-mpfm-w3h.<base-domain>:443` resp. mgzmgr) en het
+  ZAD mesh-hosts (`https://mgzctl-<deployment>-mpfoa-e01.<base-domain>:443` resp. mgzmgr) en het
   cert/key/CA door de group-cert-attachments (niet de internal-cert — de mesh-call loopt over de
   group-PKI, zie `cert-manifest.md`).
 - **UI**: via de mgzctl-beheer-UI (`LISTEN_ADDRESS_UI`, `AUTHN_TYPE=none`) een dienst aanmaken

--- a/fsc/pki/README.md
+++ b/fsc/pki/README.md
@@ -1,0 +1,77 @@
+# FSC PKI-scaffolding — provider-peer `magazijn-a`
+
+Test-PKI voor de FSC provider-peer die later `berichtenmagazijn` als dienst publiceert.
+Scripts en CA-configs zijn 1:1 overgenomen uit `MinBZK/moza-fsc-testnet` (`pki/`), zodat deze
+peer aansluit op dezelfde testnet-conventies als de andere deelnemers (group `moza-fbs-test`,
+directory-OIN `00000000000000000010`).
+
+> **Niet voor productie.** Sleutels/certs horen **niet** in git: `ca/`, `out/`, `internal/` en
+> `zad-upload/` zijn gitignored (repo-root `.gitignore`). Alleen scripts, CA-configs en
+> `csr.json`-templates staan in git — zie ook repo A's eigen `pki/README.md` voor het
+> achterliggende ontwerp (`docs/superpowers/specs/2026-06-24-test-pki-design.md`, repo A).
+
+## Wat de scripts doen
+
+| Script | Doet |
+|--------|------|
+| `init-ca.sh` | Genereert de **group** root- + intermediate-CA (`ca.json`/`intermediate.json` → `ca/root.pem`, `ca/intermediate.pem`). Trust-anchor voor het hele testnet. |
+| `issue.sh [-f]` | Voor elke `peers/<peer>/<endpoint>/csr.json`: een **group**-cert (getekend door de group-intermediate) én een **internal**-cert (getekend door een per-peer self-signed internal-CA, automatisch aangemaakt). `-f` forceert her-uitgifte. |
+| `verify.sh` | Acceptatie-asserts: ketengeldigheid group- en internal-certs, OIN in het subject, isolatie group↔internal en tussen peers onderling, CRL leesbaar, geen secrets zichtbaar voor git. Exit 0 = groen. |
+| `zad-bundle.sh <peer>` | Verzamelt de upload-klare cert-set van één peer (group-trust-anchor + per-endpoint group/internal cert+key) in `zad-upload/<peer>/` met een `MANIFEST.md` (pod-pad + `TLS_*`-env-var per bestand). |
+| `config.json` | cfssl signing-config: profiel `intermediate` (voor de group-intermediate) en profiel `peer` (voor endpoint-leaves). |
+| `internal-ca.json`, `ca.json`, `intermediate.json` | cfssl CSR-specs voor resp. de per-peer internal-CA, de group-root en de group-intermediate. |
+
+### GROUP versus INTERNAL keten
+
+Elk endpoint (`manager`, `controller`, `inway`, `txlog`) krijgt twee certs uit twee losse ketens,
+zodat de manager zowel extern (mesh, group-trust) als intern (component-tot-component) een
+geldig certificaat heeft:
+
+| Keten | Issuer | Output | Doel |
+|-------|--------|--------|------|
+| **group** | group-intermediate (`ca/`) | `out/magazijn-a/<endpoint>/{cert,key}.pem` | Extern: mesh-mTLS, token- en contract-endpoints (hergebruikt dezelfde identity-cert). |
+| **internal** | per-peer internal-CA (`internal/magazijn-a/ca/`) | `internal/magazijn-a/<endpoint>/{cert,key}.pem` | Intern: component-tot-component binnen de peer, los van de group-trust-anchor. |
+
+## Peer `magazijn-a`
+
+- Peer-OIN = Peer ID = `serialnumber` in elke `csr.json`: `00000001003214345000`.
+- `names[].O`: `magazijn-a`.
+- Endpoints: `manager`, `controller`, `inway`, `txlog` — hostnamen zijn placeholder
+  (`<endpoint>.magazijn-a.fsc-test.local`), spiegelt repo A's `TODO(#723)` (echte ZAD-adressen
+  volgen later).
+
+## UITGESTELD — te draaien door de mens in een omgeving met cfssl
+
+Deze omgeving heeft geen `cfssl`/`cfssljson` en geen `docker`. Er zijn dus **geen certificaten
+gegenereerd of geverifieerd** — alleen scripts en configs zijn neergezet. Het group-CA-materiaal
+zelf (`ca/root.pem`, `ca/intermediate.pem`) staat ook in repo A niet in git (`pki/ca/` is daar
+gitignored); dit is dus geen ontbrekende download maar het verwachte resultaat van `init-ca.sh`,
+door de mens uit te voeren:
+
+```bash
+cd fsc/pki
+./init-ca.sh          # 1. group root + intermediate  -> ca/
+./issue.sh             # 2. per endpoint: group- + internal-cert
+./verify.sh             # 3. acceptatie-asserts, exit 0 = groen
+```
+
+Controleer daarna dat de OIN in het certificaat zit:
+
+```bash
+openssl x509 -in out/magazijn-a/inway/cert.pem -noout -subject | grep 00000001003214345000
+```
+
+Expected: de OIN wordt geëchood (zit in `serialNumber` van het subject).
+
+Zie ook `fsc/pki/certportal-proof.md` voor het (eveneens UITGESTELDE) alternatief via
+`ca-cfssl`/`ca-certportal`.
+
+## Statische validatie (wél al gedraaid, zonder cfssl/docker)
+
+```bash
+bash -n fsc/pki/init-ca.sh fsc/pki/issue.sh fsc/pki/verify.sh fsc/pki/zad-bundle.sh
+for f in fsc/pki/peers/magazijn-a/*/csr.json; do
+  jq -e '.serialnumber=="00000001003214345000"' "$f" >/dev/null && echo "$f OK"
+done
+jq . fsc/pki/config.json fsc/pki/internal-ca.json >/dev/null && echo "json OK"
+```

--- a/fsc/pki/README.md
+++ b/fsc/pki/README.md
@@ -53,11 +53,20 @@ door de mens uit te voeren:
 
 ```bash
 cd fsc/pki
-./init-ca.sh          # 1. group root + intermediate  -> ca/
+./init-ca.sh          # 1. group root + intermediate  -> ca/   (ALLEEN lokale proof, zie hieronder)
 ./issue.sh            # 2. per endpoint: group- + internal-cert
 ./gen-crl.sh          # 3. lege CRL getekend door de intermediate -> ca/intermediate.crl
 ./verify.sh           # 4. acceptatie-asserts (incl. CRL leesbaar), exit 0 = groen
 ```
+
+> **Lokale proof vs. echte directory — de group-CA verschilt.**
+> - **Lokale compose-proof** (`fsc/deploy/local/`): geïsoleerde mesh, dus `init-ca.sh` genereert
+>   een eigen group root+intermediate. Prima — alle deelnemers vertrouwen dezelfde lokale root.
+> - **ZAD, aangesloten op de fsc-testnet-directory** (`fsc/deploy/zad/`): de group-leaf van
+>   magazijn-a moet ketenen naar **fsc-testnet's** group-root (anders vertrouwt de directory de
+>   peer niet). Draai `init-ca.sh` dan **niet**; zet fsc-testnet's `ca/root.pem` +
+>   `ca/intermediate.pem` (+ keys) in `fsc/pki/ca/` en draai alleen `issue.sh` (stap 2-4). De
+>   INTERNAL-CA blijft hoe dan ook lokaal/self-signed per-peer.
 
 Controleer daarna dat de OIN in het certificaat zit:
 

--- a/fsc/pki/README.md
+++ b/fsc/pki/README.md
@@ -16,7 +16,10 @@ directory-OIN `00000000000000000010`).
 |--------|------|
 | `init-ca.sh` | Genereert de **group** root- + intermediate-CA (`ca.json`/`intermediate.json` → `ca/root.pem`, `ca/intermediate.pem`). Trust-anchor voor het hele testnet. |
 | `issue.sh [-f]` | Voor elke `peers/<peer>/<endpoint>/csr.json`: een **group**-cert (getekend door de group-intermediate) én een **internal**-cert (getekend door een per-peer self-signed internal-CA, automatisch aangemaakt). `-f` forceert her-uitgifte. |
+| `gen-crl.sh` | Genereert een lege CRL getekend door de group-intermediate → `ca/intermediate.crl`. **Vereist vóór `verify.sh`** — die assert dat de CRL leesbaar is. |
 | `verify.sh` | Acceptatie-asserts: ketengeldigheid group- en internal-certs, OIN in het subject, isolatie group↔internal en tussen peers onderling, CRL leesbaar, geen secrets zichtbaar voor git. Exit 0 = groen. |
+| `combine-pem.sh` | Bouwt per group-endpoint één `combined.pem` (cert + key) voor de ZAD "Publicatie op het web"-passthrough-upload (modus 2). Gitignored (bevat de key). |
+| `fix-permissions.sh` | Haalt world read/write van de `*-key.pem`/`key.pem`-bestanden af. |
 | `zad-bundle.sh <peer>` | Verzamelt de upload-klare cert-set van één peer (group-trust-anchor + per-endpoint group/internal cert+key) in `zad-upload/<peer>/` met een `MANIFEST.md` (pod-pad + `TLS_*`-env-var per bestand). |
 | `config.json` | cfssl signing-config: profiel `intermediate` (voor de group-intermediate) en profiel `peer` (voor endpoint-leaves). |
 | `internal-ca.json`, `ca.json`, `intermediate.json` | cfssl CSR-specs voor resp. de per-peer internal-CA, de group-root en de group-intermediate. |
@@ -51,8 +54,9 @@ door de mens uit te voeren:
 ```bash
 cd fsc/pki
 ./init-ca.sh          # 1. group root + intermediate  -> ca/
-./issue.sh             # 2. per endpoint: group- + internal-cert
-./verify.sh             # 3. acceptatie-asserts, exit 0 = groen
+./issue.sh            # 2. per endpoint: group- + internal-cert
+./gen-crl.sh          # 3. lege CRL getekend door de intermediate -> ca/intermediate.crl
+./verify.sh           # 4. acceptatie-asserts (incl. CRL leesbaar), exit 0 = groen
 ```
 
 Controleer daarna dat de OIN in het certificaat zit:
@@ -69,7 +73,9 @@ Zie ook `fsc/pki/certportal-proof.md` voor het (eveneens UITGESTELDE) alternatie
 ## Statische validatie (wél al gedraaid, zonder cfssl/docker)
 
 ```bash
-bash -n fsc/pki/init-ca.sh fsc/pki/issue.sh fsc/pki/verify.sh fsc/pki/zad-bundle.sh
+bash -n fsc/pki/init-ca.sh fsc/pki/issue.sh fsc/pki/gen-crl.sh fsc/pki/verify.sh \
+        fsc/pki/zad-bundle.sh fsc/pki/combine-pem.sh
+sh -n   fsc/pki/fix-permissions.sh
 for f in fsc/pki/peers/magazijn-a/*/csr.json; do
   jq -e '.serialnumber=="00000001003214345000"' "$f" >/dev/null && echo "$f OK"
 done

--- a/fsc/pki/ca.json
+++ b/fsc/pki/ca.json
@@ -1,0 +1,6 @@
+{
+  "CN": "MOZa FSC Testnet Root CA",
+  "key": { "algo": "rsa", "size": 4096 },
+  "names": [{ "O": "MOZa FSC Testnet", "C": "NL" }],
+  "ca": { "expiry": "131400h" }
+}

--- a/fsc/pki/certportal-proof.md
+++ b/fsc/pki/certportal-proof.md
@@ -1,0 +1,89 @@
+# Cert-portal-bewijs — group-cert voor magazijn-OIN via self-service
+
+> **UITGESTELD.** Deze procedure vereist Docker (`ca-cfssl` + `ca-certportal`-containers) en is
+> in deze omgeving **niet uitgevoerd**. Onderstaande stappen zijn gedocumenteerd voor de mens om
+> handmatig te draaien in een omgeving met Docker + `openssl`. Er is geen cert aangevraagd en
+> geen `openssl verify`-output vastgelegd — dat gebeurt pas wanneer iemand deze procedure
+> daadwerkelijk uitvoert.
+
+## Context (Spec A, "Cert-portal-bewijs")
+
+Fragment uit repo A's
+`docs/superpowers/specs/2026-06-29-fsc-generiek-provider-onboarding-design.md`, opgehaald met:
+
+```bash
+gh api "repos/MinBZK/moza-fsc-testnet/contents/docs/superpowers/specs/2026-06-29-fsc-generiek-provider-onboarding-design.md" \
+  --jq '.content' | base64 -d | sed -n '/Cert-portal-bewijs/,+8p'
+```
+
+> Aparte, kleine verificatie (script of gedocumenteerde stappen): start `ca-cfssl` +
+> `ca-certportal`, vraag via de portal een cert aan voor een test-OIN, en toon dat het
+> geldige cert tegen de test-trust-anchor verifieert (`pki/verify.sh`-stijl). Bewijst de
+> self-service-onboarding zonder de hele tweede peer te hoeven draaien.
+
+Uit dezelfde spec, de rol van beide componenten:
+
+| Component | Rol | Image |
+|-----------|-----|-------|
+| `ca-cfssl` | draaiende test-CA (CFSSL, `:8888`) die certs signt tegen de test-trust-anchor | `open-fsc-ca-cfssl-unsafe` |
+| `ca-certportal` | web/HTTP-portal waarmee een peer een group-cert aanvraagt; client van `ca-cfssl` (`--ca-host`) | `open-fsc-ca-certportal` |
+
+`ca-cfssl` draait dezelfde group-CA-config (root + intermediate) als in `fsc/pki/` — dus eerst
+`fsc/pki/init-ca.sh` draaien (zie `fsc/pki/README.md`, ook UITGESTELD) zodat `fsc/pki/ca/root.pem`
++ `ca/intermediate.pem` bestaan.
+
+## Stap 1 — `ca-cfssl` starten met de group-CA uit `fsc/pki/`
+
+Mount de group-CA (`fsc/pki/ca/`) en `fsc/pki/config.json` in de container en start CFSSL als
+HTTP-service op `:8888`. Gebruik dezelfde image-tag als elders in dit project
+(`IMAGE_TAG=v1.43.7`, zie `fsc/deploy/local/.env.example`):
+
+```bash
+docker run --rm -d --name ca-cfssl \
+  -p 8888:8888 \
+  -v "$(pwd)/fsc/pki/ca:/ca:ro" \
+  -v "$(pwd)/fsc/pki/config.json:/config.json:ro" \
+  open-fsc-ca-cfssl-unsafe:v1.43.7 \
+  serve -ca /ca/intermediate.pem -ca-key /ca/intermediate-key.pem -config /config.json -address 0.0.0.0
+```
+
+## Stap 2 — `ca-certportal` starten als client van `ca-cfssl`
+
+```bash
+docker run --rm -d --name ca-certportal \
+  -p 8443:8443 \
+  --link ca-cfssl \
+  open-fsc-ca-certportal:v1.43.7 \
+  --ca-host ca-cfssl --ca-port 8888
+```
+
+## Stap 3 — group-cert aanvragen voor de magazijn-OIN via de portal
+
+Vraag via de portal-UI (of diens HTTP-API, afhankelijk van wat `ca-certportal` blootlegt) een
+group-cert aan met dezelfde velden als `fsc/pki/peers/magazijn-a/manager/csr.json`:
+
+- `CN`: `manager.magazijn-a.fsc-test.local`
+- `serialnumber` (OIN): `00000001003214345000`
+- `O`: `magazijn-a`
+
+Sla het teruggegeven certificaat lokaal op als `<portal-cert>.pem`.
+
+## Stap 4 — verifiëren tegen de trust-anchor
+
+```bash
+openssl verify -CAfile fsc/pki/group/root.pem <portal-cert>.pem   # Expected: OK
+openssl x509 -in <portal-cert>.pem -noout -subject | grep 00000001003214345000
+```
+
+`fsc/pki/group/root.pem` verwijst hier naar de group-trust-anchor die `init-ca.sh` produceert op
+`fsc/pki/ca/root.pem` — pas het pad aan als de lokale checkout een andere structuur gebruikt.
+
+Expected: `openssl verify` meldt `OK`; de `grep` op de OIN levert een treffer op (OIN zit in
+`serialNumber` van het subject).
+
+## Resultaat van deze bundel
+
+Geen van bovenstaande stappen is uitgevoerd. Er is geen container gestart, geen cert
+aangevraagd en geen verify-output vastgelegd. Dit document is de gedocumenteerde procedure;
+het daadwerkelijke bewijs (geplakte `openssl verify: OK`-output) volgt zodra iemand dit met
+Docker beschikbaar uitvoert.

--- a/fsc/pki/certportal-proof.md
+++ b/fsc/pki/certportal-proof.md
@@ -35,8 +35,8 @@ Uit dezelfde spec, de rol van beide componenten:
 ## Stap 1 — `ca-cfssl` starten met de group-CA uit `fsc/pki/`
 
 Mount de group-CA (`fsc/pki/ca/`) en `fsc/pki/config.json` in de container en start CFSSL als
-HTTP-service op `:8888`. Gebruik dezelfde image-tag als elders in dit project
-(`IMAGE_TAG=v1.43.7`, zie `fsc/deploy/local/.env.example`):
+HTTP-service op `:8888`. Gebruik de projectbrede image-pin `v1.43.7` (zie
+`docs/plans/2026-07-08-magazijn-provider-peer-fsc-design.md`, tabel "Bekende parameters"):
 
 ```bash
 docker run --rm -d --name ca-cfssl \

--- a/fsc/pki/combine-pem.sh
+++ b/fsc/pki/combine-pem.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright © MOZa FSC Testnet — Licensed under the EUPL
+# Bouwt per group-endpoint één PEM met cert + key voor de ZAD "Publicatie op het web"-
+# passthrough-upload (modus 2: eigen certificaat op de pod). ZAD wil daar één bestand met
+# cert + key; pki/issue.sh levert ze gescheiden. Output: pki/out/<peer>/<endpoint>/combined.pem
+# (= leaf + intermediate-chain uit cert.pem, gevolgd door key.pem). Gitignored (bevat de key).
+set -euo pipefail
+
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+made=0
+for cert in "${BASE_DIR}"/out/*/*/cert.pem; do
+  [ -e "${cert}" ] || { echo "Geen group-certs in ${BASE_DIR}/out (issue.sh gedraaid?)" >&2; exit 1; }
+  dir="$(dirname "${cert}")"
+  key="${dir}/key.pem"
+  rel="${dir#"${BASE_DIR}/out/"}"
+  if [ ! -s "${key}" ]; then
+    echo "FAIL: key ontbreekt voor ${rel} (${key})" >&2
+    exit 1
+  fi
+  combined="${dir}/combined.pem"
+  umask 077                       # 0600: het bestand bevat de privésleutel
+  cat "${cert}" "${key}" > "${combined}"
+  echo "OK  combined: out/${rel}/combined.pem"
+  made=$((made + 1))
+done
+echo "Klaar: ${made} combined-PEM('s). Upload deze als 'eigen certificaat op de pod' (modus 2)."

--- a/fsc/pki/config.json
+++ b/fsc/pki/config.json
@@ -1,0 +1,16 @@
+{
+  "signing": {
+    "default": { "expiry": "26280h" },
+    "profiles": {
+      "intermediate": {
+        "expiry": "131376h",
+        "ca_constraint": { "is_ca": true, "max_path_len": 0, "max_path_len_zero": true },
+        "usages": ["digital signature", "cert sign", "crl sign", "signing"]
+      },
+      "peer": {
+        "expiry": "26280h",
+        "usages": ["signing", "key encipherment", "server auth", "client auth"]
+      }
+    }
+  }
+}

--- a/fsc/pki/fix-permissions.sh
+++ b/fsc/pki/fix-permissions.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+# Copyright © MOZa FSC Testnet — Licensed under the EUPL
+# Verwijder world read/write van key-bestanden.
+BASE_DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
+find "${BASE_DIR}" -name "*-key.pem" -type f -exec chmod o-rw {} \;
+find "${BASE_DIR}" -name "key.pem"   -type f -exec chmod o-rw {} \;

--- a/fsc/pki/gen-crl.sh
+++ b/fsc/pki/gen-crl.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Copyright © MOZa FSC Testnet — Licensed under the EUPL
+# Genereert een lege CRL getekend door de intermediate (issuer van peer-certs) (#722).
+#
+# cfssl 1.6.x gencrl-variant: output is base64-gecodeerde DER (geen JSON, geen rauwe bytes).
+# Decoded met `base64 -d`, geconverteerd naar PEM via `openssl crl -inform DER`.
+set -euo pipefail
+
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+CA_DIR="${BASE_DIR}/ca"
+EMPTY="$(mktemp)"
+trap 'rm -f "${EMPTY}"' EXIT
+
+# cfssl gencrl <serials-file> <ca-cert> <ca-key> <expiry-uren> → base64(DER)
+# Expiry 43800 uur = 5 jaar (ruim genoeg voor testnet-gebruik).
+cfssl gencrl "${EMPTY}" "${CA_DIR}/intermediate.pem" "${CA_DIR}/intermediate-key.pem" 43800 \
+  | base64 -d \
+  | openssl crl -inform DER -out "${CA_DIR}/intermediate.crl"
+
+echo "OK: intermediate.crl in ${CA_DIR}"

--- a/fsc/pki/init-ca.sh
+++ b/fsc/pki/init-ca.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Copyright © MOZa FSC Testnet — Licensed under the EUPL
+# Genereert root + intermediate test-CA (#722). NIET voor productie.
+set -euo pipefail
+
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+CONFIG="${BASE_DIR}/config.json"
+CA_DIR="${BASE_DIR}/ca"
+mkdir -p "${CA_DIR}"
+
+# Root: self-signed CA
+cfssl genkey -initca "${BASE_DIR}/ca.json" | cfssljson -bare "${CA_DIR}/root"
+
+# Intermediate: self-signed, daarna her-tekenen door root met profiel 'intermediate'
+cfssl genkey -initca "${BASE_DIR}/intermediate.json" | cfssljson -bare "${CA_DIR}/intermediate"
+cfssl sign -config "${CONFIG}" \
+  -ca "${CA_DIR}/root.pem" -ca-key "${CA_DIR}/root-key.pem" \
+  -profile intermediate "${CA_DIR}/intermediate.csr" \
+  | cfssljson -bare "${CA_DIR}/intermediate"
+
+rm -f "${CA_DIR}/root.csr" "${CA_DIR}/intermediate.csr"
+echo "OK: root.pem (trust-anchor) + intermediate.pem in ${CA_DIR}"

--- a/fsc/pki/intermediate.json
+++ b/fsc/pki/intermediate.json
@@ -1,0 +1,6 @@
+{
+  "CN": "MOZa FSC Testnet Intermediate CA",
+  "key": { "algo": "rsa", "size": 4096 },
+  "names": [{ "O": "MOZa FSC Testnet", "C": "NL" }],
+  "ca": { "expiry": "131376h" }
+}

--- a/fsc/pki/internal-ca.json
+++ b/fsc/pki/internal-ca.json
@@ -1,0 +1,6 @@
+{
+  "CN": "MOZa FSC Testnet Internal CA",
+  "key": { "algo": "rsa", "size": 4096 },
+  "names": [{ "O": "MOZa FSC Testnet (internal)", "C": "NL" }],
+  "ca": { "expiry": "131376h" }
+}

--- a/fsc/pki/issue.sh
+++ b/fsc/pki/issue.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Copyright © MOZa FSC Testnet — Licensed under the EUPL
+# Issued per-endpoint peer-certs uit pki/peers/*/*/csr.json (#722). -f = forceer her-uitgifte.
+#
+# Twee cert-ketens per endpoint (gegrond op open-fsc `modd.conf`):
+#   - GROUP (extern): getekend door de group-intermediate -> pki/out/<peer>/<endpoint>/
+#       dekt TLS_GROUP_CERT/KEY + (hergebruikt) TLS_GROUP_TOKEN_* + TLS_GROUP_CONTRACT_*.
+#   - INTERNAL: getekend door een PER-PEER internal-CA -> pki/internal/<peer>/<endpoint>/
+#       dekt TLS_CERT/KEY + (hergebruikt) TLS_INTERNAL_UNAUTHENTICATED_*. De internal-CA
+#       is een eigen self-signed root per peer (spiegelt open-fsc `pki/internal/<org>/ca/`).
+set -euo pipefail
+
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+CONFIG="${BASE_DIR}/config.json"
+CA_CERT="${BASE_DIR}/ca/intermediate.pem"
+CA_KEY="${BASE_DIR}/ca/intermediate-key.pem"
+INTERNAL_CA_SPEC="${BASE_DIR}/internal-ca.json"
+
+FORCE=0
+[ "${1:-}" = "-f" ] && FORCE=1
+
+# 1. Per-peer internal-CA root (self-signed). Eén per peer-map onder pki/peers/.
+for PEER_DIR in "${BASE_DIR}"/peers/*/; do
+  PEER="$(basename "${PEER_DIR}")"
+  ICA_DIR="${BASE_DIR}/internal/${PEER}/ca"
+  if [ -s "${ICA_DIR}/root.pem" ] && [ -s "${ICA_DIR}/root-key.pem" ] && [ "${FORCE}" -eq 0 ]; then
+    echo "skip internal-CA ${PEER} (geen -f)"
+    continue
+  fi
+  mkdir -p "${ICA_DIR}"
+  echo "internal-CA voor ${PEER}..."
+  cfssl genkey -initca "${INTERNAL_CA_SPEC}" | cfssljson -bare "${ICA_DIR}/root"
+  rm -f "${ICA_DIR}/root.csr"
+  [ -s "${ICA_DIR}/root.pem" ] && [ -s "${ICA_DIR}/root-key.pem" ] \
+    || { echo "FAIL: internal-CA ${PEER} onvolledig" >&2; exit 1; }
+done
+
+# 2. Per endpoint: group-cert (extern) + internal-cert (per-peer CA). Zelfde csr.json.
+find "${BASE_DIR}/peers" -name csr.json -print0 | while IFS= read -r -d '' CSR; do
+  REL="$(dirname "${CSR#"${BASE_DIR}/peers/"}")"   # <peer>/<endpoint>
+  PEER="${REL%%/*}"
+  GROUP_OUT="${BASE_DIR}/out/${REL}"
+  INT_OUT="${BASE_DIR}/internal/${REL}"
+  ICA_DIR="${BASE_DIR}/internal/${PEER}/ca"
+
+  # GROUP (extern, group-intermediate). Hecht intermediate aan voor de keten.
+  if [ -s "${GROUP_OUT}/cert.pem" ] && [ -s "${GROUP_OUT}/key.pem" ] && [ "${FORCE}" -eq 0 ]; then
+    echo "skip group ${REL} (geen -f)"
+  else
+    mkdir -p "${GROUP_OUT}"
+    echo "group-cert voor ${REL}..."
+    cfssl gencert -config "${CONFIG}" -ca "${CA_CERT}" -ca-key "${CA_KEY}" \
+      -profile peer "${CSR}" | cfssljson -bare "${GROUP_OUT}/cert"
+    cat "${CA_CERT}" >> "${GROUP_OUT}/cert.pem"          # hecht intermediate aan (keten)
+    mv "${GROUP_OUT}/cert-key.pem" "${GROUP_OUT}/key.pem"
+    rm -f "${GROUP_OUT}/cert.csr"
+    [ -s "${GROUP_OUT}/cert.pem" ] && [ -s "${GROUP_OUT}/key.pem" ] \
+      || { echo "FAIL: group-cert ${REL} onvolledig" >&2; exit 1; }
+  fi
+
+  # INTERNAL (per-peer internal-CA). Bare leaf; TLS_ROOT_CERT wijst los naar de internal-root.
+  if [ -s "${INT_OUT}/cert.pem" ] && [ -s "${INT_OUT}/key.pem" ] && [ "${FORCE}" -eq 0 ]; then
+    echo "skip internal ${REL} (geen -f)"
+  else
+    mkdir -p "${INT_OUT}"
+    echo "internal-cert voor ${REL}..."
+    cfssl gencert -config "${CONFIG}" -ca "${ICA_DIR}/root.pem" -ca-key "${ICA_DIR}/root-key.pem" \
+      -profile peer "${CSR}" | cfssljson -bare "${INT_OUT}/cert"
+    mv "${INT_OUT}/cert-key.pem" "${INT_OUT}/key.pem"
+    rm -f "${INT_OUT}/cert.csr"
+    [ -s "${INT_OUT}/cert.pem" ] && [ -s "${INT_OUT}/key.pem" ] \
+      || { echo "FAIL: internal-cert ${REL} onvolledig" >&2; exit 1; }
+  fi
+done
+echo "OK: group-certs in ${BASE_DIR}/out, internal-certs in ${BASE_DIR}/internal"

--- a/fsc/pki/peers/directory/directory/csr.json
+++ b/fsc/pki/peers/directory/directory/csr.json
@@ -1,0 +1,7 @@
+{
+  "CN": "directory.fsc-test.local",
+  "key": { "algo": "rsa", "size": 4096 },
+  "hosts": ["directory.fsc-test.local", "*.rig.prd1.gn2.quattro.rijksapps.nl"],
+  "serialnumber": "00000000000000000010",
+  "names": [{ "O": "directory", "C": "NL" }]
+}

--- a/fsc/pki/peers/directory/manager/csr.json
+++ b/fsc/pki/peers/directory/manager/csr.json
@@ -1,0 +1,7 @@
+{
+  "CN": "manager.directory.fsc-test.local",
+  "key": { "algo": "rsa", "size": 4096 },
+  "hosts": ["manager.directory.fsc-test.local"],
+  "serialnumber": "00000000000000000010",
+  "names": [{ "O": "directory", "C": "NL" }]
+}

--- a/fsc/pki/peers/magazijn-a/controller/csr.json
+++ b/fsc/pki/peers/magazijn-a/controller/csr.json
@@ -6,7 +6,7 @@
   },
   "hosts": [
     "controller.magazijn-a.fsc-test.local",
-    "mgzctl-peer-mpfm-w3h.rig.prd1.gn2.quattro.rijksapps.nl"
+    "mgzctl-test-mpfoa-e01.rig.prd1.gn2.quattro.rijksapps.nl"
   ],
   "serialnumber": "00000001003214345000",
   "names": [

--- a/fsc/pki/peers/magazijn-a/controller/csr.json
+++ b/fsc/pki/peers/magazijn-a/controller/csr.json
@@ -1,0 +1,7 @@
+{
+  "CN": "controller.magazijn-a.fsc-test.local",
+  "key": { "algo": "rsa", "size": 4096 },
+  "hosts": ["controller.magazijn-a.fsc-test.local"],
+  "serialnumber": "00000001003214345000",
+  "names": [{ "O": "magazijn-a", "C": "NL" }]
+}

--- a/fsc/pki/peers/magazijn-a/controller/csr.json
+++ b/fsc/pki/peers/magazijn-a/controller/csr.json
@@ -5,8 +5,8 @@
     "size": 4096
   },
   "hosts": [
-    "*.rig.prd1.gn2.quattro.rijksapps.nl",
-    "controller.magazijn-a.fsc-test.local"
+    "controller.magazijn-a.fsc-test.local",
+    "mgzctl-peer-mpfm-w3h.rig.prd1.gn2.quattro.rijksapps.nl"
   ],
   "serialnumber": "00000001003214345000",
   "names": [

--- a/fsc/pki/peers/magazijn-a/controller/csr.json
+++ b/fsc/pki/peers/magazijn-a/controller/csr.json
@@ -1,7 +1,18 @@
 {
   "CN": "controller.magazijn-a.fsc-test.local",
-  "key": { "algo": "rsa", "size": 4096 },
-  "hosts": ["controller.magazijn-a.fsc-test.local"],
+  "key": {
+    "algo": "rsa",
+    "size": 4096
+  },
+  "hosts": [
+    "*.rig.prd1.gn2.quattro.rijksapps.nl",
+    "controller.magazijn-a.fsc-test.local"
+  ],
   "serialnumber": "00000001003214345000",
-  "names": [{ "O": "magazijn-a", "C": "NL" }]
+  "names": [
+    {
+      "O": "magazijn-a",
+      "C": "NL"
+    }
+  ]
 }

--- a/fsc/pki/peers/magazijn-a/inway/csr.json
+++ b/fsc/pki/peers/magazijn-a/inway/csr.json
@@ -1,0 +1,7 @@
+{
+  "CN": "inway.magazijn-a.fsc-test.local",
+  "key": { "algo": "rsa", "size": 4096 },
+  "hosts": ["inway.magazijn-a.fsc-test.local"],
+  "serialnumber": "00000001003214345000",
+  "names": [{ "O": "magazijn-a", "C": "NL" }]
+}

--- a/fsc/pki/peers/magazijn-a/inway/csr.json
+++ b/fsc/pki/peers/magazijn-a/inway/csr.json
@@ -6,7 +6,7 @@
   },
   "hosts": [
     "inway.magazijn-a.fsc-test.local",
-    "mgzinway-peer-mpfm-w3h.rig.prd1.gn2.quattro.rijksapps.nl"
+    "mgzinway-test-mpfoa-e01.rig.prd1.gn2.quattro.rijksapps.nl"
   ],
   "serialnumber": "00000001003214345000",
   "names": [

--- a/fsc/pki/peers/magazijn-a/inway/csr.json
+++ b/fsc/pki/peers/magazijn-a/inway/csr.json
@@ -5,8 +5,8 @@
     "size": 4096
   },
   "hosts": [
-    "*.rig.prd1.gn2.quattro.rijksapps.nl",
-    "inway.magazijn-a.fsc-test.local"
+    "inway.magazijn-a.fsc-test.local",
+    "mgzinway-peer-mpfm-w3h.rig.prd1.gn2.quattro.rijksapps.nl"
   ],
   "serialnumber": "00000001003214345000",
   "names": [

--- a/fsc/pki/peers/magazijn-a/inway/csr.json
+++ b/fsc/pki/peers/magazijn-a/inway/csr.json
@@ -1,7 +1,18 @@
 {
   "CN": "inway.magazijn-a.fsc-test.local",
-  "key": { "algo": "rsa", "size": 4096 },
-  "hosts": ["inway.magazijn-a.fsc-test.local"],
+  "key": {
+    "algo": "rsa",
+    "size": 4096
+  },
+  "hosts": [
+    "*.rig.prd1.gn2.quattro.rijksapps.nl",
+    "inway.magazijn-a.fsc-test.local"
+  ],
   "serialnumber": "00000001003214345000",
-  "names": [{ "O": "magazijn-a", "C": "NL" }]
+  "names": [
+    {
+      "O": "magazijn-a",
+      "C": "NL"
+    }
+  ]
 }

--- a/fsc/pki/peers/magazijn-a/manager/csr.json
+++ b/fsc/pki/peers/magazijn-a/manager/csr.json
@@ -1,0 +1,7 @@
+{
+  "CN": "manager.magazijn-a.fsc-test.local",
+  "key": { "algo": "rsa", "size": 4096 },
+  "hosts": ["manager.magazijn-a.fsc-test.local"],
+  "serialnumber": "00000001003214345000",
+  "names": [{ "O": "magazijn-a", "C": "NL" }]
+}

--- a/fsc/pki/peers/magazijn-a/manager/csr.json
+++ b/fsc/pki/peers/magazijn-a/manager/csr.json
@@ -1,7 +1,19 @@
 {
   "CN": "manager.magazijn-a.fsc-test.local",
-  "key": { "algo": "rsa", "size": 4096 },
-  "hosts": ["manager.magazijn-a.fsc-test.local", "magazijn-a.fsc-test.local"],
+  "key": {
+    "algo": "rsa",
+    "size": 4096
+  },
+  "hosts": [
+    "*.rig.prd1.gn2.quattro.rijksapps.nl",
+    "magazijn-a.fsc-test.local",
+    "manager.magazijn-a.fsc-test.local"
+  ],
   "serialnumber": "00000001003214345000",
-  "names": [{ "O": "magazijn-a", "C": "NL" }]
+  "names": [
+    {
+      "O": "magazijn-a",
+      "C": "NL"
+    }
+  ]
 }

--- a/fsc/pki/peers/magazijn-a/manager/csr.json
+++ b/fsc/pki/peers/magazijn-a/manager/csr.json
@@ -7,7 +7,7 @@
   "hosts": [
     "magazijn-a.fsc-test.local",
     "manager.magazijn-a.fsc-test.local",
-    "mgzmgr-peer-mpfm-w3h.rig.prd1.gn2.quattro.rijksapps.nl"
+    "mgzmgr-test-mpfoa-e01.rig.prd1.gn2.quattro.rijksapps.nl"
   ],
   "serialnumber": "00000001003214345000",
   "names": [

--- a/fsc/pki/peers/magazijn-a/manager/csr.json
+++ b/fsc/pki/peers/magazijn-a/manager/csr.json
@@ -5,9 +5,9 @@
     "size": 4096
   },
   "hosts": [
-    "*.rig.prd1.gn2.quattro.rijksapps.nl",
     "magazijn-a.fsc-test.local",
-    "manager.magazijn-a.fsc-test.local"
+    "manager.magazijn-a.fsc-test.local",
+    "mgzmgr-peer-mpfm-w3h.rig.prd1.gn2.quattro.rijksapps.nl"
   ],
   "serialnumber": "00000001003214345000",
   "names": [

--- a/fsc/pki/peers/magazijn-a/manager/csr.json
+++ b/fsc/pki/peers/magazijn-a/manager/csr.json
@@ -1,7 +1,7 @@
 {
   "CN": "manager.magazijn-a.fsc-test.local",
   "key": { "algo": "rsa", "size": 4096 },
-  "hosts": ["manager.magazijn-a.fsc-test.local"],
+  "hosts": ["manager.magazijn-a.fsc-test.local", "magazijn-a.fsc-test.local"],
   "serialnumber": "00000001003214345000",
   "names": [{ "O": "magazijn-a", "C": "NL" }]
 }

--- a/fsc/pki/peers/magazijn-a/txlog/csr.json
+++ b/fsc/pki/peers/magazijn-a/txlog/csr.json
@@ -1,7 +1,7 @@
 {
   "CN": "txlog.magazijn-a.fsc-test.local",
   "key": { "algo": "rsa", "size": 4096 },
-  "hosts": ["txlog.magazijn-a.fsc-test.local"],
+  "hosts": ["txlog.magazijn-a.fsc-test.local", "mgztxlog-test-mpfoa-e01.rig.prd1.gn2.quattro.rijksapps.nl"],
   "serialnumber": "00000001003214345000",
   "names": [{ "O": "magazijn-a", "C": "NL" }]
 }

--- a/fsc/pki/peers/magazijn-a/txlog/csr.json
+++ b/fsc/pki/peers/magazijn-a/txlog/csr.json
@@ -1,0 +1,7 @@
+{
+  "CN": "txlog.magazijn-a.fsc-test.local",
+  "key": { "algo": "rsa", "size": 4096 },
+  "hosts": ["txlog.magazijn-a.fsc-test.local"],
+  "serialnumber": "00000001003214345000",
+  "names": [{ "O": "magazijn-a", "C": "NL" }]
+}

--- a/fsc/pki/verify.sh
+++ b/fsc/pki/verify.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Copyright © MOZa FSC Testnet — Licensed under the EUPL
+# Acceptatie-asserts test-PKI (#722). Exit 0 = groen.
+set -uo pipefail
+
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+fail=0
+
+# 1. Ketengeldigheid per group-leaf
+for cert in "${BASE_DIR}"/out/*/*/cert.pem; do
+  [ -e "${cert}" ] || { echo "FAIL group-certs ontbreken (issue.sh gedraaid?)"; fail=1; break; }
+  if openssl verify -CAfile "${BASE_DIR}/ca/root.pem" \
+       -untrusted "${BASE_DIR}/ca/intermediate.pem" "${cert}" >/dev/null 2>&1; then
+    echo "OK  keten: ${cert#"${BASE_DIR}/"}"
+  else
+    echo "FAIL keten: ${cert#"${BASE_DIR}/"}"; fail=1
+  fi
+done
+
+# 2. serialNumber (OIN) aanwezig in subject — group én internal (zelfde csr.json)
+for cert in "${BASE_DIR}"/out/*/*/cert.pem "${BASE_DIR}"/internal/*/*/cert.pem; do
+  [ -e "${cert}" ] || continue
+  if openssl x509 -in "${cert}" -noout -subject -nameopt sep_multiline | grep -q 'serialNumber'; then
+    echo "OK  OIN:   ${cert#"${BASE_DIR}/"}"
+  else
+    echo "FAIL OIN ontbreekt: ${cert#"${BASE_DIR}/"}"; fail=1
+  fi
+done
+
+# 3. Internal-keten: elke internal-leaf valideert tegen de internal-CA van zíjn peer
+for cert in "${BASE_DIR}"/internal/*/*/cert.pem; do
+  [ -e "${cert}" ] || { echo "FAIL internal-certs ontbreken"; fail=1; break; }
+  peer="$(basename "$(dirname "$(dirname "${cert}")")")"
+  root="${BASE_DIR}/internal/${peer}/ca/root.pem"
+  if openssl verify -CAfile "${root}" "${cert}" >/dev/null 2>&1; then
+    echo "OK  internal: ${cert#"${BASE_DIR}/"}"
+  else
+    echo "FAIL internal-keten: ${cert#"${BASE_DIR}/"}"; fail=1
+  fi
+done
+
+# 3b. ISOLATIE: internal-leaf mag NIET tegen de group-trust-anchor valideren,
+#     en peer-A's leaf NIET tegen peer-B's internal-root. Slagen = boundary lek = FAIL.
+for cert in "${BASE_DIR}"/internal/*/*/cert.pem; do
+  [ -e "${cert}" ] || break
+  rel="${cert#"${BASE_DIR}/internal/"}"
+  peer="$(basename "$(dirname "$(dirname "${cert}")")")"
+  if openssl verify -CAfile "${BASE_DIR}/ca/root.pem" \
+       -untrusted "${BASE_DIR}/ca/intermediate.pem" "${cert}" >/dev/null 2>&1; then
+    echo "FAIL isolatie: internal-leaf accepteert group-anchor: ${rel}"; fail=1
+  fi
+  for other_root in "${BASE_DIR}"/internal/*/ca/root.pem; do
+    other_peer="$(basename "$(dirname "$(dirname "${other_root}")")")"
+    [ "${other_peer}" = "${peer}" ] && continue
+    if openssl verify -CAfile "${other_root}" "${cert}" >/dev/null 2>&1; then
+      echo "FAIL isolatie: ${peer}-leaf accepteert ${other_peer}-internal-root: ${rel}"; fail=1
+    fi
+  done
+done
+[ "${fail}" -eq 0 ] && echo "OK  isolatie group<->internal + cross-peer"
+
+# 3c. PARITEIT: elk group-endpoint heeft een internal-tegenhanger (en omgekeerd)
+for g in "${BASE_DIR}"/out/*/*/cert.pem; do
+  [ -e "${g}" ] || break
+  rel="${g#"${BASE_DIR}/out/"}"
+  [ -f "${BASE_DIR}/internal/${rel}" ] || { echo "FAIL pariteit: geen internal-cert voor ${rel%/cert.pem}"; fail=1; }
+done
+
+# 4. CRL parseert
+if openssl crl -in "${BASE_DIR}/ca/intermediate.crl" -noout -text >/dev/null 2>&1; then
+  echo "OK  crl"
+else
+  echo "FAIL crl"; fail=1
+fi
+
+# 5. Geen secrets gestaged/untracked-toevoegbaar
+if git -C "${BASE_DIR}/.." status --porcelain pki | grep -E '\.(pem|key|crt|crl)$'; then
+  echo "FAIL: PKI-secrets zichtbaar voor git"; fail=1
+else
+  echo "OK  geen secrets voor git"
+fi
+
+[ "${fail}" -eq 0 ] && echo "== ALLE ASSERTS GROEN ==" || echo "== FAILURES =="
+exit "${fail}"

--- a/fsc/pki/zad-bundle.sh
+++ b/fsc/pki/zad-bundle.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Copyright © MOZa FSC Testnet — Licensed under the EUPL
+# Verzamelt de upload-klare cert-set van één peer in pki/zad-upload/<peer>/ met een MANIFEST:
+# per bestand het beoogde pod-pad (/etc/fsc/...) + de TLS_*-env-var(s). Voor het uploaden naar
+# ZAD: de losse certs als attachments. "Publicatie op het web" modus 2 (passthrough) heeft GEEN
+# combined.pem nodig — de pod serveert de losse TLS_GROUP_CERT/KEY (zie docs/spikes/zad-attachments.md,
+# vraag 5). combine-pem.sh blijft een losse optie. Output is gitignored (bevat privésleutels).
+# Draai eerst pki/issue.sh.
+set -euo pipefail
+
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+PEER="${1:?usage: zad-bundle.sh <peer> (bv. directory)}"
+OUT="${BASE_DIR}/zad-upload/${PEER}"
+MANIFEST="${OUT}/MANIFEST.md"
+
+[ -d "${BASE_DIR}/out/${PEER}" ] || { echo "Geen group-certs voor '${PEER}' (pki/issue.sh gedraaid?)" >&2; exit 1; }
+
+# TLS_*-env-var(s) per relatief pad-patroon (spiegelt peers/directory/manager.env.example).
+env_for() {
+  case "$1" in
+    ca/root.pem)            echo "TLS_GROUP_ROOT_CERT" ;;
+    ca/intermediate.crl)    echo "group-config crl: (revocatielijst)" ;;
+    out/*/cert.pem)         echo "TLS_GROUP_CERT (+ TLS_GROUP_TOKEN_CERT, TLS_GROUP_CONTRACT_CERT)" ;;
+    out/*/key.pem)          echo "TLS_GROUP_KEY (+ TLS_GROUP_TOKEN_KEY, TLS_GROUP_CONTRACT_KEY)" ;;
+    internal/*/ca/root.pem) echo "TLS_ROOT_CERT (+ TLS_INTERNAL_UNAUTHENTICATED_ROOT_CERT)" ;;
+    internal/*/cert.pem)    echo "TLS_CERT (+ TLS_INTERNAL_UNAUTHENTICATED_CERT)" ;;
+    internal/*/key.pem)     echo "TLS_KEY (+ TLS_INTERNAL_UNAUTHENTICATED_KEY)" ;;
+    *)                      echo "?" ;;
+  esac
+}
+
+umask 077                                  # 0600: bevat privésleutels
+rm -rf "${OUT}"; mkdir -p "${OUT}"
+
+{
+  echo "# ZAD-upload-set voor peer \`${PEER}\`"
+  echo
+  echo "Gegenereerd door \`pki/zad-bundle.sh\`. **Bevat privésleutels — niet committen, niet delen.**"
+  echo "Hostnames zijn nog placeholder (\`*.fsc-test.local\`). De mesh valideert op OIN; \`directory-ui\`"
+  echo "doet wél hostnaam-verificatie, dus de group-cert heeft de ZAD-hostnaam in de SAN (wildcard)."
+  echo
+  echo "**Attachments** (losse files, elk op hun pod-pad). Modus 2 (passthrough) serveert deze los —"
+  echo "geen \`combined.pem\` nodig (zie \`docs/spikes/zad-attachments.md\`, vraag 5):"
+  echo
+  echo "| Bestand | Beoogd pod-pad / gebruik | TLS_*-env-var(s) |"
+  echo "|---------|---------------------------|-------------------|"
+} > "${MANIFEST}"
+
+copy_one() {                               # $1 = relatief pad onder pki/  [$2=required -> warn als leeg/weg]
+  local rel="$1" src="${BASE_DIR}/$1" dst="${OUT}/$1"
+  if [ ! -s "${src}" ]; then
+    [ "${2:-}" = required ] && \
+      echo "WAARSCHUWING: verplichte cert ontbreekt of is leeg: pki/${rel} — niet in de bundle (draai pki/issue.sh?)." >&2
+    return 0
+  fi
+  mkdir -p "$(dirname "${dst}")"
+  cp "${src}" "${dst}"
+  printf '| `%s` | `/etc/fsc/%s` | %s |\n' "${rel}" "${rel}" "$(env_for "${rel}")" >> "${MANIFEST}"
+}
+
+# 1. group-trust-anchor (gedeeld door alle peers) — verplicht
+copy_one "ca/root.pem" required
+# CRL (gen-crl.sh) hoort bij het trust-anchor: mount 'm zodat CRL-checks aangezet kunnen worden.
+copy_one "ca/intermediate.crl" required
+
+# 2. group-endpoints: losse cert + key (modus 2 serveert deze los; geen combined.pem)
+for d in "${BASE_DIR}/out/${PEER}"/*/; do
+  [ -d "${d}" ] || continue
+  e="$(basename "${d}")"
+  copy_one "out/${PEER}/${e}/cert.pem"
+  copy_one "out/${PEER}/${e}/key.pem"
+done
+
+# 3. internal-CA root + internal-endpoints (inter-component mTLS)
+copy_one "internal/${PEER}/ca/root.pem" required
+for d in "${BASE_DIR}/internal/${PEER}"/*/; do
+  [ -d "${d}" ] || continue
+  e="$(basename "${d}")"
+  [ "${e}" = "ca" ] && continue
+  copy_one "internal/${PEER}/${e}/cert.pem"
+  copy_one "internal/${PEER}/${e}/key.pem"
+done
+
+echo "OK: upload-set in ${OUT} (zie MANIFEST.md)."


### PR DESCRIPTION
## Wat & waarom

Sluit de **magazijn-kant** als aanbiedende organisatie aan op de FSC-federatie (repo A =
`moza-fsc-testnet`): een provider-peer voor **magazijn-a** (echte OIN `00000001003214345000`,
manager + inway + controller + DB) die `berichtenmagazijn` als vindbare dienst in de directory
publiceert. Alleen de provider-peer — consumer/outway (#725/#726) en magazijn-b vallen buiten
deze PR.

Werkt aan #780 (onder epic #737). Bewust zónder GitHub-sluitwoord bij het issuenummer, zodat #780 open blijft wanneer deze PR gemerged of gesloten wordt. Design + plan: `docs/plans/2026-07-08-magazijn-provider-peer-fsc-{design,plan}.md`.

## Verificatiestatus

**Lokaal end-to-end BEWEZEN (groen):**
- **PKI** — `fsc/pki/verify.sh` → `== ALLE ASSERTS GROEN ==`: group- + internal-keten, OIN-in-subject,
  group↔internal + cross-peer isolatie, en de CRL (`OK crl`).
- **Onboarding via de lokale compose-harness** (`fsc/deploy/local/run-smokes.sh`):
  **announce** (magazijn-a in `peers.peers` op `:443`) → **publish** (`berichtenmagazijn` aangemaakt
  + servicePublicationGrant, directory auto-signt) → **discover** (`berichtenmagazijn` vindbaar via
  de manager mesh-API `GET /v1/peers/{dir}/services`).

**Ook statisch geverifieerd:** `bash -n` op alle scripts; YAML-parse op de compose + workflow;
`upsert-peer.sh plan` → geldige JSON component-bodies (jq); SHA-pin-check op de workflow; cross-file
seam-consistentie (OIN's, hostnames ↔ cert-SANs, cert-paden, DB-namen, image-pins) via whole-branch review.

**Nog UITGESTELD (vereist ZAD-credentials/cluster):** `upsert-peer.sh validate/apply` naar ZAD,
cert-attachments mounten (UI), en `verify-zad.md`. Als **UITGESTELD** gemarkeerd in de runbooks;
niets beweert dat de peer op ZAD draait. Zie ook het "Open punten"-blok in het design (interne-mTLS
SAN/poort-seam) — vóór de echte apply op te lossen.

## Inhoud

| Pad | Wat |
|-----|-----|
| `fsc/pki/` | cfssl-scaffolding + `csr.json` per endpoint (OIN 1:1 in `serialnumber`) + cert-portal-proof-doc |
| `fsc/deploy/local/` | docker-compose-harness (directory + magazijn-a-peer) + `smoke-announce`/`publish-service`/`smoke-discover`/`run-smokes` |
| `fsc/deploy/zad/` | `upsert-peer.sh` (ZAD v2-API) + cert-manifest/verify-runbooks |
| `.github/workflows/zad-deploy-peer.yml` | SHA-pinned deploy-workflow (project `mpfm-w3h`) |
| `docs/plans/…` | design + implementatieplan |

De harness spiegelt repo A's `example-provider`-template, met de echte OIN + `berichtenmagazijn`
als dienst en de consumer-peer weggelaten.

## Openstaande punten (vóór de echte ZAD-apply)

Genoteerd in het design onder "Open punten" — met name:
- **Interne-mTLS-adressen op ZAD (SAN + poort):** de registratiecalls wijzen naar ingress-
  hostnamen op `:443` die niet in de magazijn-a internal-cert-SANs zitten, terwijl de interne
  API's op `:9443`/`:9444` luisteren. Oplossen vóór boot (anders crash-loop).
- Intra-project-DNS-vorm van de `magazijna`-upstream in mpfm-w3h.
- `berichtenmagazijn` OIN in een publiek repo (stond al in `application.properties`).

## Reviewproces

Ontwikkeld met subagent-driven development: implementer + review-gate per bundel, plus een
whole-branch review. Gevonden en gefixt: manager-cert tweede SAN (mesh-SNI), en ZAD-substitutie-
vars die naar het `aliases`-blok moesten (env_vars expandeert `$DEPLOYMENT_NAME` niet).


🤖 Generated with [Claude Code](https://claude.com/claude-code)

