### PR TITLE
FSC-outway grant-hash: magazijnen + Profiel-service

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,10 +241,11 @@ géén uitgeschakeld component**).
 
 ## Omgevingsvariabelen
 
-| Variabele              | Default | Beschrijving                                        |
-|------------------------|---------|-----------------------------------------------------|
-| `CLICKHOUSE_USERNAME`  | `ldv`   | ClickHouse gebruikersnaam (Logboek Dataverwerkingen) |
-| `CLICKHOUSE_PASSWORD`  | `ldv`   | ClickHouse wachtwoord                                |
+| Variabele               | Default | Beschrijving                                                                                                     |
+|-------------------------|---------|--------------------------------------------------------------------------------------------------------------------|
+| `CLICKHOUSE_USERNAME`   | `ldv`   | ClickHouse gebruikersnaam (Logboek Dataverwerkingen)                                                              |
+| `CLICKHOUSE_PASSWORD`   | `ldv`   | ClickHouse wachtwoord                                                                                             |
+| `MAGAZIJN_A_GRANT_HASH` | leeg    | Grant-hash van het valide FSC-contract voor magazijn-a; leeg = geen `Fsc-Grant-Hash`-header, magazijn wordt dan direct/zonder outway aangeroepen |
 
 ## Plannen
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,6 +246,7 @@ géén uitgeschakeld component**).
 | `CLICKHOUSE_USERNAME`   | `ldv`   | ClickHouse gebruikersnaam (Logboek Dataverwerkingen)                                                              |
 | `CLICKHOUSE_PASSWORD`   | `ldv`   | ClickHouse wachtwoord                                                                                             |
 | `MAGAZIJN_A_GRANT_HASH` | leeg    | Grant-hash van het valide FSC-contract voor magazijn-a; leeg = geen `Fsc-Grant-Hash`-header, magazijn wordt dan direct/zonder outway aangeroepen |
+| `PROFIEL_SERVICE_GRANT_HASH` | leeg    | Grant-hash van het valide FSC-contract voor de Profiel-service; leeg = geen `Fsc-Grant-Hash`-header, de Profiel-service wordt dan direct/zonder outway aangeroepen |
 
 ## Plannen
 

--- a/docs/plans/2026-07-17-fsc-outway-grant-hash-header.md
+++ b/docs/plans/2026-07-17-fsc-outway-grant-hash-header.md
@@ -1,0 +1,169 @@
+**Status:** Concept
+
+# berichtenuitvraag naar magazijn via de FSC-outway — `Fsc-Grant-Hash`-header (#552)
+
+## Context / aanleiding
+
+De FSC-consumer-peer `uitvraag-org` draait (outway `uvrout` + manager/controller/txlog op ZAD,
+project `mpfuc-84g`). De datatunnel is bewezen: `curl → outway → inway magazijn-a → berichtenmagazijn`
+geeft een 200. Om berichtenuitvraag magazijn-a via die outway te laten lopen is de magazijn-URL al
+config-only om te zetten (`MAGAZIJN_A_URL` → de outway-ingress). Wat nog ontbreekt is de
+**routering**: de OpenFSC-outway kiest de doeldienst/inway op de **`Fsc-Grant-Hash`-header**, niet op
+het pad, en `fsc-outway serve` (v1.43.7) eist bovendien een **`Fsc-Transaction-Id` in UUID-v7-vorm**.
+Zonder die headers antwoordt de outway met "service not found" resp. "invalid uuid version, must be v7".
+
+`MagazijnClient` markeert dit al: `TODO(#552): vervangen door FSC outway zodra de federatieve
+connectiviteit op MOZ-niveau is vastgesteld`.
+
+### Twee client-bouwplekken (beide raken magazijnen)
+
+Beide bouwen een REST-client met `Magazijninschrijving.url` als base-URI en kunnen een JAX-RS
+`ClientRequestFilter` registreren:
+
+| Plek | Bestand | Rol |
+|------|---------|-----|
+| sessiecache-aggregatie (`_ophalen`/SSE) | `libraries/fbs-berichtensessiecache/.../magazijn/MagazijnClientFactory.kt` (`createClient`) | bulk-lijst per magazijn |
+| losse bericht-operaties | `services/berichtenuitvraag/.../uitvraag/MagazijnRouter.kt` (`forMagazijn`) | get-by-id / patch / delete / bijlage |
+
+Beide moeten de FSC-headers meesturen voor een magazijn dat achter een outway zit.
+
+## Ontwerpkeuzes (afgestemd)
+
+1. **Grant-hash uit statische config.** Nieuw, **optioneel** veld `magazijnen."<OIN>".grantHash`
+   (env-var, net als `url`). Aanwezig = "dit magazijn is via een outway; stuur FSC-headers".
+   Afwezig = ongewijzigd gedrag (bv. magazijn-b, nog direct). Dynamisch ophalen = vervolg.
+2. **`Fsc-Transaction-Id` zelf genereren als UUID v7** en meesturen (voor LDV-correlatie
+   outway↔inway↔app-log). De JDK kent geen v7 → een kleine generator in `fbs-common`.
+3. **Headers alléén als `grantHash` gezet is.** De filter wordt per client geregistreerd mét de
+   grant-hash; magazijnen zonder grant-hash krijgen geen filter en blijven byte-identiek.
+4. **Gedeelde plaatsing.** De `grantHash` hoort bij het register-domein (`Magazijninschrijving`);
+   de header-filter + v7-generator zijn client-infrastructuur en horen in `fbs-common` (waar beide
+   consumers al van afhangen). Zo is er één filter-implementatie voor beide bouwplekken.
+
+### Buiten scope (vervolg)
+- Dynamische grant-hash-discovery (`Fsc-Grant-Hash: discover` / manager-API).
+- De gegenereerde `Fsc-Transaction-Id` óók als veld in de LDV-audittrail (ClickHouse) opnemen —
+  nu loggen we 'm alleen bij de uitgaande call, zodat hij via logs correleerbaar is. Volledige
+  LDV-veldkoppeling is een aparte wijziging (raakt `LogboekContext`/de LDV-schema's).
+- magazijn-b via een eigen outway (heeft eigen peer/contract nodig).
+
+## Structuur (bestanden)
+
+- Wijzig: `libraries/fbs-magazijnregister/.../MagazijnregisterConfig.kt` — `grantHash()` op `Inschrijving`.
+- Wijzig: `libraries/fbs-magazijnregister/.../Magazijnregister.kt` — `grantHash` op `Magazijninschrijving`.
+- Wijzig: `libraries/fbs-magazijnregister/.../ConfigMagazijnregister.kt` — `grantHash` doorgeven + valideren.
+- Maak: `libraries/fbs-common/.../fsc/UuidV7.kt` — UUID-v7-generator.
+- Maak: `libraries/fbs-common/.../fsc/FscOutwayHeadersFilter.kt` — `ClientRequestFilter` die
+  `Fsc-Grant-Hash` + `Fsc-Transaction-Id` zet.
+- Wijzig: `libraries/fbs-berichtensessiecache/.../magazijn/MagazijnClientFactory.kt` — filter registreren als `grantHash != null`.
+- Wijzig: `services/berichtenuitvraag/.../uitvraag/MagazijnRouter.kt` — filter registreren als `grantHash != null`.
+- Wijzig: `services/berichtenuitvraag/src/main/resources/application.properties` — `magazijnen."<OIN>".grantHash=${MAGAZIJN_A_GRANT_HASH:}`.
+- Tests bij elke module (zie stappen).
+
+## Stappen
+
+> TDD per module. **Altijd `clean` vóór `test`.** Commit per afgeronde stap.
+
+### Stap 1 — `grantHash` in de magazijnregister-library
+
+**Test eerst** (`libraries/fbs-magazijnregister/src/test/...`):
+- `MagazijnregisterConfigTest` (of het bestaande config/register-testbestand): een config met
+  `magazijnen."<OIN>".grantHash=abc123` levert een `Magazijninschrijving.grantHash == "abc123"`;
+  zónder de key levert `grantHash == null`. Dek de cardinaliteiten: 0 magazijnen (bestaande
+  boot-faalcheck), 1 mét grantHash, meerdere waarvan één mét en één zónder.
+- Grens: een lege/whitespace-`grantHash` moet fail-fast bij boot (net als een lege URL), met een
+  duidelijke `magazijnen."<OIN>".grantHash`-melding.
+
+**Implementatie:**
+- `MagazijnregisterConfig.Inschrijving`: `fun grantHash(): Optional<String>`.
+- `Magazijninschrijving`: veld `val grantHash: String?` (na `naam`); in `init` een
+  `require(grantHash == null || grantHash.isNotBlank()) { ... }`.
+- `ConfigMagazijnregister.init`: `grantHash = entry.grantHash().map { it.trim() }.orElse(null)`
+  doorgeven; bij blank → `IllegalStateException` met de configkey (spiegelt de URL-validatie).
+
+**Verificatie:** `./mvnw clean test -pl libraries/fbs-magazijnregister -am` groen; JaCoCo ≥ 90%.
+Commit: `feat(magazijnregister): optionele grantHash per magazijn (#552)`.
+
+### Stap 2 — v7-generator + header-filter in `fbs-common`
+
+**Test eerst** (`libraries/fbs-common/src/test/...`):
+- `UuidV7Test`: `UuidV7.generate()` levert een `UUID` met **version == 7** en **variant == 2**
+  (RFC 4122); twee opeenvolgende waarden zijn verschillend en, gegeven een oplopende klok,
+  lexicografisch niet-dalend (tijd-geordend). Test met een injecteerbare `Clock`/`epochMilli`-
+  parameter zodat het timestamp-deel deterministisch is.
+- `FscOutwayHeadersFilterTest`: een `ClientRequestContext`-mock/-fake; na `filter(ctx)` bevat
+  `ctx.headers` een `Fsc-Grant-Hash` == de meegegeven hash én een `Fsc-Transaction-Id` die als
+  UUID v7 parseert (version 7). Twee invocaties → twee verschillende transaction-ids.
+
+**Implementatie:**
+- `UuidV7`: object met `fun generate(epochMilli: Long = System.currentTimeMillis(), rnd: java.util.Random = java.security.SecureRandom()): UUID`.
+  48-bit ms-timestamp in de hoge bits, `version = 7` (nibble op bit 12–15 van time_hi), `variant = 0b10`,
+  rest random. Één plek, goed getest.
+- `FscOutwayHeadersFilter(private val grantHash: String) : jakarta.ws.rs.client.ClientRequestFilter`
+  met `@Provider` NIET nodig (handmatig geregistreerd). In `filter(ctx)`:
+  `ctx.headers.putSingle("Fsc-Grant-Hash", grantHash)` en
+  `ctx.headers.putSingle("Fsc-Transaction-Id", UuidV7.generate().toString())`. Log op `debug` de
+  transaction-id + magazijn zodat de call correleerbaar is met de outway/inway-logs.
+
+**Verificatie:** `./mvnw clean test -pl libraries/fbs-common -am` groen; JaCoCo ≥ 90%; detekt schoon.
+Commit: `feat(common): UuidV7 + FscOutwayHeadersFilter (Fsc-Grant-Hash/-Transaction-Id) (#552)`.
+
+### Stap 3 — filter registreren in de sessiecache-factory
+
+**Test eerst** (`libraries/fbs-berichtensessiecache/src/test/...`):
+- Omdat `createClient` `protected open` is en de echte builder buiten `@QuarkusTest` faalt: dek de
+  **registratie-beslissing** apart. Refactor de filter-keuze naar een testbare helper (bv.
+  `fscFilterVoor(inschrijving): FscOutwayHeadersFilter?` → non-null als `grantHash != null`, anders
+  null) en test die met een inschrijving mét en zónder grantHash. Plus een `@QuarkusTest`/WireMock-
+  integratietest (zie stap 5) die bewijst dat de header daadwerkelijk op de uitgaande call staat.
+
+**Implementatie:**
+- In `createClient`: `val b = QuarkusRestClientBuilder.newBuilder().baseUri(...).connectTimeout(...).readTimeout(...)`;
+  `inschrijving.grantHash?.let { b.register(FscOutwayHeadersFilter(it)) }`; `b.build(MagazijnClient::class.java)`.
+
+**Verificatie:** `docker compose up -d`; `./mvnw clean test -pl libraries/fbs-berichtensessiecache -am`
+groen; JaCoCo ≥ 90%.
+Commit: `feat(sessiecache): FSC-outway-headers op magazijn-aggregatie-client (#552)`.
+
+### Stap 4 — filter registreren in `MagazijnRouter` + config
+
+**Test eerst** (`services/berichtenuitvraag/src/test/...`):
+- `MagazijnRouterTest`: identieke aanpak — de filter-keuze in een testbare helper, getest met/zonder
+  grantHash. `%test`-profiel-config: voeg een `grantHash` toe aan één test-magazijn en assert dat de
+  gebouwde client 'm meekrijgt (of via de integratietest van stap 5).
+
+**Implementatie:**
+- In `forMagazijn`'s `RestClientBuilder`-keten: `inschrijving.grantHash?.let { builder.register(FscOutwayHeadersFilter(it)) }`
+  vóór `.build(...)`.
+- `application.properties`: `magazijnen."00000001003214345000".grantHash=${MAGAZIJN_A_GRANT_HASH:}`
+  (lege default → header uit tenzij de env-var gezet is; magazijn-b krijgt géén grantHash). Documenteer
+  de env-var in de env-var-tabel van `CLAUDE.md`.
+
+**Verificatie:** `./mvnw clean test -pl services/berichtenuitvraag -am` groen; JaCoCo ≥ 90%.
+Commit: `feat(uitvraag): FSC-outway-headers op MagazijnRouter + grantHash-config (#552)`.
+
+### Stap 5 — integratietest: de header komt aan
+
+**Test** (WireMock-contracttest, `@QuarkusTest`, in de sessiecache- of uitvraag-laag waar WireMock al
+draait): stub het magazijn; roep de flow aan met een inschrijving die een grantHash heeft; verifieer
+via `WireMock.verify(getRequestedFor(...).withHeader("Fsc-Grant-Hash", equalTo("<hash>"))
+.withHeader("Fsc-Transaction-Id", matching("<uuid-regex>")))`. Én een negatief geval: een magazijn
+**zonder** grantHash → géén `Fsc-Grant-Hash`-header op de call.
+
+**Verificatie:** de betreffende module groen incl. de nieuwe integratietest.
+Commit: `test(fsc): integratietest FSC-outway-headers op de magazijn-call (#552)`.
+
+## Verificatie (geheel)
+
+- Per module `./mvnw clean test -pl <module> -am` groen; volledige suite `./mvnw clean verify` groen.
+- JaCoCo ≥ 90% line coverage in elke geraakte module; gegenereerde code uitgesloten.
+- `./mvnw detekt:check` schoon; geen nieuwe, onverklaarde build-/test-warnings.
+- Handmatig (ZAD, ná deploy): `MAGAZIJN_A_URL` = de outway-ingress + `MAGAZIJN_A_GRANT_HASH` = de
+  grant-hash van het valide contract; de SSE-curl
+  `GET /api/v1/berichten/_ophalen` (X-Ontvanger: BSN:999273127) geeft voor magazijn-a een geldig
+  (leeg-of-gevuld) resultaat i.p.v. een fout-event.
+
+## Git-werkwijze
+
+Feature branch `feature/fsc-outway-grant-hash`, draft-PR (CODEOWNERS bestaat), geen reviewer, geen
+auto-close-keyword (issue #552 blijft open). Plan + implementatie op dezelfde branch.

--- a/docs/plans/2026-07-21-fsc-outway-grant-hash-profielservice-implementatie.md
+++ b/docs/plans/2026-07-21-fsc-outway-grant-hash-profielservice-implementatie.md
@@ -1,4 +1,4 @@
-**Status:** Concept
+**Status:** Uitgevoerd
 
 # Profiel-service via FSC-outway — implementatieplan (#730)
 

--- a/docs/plans/2026-07-21-fsc-outway-grant-hash-profielservice-implementatie.md
+++ b/docs/plans/2026-07-21-fsc-outway-grant-hash-profielservice-implementatie.md
@@ -1,0 +1,836 @@
+**Status:** Concept
+
+# Profiel-service via FSC-outway — implementatieplan (#730)
+
+> **Voor agentic workers:** implementeer taak-voor-taak. Stappen gebruiken checkbox-syntax
+> (`- [ ]`) voor voortgang. Ontwerp en rationale staan in
+> `docs/plans/2026-07-21-fsc-outway-grant-hash-profielservice.md` — lees die eerst; dit document
+> bevat de concrete code.
+
+**Doel:** de Profiel-service optioneel via de FSC-outway benaderen, door naast de URL ook een
+grant-hash configureerbaar te maken — per service, met leeg = ongewijzigd gedrag.
+
+**Architectuur:** `ProfielServiceClient` is een declaratieve `@RegisterRestClient`-interface, dus er
+is geen builder om een filter op te registreren zoals bij de magazijn-clients. In plaats daarvan
+krijgt de interface een `@RegisterProvider` met een filter die zijn grant-hash zelf uit config
+leest en niets doet als die ontbreekt. De header-set-logica wordt gedeeld met de bestaande
+magazijn-filter, zodat het FSC-header-contract op één plek staat.
+
+**Tech stack:** Kotlin/JVM 21, Quarkus 3.x, MicroProfile REST Client + Fault Tolerance,
+JUnit 5 + MockK + WireMock, detekt, JaCoCo.
+
+## Globale randvoorwaarden
+
+Gelden impliciet voor élke taak hieronder.
+
+- **Altijd `clean` vóór `test`** — een achtergebleven `target/` van een andere branch-state geeft
+  misleidende fouten.
+- Draaien tests via `mcp__maven-host`? Zet `TESTCONTAINERS_RYUK_DISABLED=true` (bind-mount-issue).
+- Commentaar legt het **waarom** vast, niet het wat. Geen review-labels, geen verwijzingen naar
+  CLAUDE.md, geen "PoC"/"voorlopig".
+- Kotlin-stijl: lege regel vóór én ná multi-line blokken en zelfstandige control-statements.
+- Domeinbegrippen Nederlands (`zet`, `grantHash`), technische idiomen Engels (`filter`, `provider`).
+- detekt-gate is `maxIssues: 0` zonder baseline — élke bevinding faalt de build.
+- JaCoCo ≥ 90% line coverage per geraakte module.
+- Commits: `<type>(<scope>): <omschrijving> (#730)`. Commit per afgeronde taak.
+
+## Bestandsoverzicht
+
+| Bestand | Verantwoordelijkheid |
+|---------|----------------------|
+| `libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeaders.kt` | **Nieuw.** Enige plek die het FSC-header-contract kent (headernamen + v7-transaction-id). |
+| `.../fsc/FscOutwayHeadersFilter.kt` | **Wijzig.** Wordt dunne wrapper; publiek gedrag ongewijzigd. |
+| `.../fsc/ProfielFscOutwayHeadersFilter.kt` | **Nieuw.** Config-lezende filter voor de Profiel-client. |
+| `.../profiel/ProfielServiceClient.kt` | **Wijzig.** `@RegisterProvider` erbij. |
+| `services/*/src/main/resources/application.properties` | **Wijzig.** `profiel-service.grant-hash`. |
+| `CLAUDE.md` | **Wijzig.** Env-var-tabel. |
+
+---
+
+## Taak 1: header-logica extraheren naar `FscOutwayHeaders`
+
+Pure extractie. De bestaande `FscOutwayHeadersFilterTest` moet **ongewijzigd** groen blijven — dat
+is de regressie-check.
+
+**Bestanden:**
+- Maak: `libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeaders.kt`
+- Wijzig: `libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeadersFilter.kt`
+- Test: `libraries/fbs-common/src/test/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeadersTest.kt`
+
+**Interfaces:**
+- Produceert: `FscOutwayHeaders.zet(requestContext: ClientRequestContext, grantHash: String)`,
+  `FscOutwayHeaders.GRANT_HASH_HEADER = "Fsc-Grant-Hash"`,
+  `FscOutwayHeaders.TRANSACTION_ID_HEADER = "Fsc-Transaction-Id"`. Taak 2 gebruikt alle drie.
+
+- [ ] **Stap 1.1: schrijf de falende test**
+
+Maak `libraries/fbs-common/src/test/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeadersTest.kt`:
+
+```kotlin
+package nl.rijksoverheid.moz.fbs.common.fsc
+
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.ws.rs.client.ClientRequestContext
+import jakarta.ws.rs.core.MultivaluedHashMap
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+import java.net.URI
+import java.util.UUID
+
+class FscOutwayHeadersTest {
+
+    private fun zetHeaders(grantHash: String): MultivaluedHashMap<String, Any> {
+        val ctx = mockk<ClientRequestContext>()
+        val headers = MultivaluedHashMap<String, Any>()
+        every { ctx.headers } returns headers
+        every { ctx.uri } returns URI.create("https://outway.voorbeeld.test/api/profielservice/v1/BSN/999993653")
+
+        FscOutwayHeaders.zet(ctx, grantHash)
+
+        return headers
+    }
+
+    @Test
+    fun `zet de grant-hash ongewijzigd op de Fsc-Grant-Hash-header`() {
+        val headers = zetHeaders("abc123")
+
+        assertEquals(listOf("abc123"), headers[FscOutwayHeaders.GRANT_HASH_HEADER])
+    }
+
+    @Test
+    fun `zet een Fsc-Transaction-Id die als UUID v7 parseert`() {
+        val headers = zetHeaders("abc123")
+
+        val uuid = UUID.fromString(headers.getFirst(FscOutwayHeaders.TRANSACTION_ID_HEADER) as String)
+
+        assertEquals(7, uuid.version())
+        assertEquals(2, uuid.variant())
+    }
+
+    @Test
+    fun `twee invocaties leveren twee verschillende transaction-ids`() {
+        val eerste = zetHeaders("abc123")
+        val tweede = zetHeaders("abc123")
+
+        assertNotEquals(
+            eerste.getFirst(FscOutwayHeaders.TRANSACTION_ID_HEADER),
+            tweede.getFirst(FscOutwayHeaders.TRANSACTION_ID_HEADER),
+        )
+    }
+}
+```
+
+- [ ] **Stap 1.2: draai de test en bevestig dat hij faalt**
+
+```bash
+./mvnw clean test -pl libraries/fbs-common -am -Dtest=FscOutwayHeadersTest
+```
+
+Verwacht: compilatiefout — `Unresolved reference: FscOutwayHeaders`.
+
+- [ ] **Stap 1.3: maak de helper**
+
+Maak `libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeaders.kt`:
+
+```kotlin
+package nl.rijksoverheid.moz.fbs.common.fsc
+
+import jakarta.ws.rs.client.ClientRequestContext
+import org.jboss.logging.Logger
+
+/**
+ * Het FSC-outway-headercontract op één plek. De OpenFSC-outway kiest de doel-inway op
+ * `Fsc-Grant-Hash` (niet op het pad) en `fsc-outway serve` eist een `Fsc-Transaction-Id` in
+ * UUID-v7-vorm; zonder deze headers antwoordt de outway met "service not found" resp.
+ * "invalid uuid version, must be v7".
+ *
+ * Meerdere clients sturen deze headers (magazijn-calls per inschrijving, de Profiel-call),
+ * elk met een eigen manier om aan hun grant-hash te komen. Die herkomst verschilt; het
+ * contract niet — daarom staat het hier en niet in de afzonderlijke filters.
+ */
+object FscOutwayHeaders {
+
+    const val GRANT_HASH_HEADER = "Fsc-Grant-Hash"
+    const val TRANSACTION_ID_HEADER = "Fsc-Transaction-Id"
+
+    private val log = Logger.getLogger(FscOutwayHeaders::class.java)
+
+    fun zet(requestContext: ClientRequestContext, grantHash: String) {
+        val transactionId = UuidV7.generate()
+
+        requestContext.headers.putSingle(GRANT_HASH_HEADER, grantHash)
+        requestContext.headers.putSingle(TRANSACTION_ID_HEADER, transactionId.toString())
+
+        // Zonder deze transaction-id in de app-log is een call niet terug te vinden in de
+        // outway-/inway-logs, die 'm ongewijzigd doorgeven.
+        log.debugf(
+            "FSC-outway-call naar %s: Fsc-Transaction-Id=%s",
+            requestContext.uri,
+            transactionId,
+        )
+    }
+}
+```
+
+- [ ] **Stap 1.4: maak `FscOutwayHeadersFilter` een wrapper**
+
+Vervang de volledige inhoud van
+`libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeadersFilter.kt`:
+
+```kotlin
+package nl.rijksoverheid.moz.fbs.common.fsc
+
+import jakarta.ws.rs.client.ClientRequestContext
+import jakarta.ws.rs.client.ClientRequestFilter
+
+/**
+ * Zet de FSC-outway-routeringsheaders op een uitgaande magazijn-call.
+ *
+ * Bewust géén `@Provider`: de grant-hash is per magazijn verschillend, dus wordt de filter
+ * per client handmatig geregistreerd in plaats van als globale JAX-RS-provider. De
+ * Profiel-client heeft één vaste grant-hash en gebruikt daarom
+ * [ProfielFscOutwayHeadersFilter].
+ */
+class FscOutwayHeadersFilter(private val grantHash: String) : ClientRequestFilter {
+
+    override fun filter(requestContext: ClientRequestContext) {
+        FscOutwayHeaders.zet(requestContext, grantHash)
+    }
+}
+```
+
+- [ ] **Stap 1.5: draai beide tests**
+
+```bash
+./mvnw clean test -pl libraries/fbs-common -am -Dtest='FscOutwayHeaders*Test'
+```
+
+Verwacht: PASS — zowel `FscOutwayHeadersTest` (nieuw) als `FscOutwayHeadersFilterTest`
+(ongewijzigd, bewijst dat de extractie gedragsneutraal is).
+
+- [ ] **Stap 1.6: volledige module + detekt**
+
+```bash
+./mvnw clean verify -pl libraries/fbs-common -am
+./mvnw detekt:check -pl libraries/fbs-common
+```
+
+Verwacht: BUILD SUCCESS, JaCoCo-check haalt 90%, detekt 0 bevindingen.
+
+- [ ] **Stap 1.7: commit**
+
+```bash
+git add libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeaders.kt \
+        libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeadersFilter.kt \
+        libraries/fbs-common/src/test/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeadersTest.kt
+git commit -m "refactor(common): FSC-header-logica naar gedeelde FscOutwayHeaders (#730)"
+```
+
+---
+
+## Taak 2: `ProfielFscOutwayHeadersFilter`
+
+**Bestanden:**
+- Maak: `libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/ProfielFscOutwayHeadersFilter.kt`
+- Test: `libraries/fbs-common/src/test/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/ProfielFscOutwayHeadersFilterTest.kt`
+
+**Interfaces:**
+- Consumeert: `FscOutwayHeaders.zet(...)` uit taak 1.
+- Produceert: `class ProfielFscOutwayHeadersFilter()` (publieke no-arg constructor — de
+  rest-client-runtime instantieert 'm) en `ProfielFscOutwayHeadersFilter.CONFIG_KEY =
+  "profiel-service.grant-hash"`. Taak 3 gebruikt beide.
+
+- [ ] **Stap 2.1: schrijf de falende test**
+
+Maak `libraries/fbs-common/src/test/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/ProfielFscOutwayHeadersFilterTest.kt`:
+
+```kotlin
+package nl.rijksoverheid.moz.fbs.common.fsc
+
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.ws.rs.client.ClientRequestContext
+import jakarta.ws.rs.core.MultivaluedHashMap
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.NullSource
+import org.junit.jupiter.params.provider.ValueSource
+import java.net.URI
+import java.util.UUID
+
+class ProfielFscOutwayHeadersFilterTest {
+
+    private fun runFilter(grantHash: String?): MultivaluedHashMap<String, Any> {
+        val ctx = mockk<ClientRequestContext>()
+        val headers = MultivaluedHashMap<String, Any>()
+        every { ctx.headers } returns headers
+        every { ctx.uri } returns URI.create("https://outway.voorbeeld.test/api/profielservice/v1/BSN/999993653")
+
+        ProfielFscOutwayHeadersFilter { grantHash }.filter(ctx)
+
+        return headers
+    }
+
+    /**
+     * De drie vormen waarin "niet geconfigureerd" binnenkomt: de key ontbreekt (null), of
+     * `${PROFIEL_SERVICE_GRANT_HASH:}` expandeert naar leeg/whitespace. Alle drie moeten de
+     * call byte-identiek laten aan de situatie vóór deze feature — een half gezette header
+     * zou de outway een onbruikbare route geven.
+     */
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = ["", "   ", "\t"])
+    fun `zonder bruikbare grant-hash worden geen FSC-headers gezet`(grantHash: String?) {
+        val headers = runFilter(grantHash)
+
+        assertFalse(headers.containsKey(FscOutwayHeaders.GRANT_HASH_HEADER))
+        assertFalse(headers.containsKey(FscOutwayHeaders.TRANSACTION_ID_HEADER))
+    }
+
+    @Test
+    fun `met grant-hash worden beide FSC-headers gezet`() {
+        val headers = runFilter("profiel-hash-1")
+
+        assertEquals(listOf("profiel-hash-1"), headers[FscOutwayHeaders.GRANT_HASH_HEADER])
+
+        val uuid = UUID.fromString(headers.getFirst(FscOutwayHeaders.TRANSACTION_ID_HEADER) as String)
+
+        assertEquals(7, uuid.version())
+        assertEquals(2, uuid.variant())
+    }
+
+    @Test
+    fun `omringende spaties in de config-waarde worden getrimd`() {
+        val headers = runFilter("  profiel-hash-1  ")
+
+        assertEquals(listOf("profiel-hash-1"), headers[FscOutwayHeaders.GRANT_HASH_HEADER])
+    }
+
+    @Test
+    fun `twee calls op dezelfde filter leveren verschillende transaction-ids`() {
+        val filter = ProfielFscOutwayHeadersFilter { "profiel-hash-1" }
+
+        val eerste = MultivaluedHashMap<String, Any>()
+        val tweede = MultivaluedHashMap<String, Any>()
+
+        listOf(eerste, tweede).forEach { headers ->
+            val ctx = mockk<ClientRequestContext>()
+            every { ctx.headers } returns headers
+            every { ctx.uri } returns URI.create("https://outway.voorbeeld.test/api/profielservice/v1/BSN/999993653")
+            filter.filter(ctx)
+        }
+
+        assertNotEquals(
+            eerste.getFirst(FscOutwayHeaders.TRANSACTION_ID_HEADER),
+            tweede.getFirst(FscOutwayHeaders.TRANSACTION_ID_HEADER),
+        )
+    }
+
+    @Test
+    fun `de config-key blijft de gepubliceerde sleutel`() {
+        // Pin de sleutel: application.properties van beide services hangt eraan, en een
+        // hernoeming zou de filter stil uitschakelen in plaats van te falen.
+        assertEquals("profiel-service.grant-hash", ProfielFscOutwayHeadersFilter.CONFIG_KEY)
+    }
+}
+```
+
+- [ ] **Stap 2.2: draai de test en bevestig dat hij faalt**
+
+```bash
+./mvnw clean test -pl libraries/fbs-common -am -Dtest=ProfielFscOutwayHeadersFilterTest
+```
+
+Verwacht: compilatiefout — `Unresolved reference: ProfielFscOutwayHeadersFilter`.
+
+- [ ] **Stap 2.3: implementeer de filter**
+
+Maak `libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/ProfielFscOutwayHeadersFilter.kt`:
+
+```kotlin
+package nl.rijksoverheid.moz.fbs.common.fsc
+
+import jakarta.ws.rs.client.ClientRequestContext
+import jakarta.ws.rs.client.ClientRequestFilter
+import org.eclipse.microprofile.config.ConfigProvider
+
+/**
+ * Zet de FSC-outway-headers op de Profiel-service-call, mits er een grant-hash geconfigureerd
+ * is. Zonder grant-hash doet de filter niets, zodat een deployment dat nog direct met de
+ * Profiel-service praat ongewijzigd blijft.
+ *
+ * De grant-hash komt uit config in plaats van uit een constructor-argument (zoals bij
+ * [FscOutwayHeadersFilter], waar elke magazijn-inschrijving een eigen hash heeft): deze filter
+ * wordt via `@RegisterProvider` door de rest-client-runtime geïnstantieerd, en die kan geen
+ * constructor-argument leveren. De no-arg constructor houdt de instantiatie daarmee
+ * onafhankelijk van CDI.
+ */
+class ProfielFscOutwayHeadersFilter internal constructor(
+    private val grantHashProvider: () -> String?,
+) : ClientRequestFilter {
+
+    constructor() : this({
+        ConfigProvider.getConfig().getOptionalValue(CONFIG_KEY, String::class.java).orElse(null)
+    })
+
+    // Eén keer lezen: config is boot-statisch, en dit zit op de hot-path van elke Profiel-call.
+    private val grantHash: String? by lazy {
+        grantHashProvider()?.trim()?.takeIf { it.isNotEmpty() }
+    }
+
+    override fun filter(requestContext: ClientRequestContext) {
+        grantHash?.let { FscOutwayHeaders.zet(requestContext, it) }
+    }
+
+    companion object {
+        /**
+         * Eigen prefix, niet onder `quarkus.rest-client.profiel-service.*`: dat is
+         * Quarkus-eigen namespace en een eigen sleutel daarin bijplaatsen is fragiel.
+         */
+        const val CONFIG_KEY = "profiel-service.grant-hash"
+    }
+}
+```
+
+- [ ] **Stap 2.4: draai de test**
+
+```bash
+./mvnw clean test -pl libraries/fbs-common -am -Dtest=ProfielFscOutwayHeadersFilterTest
+```
+
+Verwacht: PASS, 8 invocaties — 4 uit de `@ParameterizedTest` (null, `""`, `"   "`, `"\t"`) plus
+de 4 losse `@Test`-methodes.
+
+- [ ] **Stap 2.5: volledige module + detekt**
+
+```bash
+./mvnw clean verify -pl libraries/fbs-common -am
+./mvnw detekt:check -pl libraries/fbs-common
+```
+
+Verwacht: BUILD SUCCESS, JaCoCo ≥ 90%, detekt 0 bevindingen.
+
+- [ ] **Stap 2.6: commit**
+
+```bash
+git add libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/ProfielFscOutwayHeadersFilter.kt \
+        libraries/fbs-common/src/test/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/ProfielFscOutwayHeadersFilterTest.kt
+git commit -m "feat(common): ProfielFscOutwayHeadersFilter met optionele grant-hash (#730)"
+```
+
+---
+
+## Taak 3: registratie op de client + config in beide services
+
+Na deze taak zit de filter in de chain van élke Profiel-call in beide services. De bestaande
+suites zijn de check dat de no-op écht no-op is.
+
+**Bestanden:**
+- Wijzig: `libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/profiel/ProfielServiceClient.kt`
+- Wijzig: `services/berichtenuitvraag/src/main/resources/application.properties`
+- Wijzig: `services/berichtenmagazijn/src/main/resources/application.properties`
+- Wijzig: `CLAUDE.md`
+
+**Interfaces:**
+- Consumeert: `ProfielFscOutwayHeadersFilter` + `CONFIG_KEY` uit taak 2.
+
+- [ ] **Stap 3.1: registreer de provider op de interface**
+
+In `ProfielServiceClient.kt`, voeg twee imports toe:
+
+```kotlin
+import nl.rijksoverheid.moz.fbs.common.fsc.ProfielFscOutwayHeadersFilter
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+```
+
+en zet de annotatie direct onder de bestaande `@RegisterRestClient`:
+
+```kotlin
+/**
+ * Registratie hier en niet per service via `quarkus.rest-client.profiel-service.providers`:
+ * beide consumers delen deze interface, dus één plek voorkomt dat de registratie tussen
+ * services uit elkaar loopt. De filter is een no-op zolang er geen grant-hash geconfigureerd is.
+ */
+@RegisterRestClient(configKey = "profiel-service")
+@RegisterProvider(ProfielFscOutwayHeadersFilter::class)
+interface ProfielServiceClient {
+```
+
+- [ ] **Stap 3.2: voeg de config-key toe aan berichtenuitvraag**
+
+In `services/berichtenuitvraag/src/main/resources/application.properties`, direct ná de regel
+`quarkus.rest-client.profiel-service.keep-alive-enabled=true`:
+
+```properties
+# FSC-outway-routering naar de Profiel-service. Met een grant-hash stuurt de client
+# Fsc-Grant-Hash + Fsc-Transaction-Id mee en kiest de outway daarop de doel-inway; leeg
+# betekent een directe call zonder FSC-headers. Eigen prefix (niet onder
+# quarkus.rest-client.*): die namespace is van Quarkus zelf.
+profiel-service.grant-hash=${PROFIEL_SERVICE_GRANT_HASH:}
+```
+
+- [ ] **Stap 3.3: voeg dezelfde config-key toe aan berichtenmagazijn**
+
+Zelfde blok, in `services/berichtenmagazijn/src/main/resources/application.properties`, direct ná
+`quarkus.rest-client.profiel-service.keep-alive-enabled=true`.
+
+- [ ] **Stap 3.4: documenteer de env-var**
+
+In `CLAUDE.md`, sectie "Omgevingsvariabelen", voeg een rij toe onder `MAGAZIJN_A_GRANT_HASH`:
+
+```markdown
+| `PROFIEL_SERVICE_GRANT_HASH` | leeg    | Grant-hash van het valide FSC-contract voor de Profiel-service; leeg = geen `Fsc-Grant-Hash`-header, de Profiel-service wordt dan direct/zonder outway aangeroepen |
+```
+
+- [ ] **Stap 3.5: draai beide service-suites**
+
+```bash
+docker compose up -d
+./mvnw clean test -pl services/berichtenuitvraag -am
+./mvnw clean test -pl services/berichtenmagazijn -am
+```
+
+Verwacht: BUILD SUCCESS in beide. Alle bestaande Profiel-tests draaien nu mét de filter in de
+chain en zonder grant-hash — als er iets rood wordt, is de no-op niet echt een no-op.
+
+- [ ] **Stap 3.6: commit**
+
+```bash
+git add libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/profiel/ProfielServiceClient.kt \
+        services/berichtenuitvraag/src/main/resources/application.properties \
+        services/berichtenmagazijn/src/main/resources/application.properties \
+        CLAUDE.md
+git commit -m "feat(profiel): FSC-outway-headers op de Profiel-service-client (#730)"
+```
+
+---
+
+## Taak 4: integratietests — de headers komen aan
+
+Unit-tests dekken de filter-logica; deze taak bewijst dat de headers via de échte, door CDI
+gebouwde client op de wire staan. Per service één nieuwe klasse voor het positieve geval (eigen
+`TestProfile` met grant-hash) en één extra test in een bestaande klasse voor het negatieve geval
+(die profielen draaien al zónder grant-hash).
+
+**Bestanden:**
+- Maak: `libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/ProfielFscOutwayHeadersWireMockTest.kt`
+- Wijzig: `libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/ProfielMagazijnResolverIntegrationTest.kt`
+- Maak: `services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/validatie/ProfielFscOutwayHeadersWireMockTest.kt`
+- Wijzig: `services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/validatie/ProfielServiceClientWireMockTest.kt`
+
+**Interfaces:**
+- Consumeert: de registratie uit taak 3; bestaande `WireMockProfielServiceResource` (beide
+  modules, companion `server: WireMockServer?`) en `MockProfielServiceClient`.
+
+- [ ] **Stap 4.1: positieve test in de sessiecache-module**
+
+Maak `libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/ProfielFscOutwayHeadersWireMockTest.kt`:
+
+```kotlin
+package nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.matching
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import jakarta.inject.Inject
+import nl.rijksoverheid.moz.fbs.common.profiel.ProfielServiceClient
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Bewijst dat de FSC-outway-headers op de échte, door CDI gebouwde Profiel-client staan —
+ * niet alleen dat de filter-logica klopt (dat dekt ProfielFscOutwayHeadersFilterTest).
+ * Het negatieve geval staat in ProfielMagazijnResolverIntegrationTest, dat zonder
+ * grant-hash draait.
+ */
+@QuarkusTest
+@TestProfile(ProfielFscGrantHashTestProfile::class)
+@QuarkusTestResource(WireMockProfielServiceResource::class)
+class ProfielFscOutwayHeadersWireMockTest {
+
+    @Inject
+    @RestClient
+    lateinit var client: ProfielServiceClient
+
+    private val wireMock get() = WireMockProfielServiceResource.server!!
+
+    @BeforeEach
+    fun resetStubs() {
+        wireMock.resetAll()
+    }
+
+    @Test
+    fun `met grant-hash draagt de Profiel-call Fsc-Grant-Hash en een v7 Fsc-Transaction-Id`() {
+        wireMock.stubFor(
+            get(urlEqualTo(PROFIEL_PAD)).willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("""{"voorkeuren":[]}""")
+            )
+        )
+
+        client.getPartij("BSN", "999993653")
+
+        wireMock.verify(
+            getRequestedFor(urlEqualTo(PROFIEL_PAD))
+                .withHeader("Fsc-Grant-Hash", equalTo(ProfielFscGrantHashTestProfile.GRANT_HASH))
+                .withHeader("Fsc-Transaction-Id", matching(UUID_V7_REGEX))
+        )
+    }
+
+    companion object {
+        const val PROFIEL_PAD = "/api/profielservice/v1/BSN/999993653"
+
+        // De version-nibble "7" wordt expliciet gepind: de outway wijst v4 af, dus een
+        // test die alleen "is een UUID" controleert vangt precies die fout niet.
+        const val UUID_V7_REGEX =
+            "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-7[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}"
+    }
+}
+
+class ProfielFscGrantHashTestProfile : QuarkusTestProfile {
+
+    override fun getEnabledAlternatives(): Set<Class<*>> = setOf(
+        nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.MockBerichtenCache::class.java,
+    )
+
+    override fun getConfigOverrides(): Map<String, String> = mapOf(
+        // Sluit de @Mock-bean uit zodat de échte REST-client (mét de geregistreerde filter)
+        // wordt geïnjecteerd en het HTTP-pad onder test komt.
+        "quarkus.arc.exclude-types" to MockProfielServiceClient::class.java.name,
+        "quarkus.redis.devservices.enabled" to "false",
+        "quarkus.redis.hosts" to "redis://localhost:6379",
+        "profiel-service.grant-hash" to GRANT_HASH,
+    )
+
+    companion object {
+        const val GRANT_HASH = "profiel-grant-hash-test"
+    }
+}
+```
+
+- [ ] **Stap 4.2: negatieve test in de sessiecache-module**
+
+Voeg aan `ProfielMagazijnResolverIntegrationTest` (draait zónder grant-hash) deze test toe, plus
+de imports `com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor` en
+`java.time.Duration` (die laatste staat er al):
+
+```kotlin
+    @Test
+    fun `zonder grant-hash draagt de Profiel-call geen FSC-outway-headers`() {
+        wireMock.stubFor(
+            get(urlEqualTo("/api/profielservice/v1/BSN/999993653")).willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("""{"voorkeuren":[]}""")
+            )
+        )
+
+        resolver.resolve(Bsn("999993653")).await().atMost(Duration.ofSeconds(5))
+
+        wireMock.verify(
+            getRequestedFor(urlEqualTo("/api/profielservice/v1/BSN/999993653"))
+                .withoutHeader("Fsc-Grant-Hash")
+                .withoutHeader("Fsc-Transaction-Id")
+        )
+    }
+```
+
+- [ ] **Stap 4.3: draai de sessiecache-module**
+
+```bash
+docker compose up -d
+./mvnw clean test -pl libraries/fbs-berichtensessiecache -am
+```
+
+Verwacht: BUILD SUCCESS.
+
+- [ ] **Stap 4.4: positieve test in berichtenmagazijn**
+
+Maak `services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/validatie/ProfielFscOutwayHeadersWireMockTest.kt`:
+
+```kotlin
+package nl.rijksoverheid.moz.fbs.berichtenmagazijn.validatie
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.matching
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import jakarta.inject.Inject
+import nl.rijksoverheid.moz.fbs.common.profiel.ProfielServiceClient
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Bewijst dat de FSC-outway-headers op de échte, door CDI gebouwde Profiel-client staan —
+ * niet alleen dat de filter-logica klopt (dat dekt ProfielFscOutwayHeadersFilterTest).
+ * Het negatieve geval staat in ProfielServiceClientWireMockTest, dat zonder grant-hash draait.
+ */
+@QuarkusTest
+@TestProfile(ProfielFscGrantHashTestProfile::class)
+@QuarkusTestResource(WireMockProfielServiceResource::class)
+class ProfielFscOutwayHeadersWireMockTest {
+
+    @Inject
+    @RestClient
+    lateinit var client: ProfielServiceClient
+
+    private val wireMock get() = WireMockProfielServiceResource.server!!
+
+    @BeforeEach
+    fun resetStubs() {
+        wireMock.resetAll()
+    }
+
+    @Test
+    fun `met grant-hash draagt de Profiel-call Fsc-Grant-Hash en een v7 Fsc-Transaction-Id`() {
+        wireMock.stubFor(
+            get(urlEqualTo(PROFIEL_PAD)).willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("""{"voorkeuren":[]}""")
+            )
+        )
+
+        client.getPartij("BSN", "999993653")
+
+        wireMock.verify(
+            getRequestedFor(urlEqualTo(PROFIEL_PAD))
+                .withHeader("Fsc-Grant-Hash", equalTo(ProfielFscGrantHashTestProfile.GRANT_HASH))
+                .withHeader("Fsc-Transaction-Id", matching(UUID_V7_REGEX))
+        )
+    }
+
+    companion object {
+        const val PROFIEL_PAD = "/api/profielservice/v1/BSN/999993653"
+
+        // De version-nibble "7" wordt expliciet gepind: de outway wijst v4 af, dus een
+        // test die alleen "is een UUID" controleert vangt precies die fout niet.
+        const val UUID_V7_REGEX =
+            "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-7[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}"
+    }
+}
+
+class ProfielFscGrantHashTestProfile : QuarkusTestProfile {
+
+    override fun getConfigOverrides(): Map<String, String> = mapOf(
+        // Sluit de @Mock-bean uit zodat de échte REST-client (mét de geregistreerde filter)
+        // wordt geïnjecteerd en het HTTP-pad onder test komt.
+        "quarkus.arc.exclude-types" to MockProfielServiceClient::class.java.name,
+        "profiel-service.grant-hash" to GRANT_HASH,
+    )
+
+    companion object {
+        const val GRANT_HASH = "profiel-grant-hash-test"
+    }
+}
+```
+
+- [ ] **Stap 4.5: negatieve test in berichtenmagazijn**
+
+Voeg aan `ProfielServiceClientWireMockTest` (draait zónder grant-hash) toe, met import
+`com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor`:
+
+```kotlin
+    @Test
+    fun `zonder grant-hash draagt de Profiel-call geen FSC-outway-headers`() {
+        wireMock.stubFor(
+            get(urlEqualTo("/api/profielservice/v1/BSN/999993653")).willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("""{"voorkeuren":[]}""")
+            )
+        )
+
+        client.getPartij("BSN", "999993653")
+
+        wireMock.verify(
+            getRequestedFor(urlEqualTo("/api/profielservice/v1/BSN/999993653"))
+                .withoutHeader("Fsc-Grant-Hash")
+                .withoutHeader("Fsc-Transaction-Id")
+        )
+    }
+```
+
+- [ ] **Stap 4.6: draai berichtenmagazijn**
+
+```bash
+./mvnw clean test -pl services/berichtenmagazijn -am
+```
+
+Verwacht: BUILD SUCCESS.
+
+- [ ] **Stap 4.7: commit**
+
+```bash
+git add libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/ \
+        services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/validatie/
+git commit -m "test(fsc): integratietest FSC-outway-headers op de Profiel-call (#730)"
+```
+
+---
+
+## Eindverificatie
+
+- [ ] **Volledige suite**
+
+```bash
+docker compose up -d
+./mvnw clean verify
+```
+
+Verwacht: BUILD SUCCESS. Controleer de output op nieuwe waarschuwingen; alleen de drie in
+CLAUDE.md geaccepteerde (jansi `System::load`, guava `Unsafe`, `LogManager`-volgorde) zijn oké.
+
+- [ ] **detekt**
+
+```bash
+./mvnw detekt:check
+```
+
+Verwacht: 0 bevindingen.
+
+- [ ] **Coverage**
+
+Lees `target/site/jacoco/jacoco.xml` per geraakte module (niet `target/jacoco-report/jacoco.xml`);
+≥ 90% line coverage.
+
+- [ ] **Handmatig op ZAD (ná deploy)**
+
+Zet `PROFIEL_SERVICE_URL` op de **https**-outway-ingress en `PROFIEL_SERVICE_GRANT_HASH` op de
+grant-hash van het valide Profiel-contract. Dan:
+
+```bash
+curl -N -H "X-Ontvanger: BSN:999273127" https://<uitvraag-host>/api/v1/berichten/_ophalen
+```
+
+Verwacht: een resultaat dat de ontvanger-voorkeuren weerspiegelt, geen 503 uit de resolver. De
+`Fsc-Transaction-Id` uit de app-log op DEBUG moet terugkomen in de outway-/inway-logs.
+
+**Let op:** blijft `PROFIEL_SERVICE_URL` op `http://` staan, dan faalt de boot op
+`ProfielServiceEndpointValidator` — dat is bedoeld gedrag (BSN staat in het URL-pad), geen bug in
+deze wijziging.

--- a/docs/plans/2026-07-21-fsc-outway-grant-hash-profielservice.md
+++ b/docs/plans/2026-07-21-fsc-outway-grant-hash-profielservice.md
@@ -1,4 +1,4 @@
-**Status:** Concept
+**Status:** Uitgevoerd
 
 # Profiel-service via de FSC-outway — `Fsc-Grant-Hash`-header (#730)
 

--- a/docs/plans/2026-07-21-fsc-outway-grant-hash-profielservice.md
+++ b/docs/plans/2026-07-21-fsc-outway-grant-hash-profielservice.md
@@ -1,0 +1,174 @@
+**Status:** Concept
+
+# Profiel-service via de FSC-outway — `Fsc-Grant-Hash`-header (#730)
+
+## Context / aanleiding
+
+Op deze branch loopt de magazijn-call al via de FSC-outway: `Magazijninschrijving` kreeg een
+optionele `grantHash`, `fbs-common` kreeg een `UuidV7`-generator en een `FscOutwayHeadersFilter`,
+en beide magazijn-client-bouwplekken registreren die filter als er een grant-hash is
+(zie `docs/plans/2026-07-17-fsc-outway-grant-hash-header.md`).
+
+De **Profiel-service** moet nu langs dezelfde weg. Ook daar geldt: de OpenFSC-outway kiest de
+doeldienst/inway op de `Fsc-Grant-Hash`-header (niet op het pad), en `fsc-outway serve` eist een
+`Fsc-Transaction-Id` in UUID-v7-vorm. Zonder die headers antwoordt de outway met "service not
+found" resp. "invalid uuid version, must be v7".
+
+Twee services benaderen de Profiel-service, beide via dezelfde client uit `fbs-common`:
+
+| Service | Flow | Config |
+|---------|------|--------|
+| `berichtenuitvraag` | `ProfielMagazijnResolver` (magazijn-set per ontvanger) | `quarkus.rest-client.profiel-service.url=${PROFIEL_SERVICE_URL}` |
+| `berichtenmagazijn` | `BerichtValidatieService` (validatie bij aanleveren) | idem |
+
+Beide moeten onafhankelijk van elkaar om kunnen schakelen.
+
+## Het verschil met de magazijn-kant
+
+De magazijn-clients worden **programmatisch** gebouwd (`MagazijnClientFactory.createClient`,
+`MagazijnRouter.forMagazijn`), dus daar volstond `builder.register(FscOutwayHeadersFilter(hash))`
+per client. `ProfielServiceClient` is een **declaratieve** `@RegisterRestClient(configKey =
+"profiel-service")`-interface die via `@RestClient` geïnjecteerd wordt. Er is geen builder om op te
+haken, en de client-bean draagt de MP-Fault-Tolerance-`@Retry` op `getPartij` — met zijn zorgvuldig
+afgestemde `retryOn`/`abortOn`. Een programmatisch gebouwde client verliest die interceptor.
+
+Daarom een andere registratie-route, maar hetzelfde header-contract.
+
+## Ontwerpkeuzes (afgestemd)
+
+1. **Registratie via `@RegisterProvider` op de interface**, niet via
+   `quarkus.rest-client.profiel-service.providers` per service. Eén registratieplek in `fbs-common`
+   die beide services erven; de registratie kan niet tussen services uit elkaar lopen, en een
+   deployment hoeft alleen de grant-hash te zetten om om te schakelen.
+2. **De filter leest zijn eigen config** in plaats van een constructor-arg. Anders dan bij
+   magazijnen is er één Profiel-grant-hash, en een provider die door de rest-client-runtime
+   geïnstantieerd wordt kan niet betrouwbaar een constructor-argument krijgen. Een no-arg
+   constructor + `ConfigProvider.getConfig()` maakt de instantiatie onafhankelijk van CDI.
+3. **Geen grant-hash = byte-identiek gedrag.** Afwezig, leeg of whitespace-only → de filter zet
+   geen enkele header. Dat houdt dev/test (WireMock op `http://localhost:8089`) en elk nog niet
+   omgeschakeld deployment ongewijzigd.
+4. **Eén bron van waarheid voor het header-contract.** De header-set-logica wordt uit
+   `FscOutwayHeadersFilter` getrokken naar een gedeelde helper; magazijn- en profiel-filter zijn
+   beide dunne wrappers. Zonder dit staat het contract (headernamen, v7-eis, debug-log) op twee
+   plekken en kan het driften.
+5. **Eigen config-prefix** `profiel-service.grant-hash`, niet onder `quarkus.rest-client.
+   profiel-service.*`. Dat is Quarkus-eigen namespace; een eigen sleutel daarin bijplaatsen is
+   fragiel. (Vergelijk `magazijn-client.*`, dat om dezelfde reden náást `magazijnen.` staat.)
+
+### Buiten scope (vervolg)
+- Dynamische grant-hash-discovery (`Fsc-Grant-Hash: discover` / manager-API) — gelijk aan de
+  magazijn-kant.
+- De gegenereerde `Fsc-Transaction-Id` óók als veld in de LDV-audittrail (ClickHouse) opnemen.
+- Expliciete trust-store voor PKIoverheid-certificaatvalidatie (bestaande `TODO(#552)` bij de
+  Profiel-config; los van deze wijziging).
+
+## Deploy-voorwaarde (geen code)
+
+`ProfielServiceEndpointValidator` eist `https://` in `%prod`/`%staging`/`%acceptatie` omdat de
+Profiel-client BSN/RSIN/KVK in het URL-pad zet (extern contract). `PROFIEL_SERVICE_URL` moet dus
+naar een **https**-outway-ingress wijzen — precies zoals `MAGAZIJN_A_URL` op deze branch. De
+validator blijft ongewijzigd; een http-outway-ingress zou de boot terecht laten falen.
+
+## Structuur (bestanden)
+
+- Maak: `libraries/fbs-common/.../fsc/FscOutwayHeaders.kt` — gedeelde header-set-logica.
+- Wijzig: `libraries/fbs-common/.../fsc/FscOutwayHeadersFilter.kt` — wrapper om de helper.
+- Maak: `libraries/fbs-common/.../fsc/ProfielFscOutwayHeadersFilter.kt` — config-lezende filter.
+- Wijzig: `libraries/fbs-common/.../profiel/ProfielServiceClient.kt` — `@RegisterProvider`.
+- Wijzig: `services/berichtenuitvraag/src/main/resources/application.properties` — grant-hash-key.
+- Wijzig: `services/berichtenmagazijn/src/main/resources/application.properties` — idem.
+- Wijzig: `CLAUDE.md` — `PROFIEL_SERVICE_GRANT_HASH` in de env-var-tabel.
+- Tests bij elke module (zie stappen).
+
+## Stappen
+
+> TDD per module. **Altijd `clean` vóór `test`.** Commit per afgeronde stap.
+
+### Stap 1 — header-logica extraheren in `fbs-common`
+
+Pure extractie, geen gedragswijziging: de bestaande `FscOutwayHeadersFilterTest` moet ongewijzigd
+groen blijven — dat is de regressie-check op deze stap.
+
+**Implementatie:**
+- `FscOutwayHeaders`: `fun zet(requestContext: ClientRequestContext, grantHash: String)` — zet
+  `Fsc-Grant-Hash`, genereert `Fsc-Transaction-Id` via `UuidV7.generate()`, debug-logt uri +
+  transaction-id.
+- `FscOutwayHeadersFilter(grantHash)` delegeert naar de helper; KDoc-rationale blijft staan.
+
+**Test toevoegen:** `FscOutwayHeadersTest` — headers gezet met de meegegeven hash, transaction-id
+parseert als UUID **v7**, twee invocaties leveren verschillende transaction-ids.
+
+**Verificatie:** `./mvnw clean test -pl libraries/fbs-common -am` groen; JaCoCo ≥ 90%; detekt schoon.
+Commit: `refactor(common): FSC-header-logica naar gedeelde FscOutwayHeaders (#730)`.
+
+### Stap 2 — `ProfielFscOutwayHeadersFilter`
+
+**Test eerst** (`libraries/fbs-common/src/test/...`), `ProfielFscOutwayHeadersFilterTest` met een
+`ClientRequestContext`-fake. De config-waarde moet per test te sturen zijn — geef de filter daarom
+een `internal` secundaire constructor of een injecteerbare `grantHashProvider: () -> String?`, zodat
+de no-arg productie-constructor (`ConfigProvider`) én de test-variant dezelfde code raken.
+
+Cardinaliteiten van "niet geconfigureerd" — `@ParameterizedTest` over afwezig (`null`), lege string
+en whitespace-only: **géén** `Fsc-Grant-Hash` én **géén** `Fsc-Transaction-Id` op de request. Plus:
+gevulde hash → beide headers, hash exact doorgegeven, transaction-id parseert als v7. Plus: een hash
+met omringende spaties wordt getrimd doorgegeven (spiegelt de `grantHash`-trim in
+`ConfigMagazijnregister`).
+
+**Implementatie:**
+- `class ProfielFscOutwayHeadersFilter : ClientRequestFilter` met no-arg constructor.
+- Grant-hash lazy uit `ConfigProvider.getConfig().getOptionalValue(CONFIG_KEY, String::class.java)`,
+  getrimd, blank → `null`. Eén keer lezen en cachen: config is boot-statisch, en dit zit op de
+  hot-path van elke Profiel-call.
+- `filter(ctx)`: `grantHash?.let { FscOutwayHeaders.zet(ctx, it) }`.
+- `CONFIG_KEY = "profiel-service.grant-hash"` als `const` in de companion, zodat de sleutel niet als
+  string-literal in properties-tests gedupliceerd wordt.
+
+**Verificatie:** `./mvnw clean test -pl libraries/fbs-common -am` groen; JaCoCo ≥ 90%; detekt schoon.
+Commit: `feat(common): ProfielFscOutwayHeadersFilter met optionele grant-hash (#730)`.
+
+### Stap 3 — registratie + config
+
+**Implementatie:**
+- `ProfielServiceClient`: `@RegisterProvider(ProfielFscOutwayHeadersFilter::class)` naast de
+  bestaande `@RegisterRestClient`. Korte KDoc-regel bij de annotatie: waarom hier en niet per
+  service (één registratieplek, geen drift).
+- Beide `application.properties`: `profiel-service.grant-hash=${PROFIEL_SERVICE_GRANT_HASH:}` in het
+  Profiel-blok, met een comment dat leeg = geen FSC-headers = directe call.
+- `CLAUDE.md`: rij `PROFIEL_SERVICE_GRANT_HASH` in de env-var-tabel.
+
+**Verificatie:** beide services compileren en hun bestaande suites blijven groen — de filter zit nu
+in de chain van elke Profiel-call, dus dit is de check dat de no-op écht no-op is.
+Commit: `feat(profiel): FSC-outway-headers op de Profiel-service-client (#730)`.
+
+### Stap 4 — integratietest per service: de header komt aan
+
+**Test** (WireMock, `@QuarkusTest`) in **beide** services, spiegelend op
+`FscOutwayHeadersWireMockTest` aan de magazijn-kant:
+- Met een gezette `profiel-service.grant-hash` (via een `TestProfile`-override): roep de flow aan en
+  `verify(getRequestedFor(...).withHeader("Fsc-Grant-Hash", equalTo("<hash>"))
+  .withHeader("Fsc-Transaction-Id", matching("<v7-regex>")))`.
+- Negatief geval: zónder grant-hash → `withoutHeader("Fsc-Grant-Hash")` én
+  `withoutHeader("Fsc-Transaction-Id")`.
+
+De `<v7-regex>` moet de version-nibble pinnen (`...-7[0-9a-f]{3}-[89ab]...`), niet enkel
+UUID-vorm — de outway wijst v4 expliciet af, dus een test die alleen "is een UUID" controleert zou
+de bug die dit voorkomt niet vangen.
+
+**Verificatie:** `./mvnw clean test -pl services/berichtenuitvraag -am` en
+`./mvnw clean test -pl services/berichtenmagazijn -am` groen.
+Commit: `test(fsc): integratietest FSC-outway-headers op de Profiel-call (#730)`.
+
+## Verificatie (geheel)
+
+- Per module `./mvnw clean test -pl <module> -am` groen; volledige suite `./mvnw clean verify` groen.
+- JaCoCo ≥ 90% line coverage in elke geraakte module.
+- `./mvnw detekt:check` schoon; geen nieuwe, onverklaarde build-/test-warnings.
+- Handmatig (ZAD, ná deploy): `PROFIEL_SERVICE_URL` = de https-outway-ingress +
+  `PROFIEL_SERVICE_GRANT_HASH` = de grant-hash van het valide Profiel-contract. De SSE-curl
+  `GET /api/v1/berichten/_ophalen` (X-Ontvanger: BSN:999273127) levert een resultaat dat de
+  ontvanger-voorkeuren weerspiegelt in plaats van een 503 uit de resolver.
+
+## Git-werkwijze
+
+Feature branch `feature/fsc-outway-grant-hash` (voortzetting), draft-PR, geen reviewer, geen
+auto-close-keyword — issue #730 blijft open.

--- a/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnClientFactory.kt
+++ b/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnClientFactory.kt
@@ -3,6 +3,7 @@ package nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder
 import jakarta.annotation.PostConstruct
 import jakarta.enterprise.context.ApplicationScoped
+import nl.rijksoverheid.moz.fbs.common.fsc.FscOutwayHeadersFilter
 import nl.rijksoverheid.moz.fbs.common.identificatie.Oin
 import nl.rijksoverheid.moz.fbs.magazijnregister.Magazijninschrijving
 import nl.rijksoverheid.moz.fbs.magazijnregister.Magazijnregister
@@ -56,11 +57,14 @@ internal class MagazijnClientFactory(
     // `protected open` zodat unit-tests een subclass kunnen maken die niet de Quarkus-CDI
     // REST-client-builder triggert (die buiten @QuarkusTest ArC-context faalt).
     protected open fun createClient(inschrijving: Magazijninschrijving): MagazijnClient {
-        return QuarkusRestClientBuilder.newBuilder()
+        val builder = QuarkusRestClientBuilder.newBuilder()
             .baseUri(inschrijving.url)
             .connectTimeout(connectTimeoutMs, TimeUnit.MILLISECONDS)
             .readTimeout(readTimeoutMs, TimeUnit.MILLISECONDS)
-            .build(MagazijnClient::class.java)
+
+        fscFilterVoor(inschrijving)?.let { builder.register(it) }
+
+        return builder.build(MagazijnClient::class.java)
     }
 
     companion object {
@@ -69,5 +73,12 @@ internal class MagazijnClientFactory(
         // kan afwijken van de waarde die deze factory daadwerkelijk op de socket toepast.
         const val READ_TIMEOUT_MS_PROPERTY = "magazijn-client.read-timeout-ms"
         const val READ_TIMEOUT_MS_DEFAULT = "12000"
+
+        // Losgetrokken van createClient() zodat de registratie-beslissing unit-testbaar is
+        // zonder de Quarkus-REST-client-builder (die buiten @QuarkusTest ArC-context faalt).
+        // Niet elk magazijn draait al achter een FSC-outway; grantHash blijft optioneel
+        // totdat de volledige federatie is overgestapt.
+        internal fun fscFilterVoor(inschrijving: Magazijninschrijving): FscOutwayHeadersFilter? =
+            inschrijving.grantHash?.let { FscOutwayHeadersFilter(it) }
     }
 }

--- a/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/FscOutwayHeadersWireMockTest.kt
+++ b/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/FscOutwayHeadersWireMockTest.kt
@@ -1,0 +1,97 @@
+package nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.matching
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.TestProfile
+import jakarta.inject.Inject
+import nl.rijksoverheid.moz.fbs.common.identificatie.Bsn
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Bewijst dat de FSC-outway-headers daadwerkelijk op de uitgaande magazijn-call staan,
+ * niet alleen dat `MagazijnClientFactory.fscFilterVoor` de juiste registratie-beslissing
+ * neemt (dat dekt `MagazijnClientFactoryFscFilterTest` al zonder een echte REST-client-
+ * build, wat buiten @QuarkusTest ArC-context faalt). `WireMockMagazijnResource` geeft
+ * alleen magazijn-a een grantHash, zodat beide takken via de echte, door CDI gebouwde
+ * client aan bod komen: magazijn-a moet de headers sturen, magazijn-b niet.
+ */
+@QuarkusTest
+@TestProfile(WireMockTestProfile::class)
+@QuarkusTestResource(WireMockMagazijnResource::class)
+class FscOutwayHeadersWireMockTest {
+
+    private val ontvanger = Bsn("999993653")
+
+    // Echte factory: dezelfde client die de sessiecache-aggregatie ook gebruikt, inclusief
+    // de eventueel geregistreerde FscOutwayHeadersFilter.
+    @Inject
+    internal lateinit var clientFactory: MagazijnClientFactory
+
+    @BeforeEach
+    fun setUp() {
+        WireMockMagazijnResource.serverA!!.resetAll()
+        WireMockMagazijnResource.serverB!!.resetAll()
+    }
+
+    @Test
+    fun `magazijn met grantHash krijgt Fsc-Grant-Hash en een v7 Fsc-Transaction-Id op de call`() {
+        stubBerichten(WireMockMagazijnResource.serverA!!)
+
+        val client = clientFactory.getAllClients()[WireMockMagazijnResource.OIN_A]
+
+        assertNotNull(client, "client voor magazijn-OIN A moet geconfigureerd zijn")
+
+        client!!.getBerichten(ontvanger.toCanonicalString(), null)
+
+        WireMockMagazijnResource.serverA!!.verify(
+            getRequestedFor(urlPathEqualTo("/api/v1/berichten"))
+                .withHeader("Fsc-Grant-Hash", equalTo(WireMockMagazijnResource.GRANT_HASH_A))
+                .withHeader("Fsc-Transaction-Id", matching(UUID_V7_REGEX))
+        )
+    }
+
+    @Test
+    fun `magazijn zonder grantHash stuurt geen FSC-outway-headers op de call`() {
+        stubBerichten(WireMockMagazijnResource.serverB!!)
+
+        val client = clientFactory.getAllClients()[WireMockMagazijnResource.OIN_B]
+
+        assertNotNull(client, "client voor magazijn-OIN B moet geconfigureerd zijn")
+
+        client!!.getBerichten(ontvanger.toCanonicalString(), null)
+
+        WireMockMagazijnResource.serverB!!.verify(
+            getRequestedFor(urlPathEqualTo("/api/v1/berichten"))
+                .withoutHeader("Fsc-Grant-Hash")
+                .withoutHeader("Fsc-Transaction-Id")
+        )
+    }
+
+    private fun stubBerichten(server: WireMockServer) {
+        server.stubFor(
+            get(urlPathEqualTo("/api/v1/berichten"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""{"berichten":[]}""")
+                )
+        )
+    }
+
+    companion object {
+        // Version-nibble "7" op de tijd-hoge groep pint UUID-v7 op de header-string, zonder
+        // een volledige UUID-parse (de header is op de wire gewoon tekst).
+        private const val UUID_V7_REGEX =
+            "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-7[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}"
+    }
+}

--- a/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnClientFactoryFscFilterTest.kt
+++ b/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnClientFactoryFscFilterTest.kt
@@ -1,0 +1,36 @@
+package nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn
+
+import nl.rijksoverheid.moz.fbs.common.identificatie.Oin
+import nl.rijksoverheid.moz.fbs.magazijnregister.Magazijninschrijving
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.net.URI
+
+/**
+ * Dekt alleen de registratie-beslissing (`fscFilterVoor`), niet `createClient` zelf: die
+ * bouwt via `QuarkusRestClientBuilder`, wat buiten @QuarkusTest ArC-context faalt.
+ */
+class MagazijnClientFactoryFscFilterTest {
+
+    private fun inschrijving(grantHash: String?): Magazijninschrijving = Magazijninschrijving(
+        oin = Oin("00000001003214345000"),
+        url = URI.create("http://localhost:8081"),
+        naam = null,
+        grantHash = grantHash,
+    )
+
+    @Test
+    fun `grantHash aanwezig levert een FscOutwayHeadersFilter`() {
+        val filter = MagazijnClientFactory.fscFilterVoor(inschrijving(grantHash = "abc123"))
+
+        assertNotNull(filter)
+    }
+
+    @Test
+    fun `grantHash afwezig levert geen filter`() {
+        val filter = MagazijnClientFactory.fscFilterVoor(inschrijving(grantHash = null))
+
+        assertNull(filter)
+    }
+}

--- a/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/ProfielFscOutwayHeadersWireMockTest.kt
+++ b/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/ProfielFscOutwayHeadersWireMockTest.kt
@@ -1,0 +1,89 @@
+package nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.matching
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import jakarta.inject.Inject
+import nl.rijksoverheid.moz.fbs.common.profiel.ProfielServiceClient
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Bewijst dat de FSC-outway-headers op de échte, door CDI gebouwde Profiel-client staan —
+ * niet alleen dat de filter-logica klopt (dat dekt ProfielFscOutwayHeadersFilterTest).
+ * Het negatieve geval staat in ProfielMagazijnResolverIntegrationTest, dat zonder
+ * grant-hash draait.
+ */
+@QuarkusTest
+@TestProfile(ProfielFscGrantHashTestProfile::class)
+@QuarkusTestResource(WireMockProfielServiceResource::class)
+class ProfielFscOutwayHeadersWireMockTest {
+
+    @Inject
+    @RestClient
+    lateinit var client: ProfielServiceClient
+
+    private val wireMock get() = WireMockProfielServiceResource.server!!
+
+    @BeforeEach
+    fun resetStubs() {
+        wireMock.resetAll()
+    }
+
+    @Test
+    fun `met grant-hash draagt de Profiel-call Fsc-Grant-Hash en een v7 Fsc-Transaction-Id`() {
+        wireMock.stubFor(
+            get(urlEqualTo(PROFIEL_PAD)).willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("""{"voorkeuren":[]}""")
+            )
+        )
+
+        client.getPartij("BSN", "999993653")
+
+        wireMock.verify(
+            getRequestedFor(urlEqualTo(PROFIEL_PAD))
+                .withHeader("Fsc-Grant-Hash", equalTo(ProfielFscGrantHashTestProfile.GRANT_HASH))
+                .withHeader("Fsc-Transaction-Id", matching(UUID_V7_REGEX))
+        )
+    }
+
+    companion object {
+        const val PROFIEL_PAD = "/api/profielservice/v1/BSN/999993653"
+
+        // De version-nibble "7" wordt expliciet gepind: de outway wijst v4 af, dus een
+        // test die alleen "is een UUID" controleert vangt precies die fout niet.
+        const val UUID_V7_REGEX =
+            "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-7[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}"
+    }
+}
+
+class ProfielFscGrantHashTestProfile : QuarkusTestProfile {
+
+    override fun getEnabledAlternatives(): Set<Class<*>> = setOf(
+        nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.MockBerichtenCache::class.java,
+    )
+
+    override fun getConfigOverrides(): Map<String, String> = mapOf(
+        // Sluit de @Mock-bean uit zodat de échte REST-client (mét de geregistreerde filter)
+        // wordt geïnjecteerd en het HTTP-pad onder test komt.
+        "quarkus.arc.exclude-types" to MockProfielServiceClient::class.java.name,
+        "quarkus.redis.devservices.enabled" to "false",
+        "quarkus.redis.hosts" to "redis://localhost:6379",
+        "profiel-service.grant-hash" to GRANT_HASH,
+    )
+
+    companion object {
+        const val GRANT_HASH = "profiel-grant-hash-test"
+    }
+}

--- a/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/ProfielMagazijnResolverIntegrationTest.kt
+++ b/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/ProfielMagazijnResolverIntegrationTest.kt
@@ -2,6 +2,7 @@ package nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn
 
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
@@ -159,6 +160,26 @@ class ProfielMagazijnResolverIntegrationTest {
         assertThrows(ProfielServiceFoutException::class.java) {
             resolver.resolve(Bsn("999993653")).await().atMost(Duration.ofSeconds(5))
         }
+    }
+
+    @Test
+    fun `zonder grant-hash draagt de Profiel-call geen FSC-outway-headers`() {
+        wireMock.stubFor(
+            get(urlEqualTo("/api/profielservice/v1/BSN/999993653")).willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("""{"voorkeuren":[]}""")
+            )
+        )
+
+        resolver.resolve(Bsn("999993653")).await().atMost(Duration.ofSeconds(5))
+
+        wireMock.verify(
+            getRequestedFor(urlEqualTo("/api/profielservice/v1/BSN/999993653"))
+                .withoutHeader("Fsc-Grant-Hash")
+                .withoutHeader("Fsc-Transaction-Id")
+        )
     }
 }
 

--- a/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/WireMockMagazijnResource.kt
+++ b/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/WireMockMagazijnResource.kt
@@ -12,6 +12,10 @@ class WireMockMagazijnResource : QuarkusTestResourceLifecycleManager {
         const val OIN_A = "00000001003214345000"
         const val OIN_B = "00000001823288444000"
 
+        // Alleen magazijn-a krijgt een grantHash: dekt beide fscFilterVoor-takken
+        // (met/zonder outway-headers) via de echte, door CDI gebouwde client.
+        const val GRANT_HASH_A = "fsc-test-grant-hash-a"
+
         var serverA: WireMockServer? = null
         var serverB: WireMockServer? = null
     }
@@ -27,6 +31,7 @@ class WireMockMagazijnResource : QuarkusTestResourceLifecycleManager {
         return mapOf(
             "magazijnen.\"$OIN_A\".url" to a.baseUrl(),
             "magazijnen.\"$OIN_A\".naam" to "WireMock Magazijn A",
+            "magazijnen.\"$OIN_A\".grantHash" to GRANT_HASH_A,
             "magazijnen.\"$OIN_B\".url" to b.baseUrl(),
             "magazijnen.\"$OIN_B\".naam" to "WireMock Magazijn B",
         )

--- a/libraries/fbs-berichtensessiecache/src/test/resources/application.properties
+++ b/libraries/fbs-berichtensessiecache/src/test/resources/application.properties
@@ -38,6 +38,11 @@ berichtensessiecache.bericht.max-bijlage-naam-lengte=255
 # overschrijft deze waarde per testklasse.
 quarkus.rest-client.profiel-service.url=http://localhost:8089
 
+# Aanwezig-maar-leeg in de productie-vorm (env-var ongezet expandeert naar ""), niet
+# afwezig: de negatieve "geen FSC-headers"-test moet hetzelfde SmallRye-pad doorlopen
+# als productie i.p.v. het simpelere "key ontbreekt volledig"-pad.
+profiel-service.grant-hash=${PROFIEL_SERVICE_GRANT_HASH:}
+
 # Deterministische retry-timing in tests (geen jitter-flakiness).
 nl.rijksoverheid.moz.fbs.common.profiel.ProfielServiceClient/getPartij/Retry/jitter=0
 

--- a/libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeaders.kt
+++ b/libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeaders.kt
@@ -27,10 +27,13 @@ object FscOutwayHeaders {
         requestContext.headers.putSingle(TRANSACTION_ID_HEADER, transactionId.toString())
 
         // Zonder deze transaction-id in de app-log is een call niet terug te vinden in de
-        // outway-/inway-logs, die 'm ongewijzigd doorgeven.
+        // outway-/inway-logs, die 'm ongewijzigd doorgeven. Log alleen de host, nooit het
+        // volledige URI: sommige callers (Profiel-service) dragen een BSN in het pad, en
+        // deze regel logt bij DEBUG — dus een pad of query hier zou dat BSN naar de
+        // applicatielog schrijven. De host identificeert de outway afdoende.
         log.debugf(
             "FSC-outway-call naar %s: Fsc-Transaction-Id=%s",
-            requestContext.uri,
+            requestContext.uri.host,
             transactionId,
         )
     }

--- a/libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeaders.kt
+++ b/libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeaders.kt
@@ -1,0 +1,37 @@
+package nl.rijksoverheid.moz.fbs.common.fsc
+
+import jakarta.ws.rs.client.ClientRequestContext
+import org.jboss.logging.Logger
+
+/**
+ * Het FSC-outway-headercontract op één plek. De OpenFSC-outway kiest de doel-inway op
+ * `Fsc-Grant-Hash` (niet op het pad) en `fsc-outway serve` eist een `Fsc-Transaction-Id` in
+ * UUID-v7-vorm; zonder deze headers antwoordt de outway met "service not found" resp.
+ * "invalid uuid version, must be v7".
+ *
+ * Meerdere clients sturen deze headers (magazijn-calls per inschrijving, de Profiel-call),
+ * elk met een eigen manier om aan hun grant-hash te komen. Die herkomst verschilt; het
+ * contract niet — daarom staat het hier en niet in de afzonderlijke filters.
+ */
+object FscOutwayHeaders {
+
+    const val GRANT_HASH_HEADER = "Fsc-Grant-Hash"
+    const val TRANSACTION_ID_HEADER = "Fsc-Transaction-Id"
+
+    private val log = Logger.getLogger(FscOutwayHeaders::class.java)
+
+    fun zet(requestContext: ClientRequestContext, grantHash: String) {
+        val transactionId = UuidV7.generate()
+
+        requestContext.headers.putSingle(GRANT_HASH_HEADER, grantHash)
+        requestContext.headers.putSingle(TRANSACTION_ID_HEADER, transactionId.toString())
+
+        // Zonder deze transaction-id in de app-log is een call niet terug te vinden in de
+        // outway-/inway-logs, die 'm ongewijzigd doorgeven.
+        log.debugf(
+            "FSC-outway-call naar %s: Fsc-Transaction-Id=%s",
+            requestContext.uri,
+            transactionId,
+        )
+    }
+}

--- a/libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeadersFilter.kt
+++ b/libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeadersFilter.kt
@@ -2,35 +2,18 @@ package nl.rijksoverheid.moz.fbs.common.fsc
 
 import jakarta.ws.rs.client.ClientRequestContext
 import jakarta.ws.rs.client.ClientRequestFilter
-import org.jboss.logging.Logger
 
 /**
- * Zet de FSC-outway-routeringsheaders op een uitgaande magazijn-call. De OpenFSC-outway kiest
- * de doel-inway op `Fsc-Grant-Hash` (niet op het pad) en `fsc-outway serve` eist een
- * `Fsc-Transaction-Id` in UUID-v7-vorm; zonder deze headers antwoordt de outway met
- * "service not found" resp. "invalid uuid version, must be v7".
+ * Zet de FSC-outway-routeringsheaders op een uitgaande magazijn-call.
  *
- * Bewust géén `@Provider`: de grant-hash is per magazijn verschillend, dus wordt de filter
- * per client handmatig geregistreerd in plaats van als globale JAX-RS-provider.
+ * Bewust geen `@Provider`: de grant-hash is per magazijn verschillend, dus wordt de filter
+ * per client handmatig geregistreerd in plaats van als globale JAX-RS-provider. De
+ * Profiel-client heeft één vaste grant-hash en gebruikt daarom
+ * [ProfielFscOutwayHeadersFilter].
  */
 class FscOutwayHeadersFilter(private val grantHash: String) : ClientRequestFilter {
 
     override fun filter(requestContext: ClientRequestContext) {
-        val transactionId = UuidV7.generate()
-
-        requestContext.headers.putSingle("Fsc-Grant-Hash", grantHash)
-        requestContext.headers.putSingle("Fsc-Transaction-Id", transactionId.toString())
-
-        // Zonder deze transaction-id in de app-log is een call niet terug te vinden in de
-        // outway-/inway-logs, die 'm ongewijzigd doorgeven.
-        log.debugf(
-            "FSC-outway-call naar %s: Fsc-Transaction-Id=%s",
-            requestContext.uri,
-            transactionId,
-        )
-    }
-
-    companion object {
-        private val log = Logger.getLogger(FscOutwayHeadersFilter::class.java)
+        FscOutwayHeaders.zet(requestContext, grantHash)
     }
 }

--- a/libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeadersFilter.kt
+++ b/libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeadersFilter.kt
@@ -1,0 +1,36 @@
+package nl.rijksoverheid.moz.fbs.common.fsc
+
+import jakarta.ws.rs.client.ClientRequestContext
+import jakarta.ws.rs.client.ClientRequestFilter
+import org.jboss.logging.Logger
+
+/**
+ * Zet de FSC-outway-routeringsheaders op een uitgaande magazijn-call. De OpenFSC-outway kiest
+ * de doel-inway op `Fsc-Grant-Hash` (niet op het pad) en `fsc-outway serve` eist een
+ * `Fsc-Transaction-Id` in UUID-v7-vorm; zonder deze headers antwoordt de outway met
+ * "service not found" resp. "invalid uuid version, must be v7".
+ *
+ * Bewust géén `@Provider`: de grant-hash is per magazijn verschillend, dus wordt de filter
+ * per client handmatig geregistreerd in plaats van als globale JAX-RS-provider.
+ */
+class FscOutwayHeadersFilter(private val grantHash: String) : ClientRequestFilter {
+
+    override fun filter(requestContext: ClientRequestContext) {
+        val transactionId = UuidV7.generate()
+
+        requestContext.headers.putSingle("Fsc-Grant-Hash", grantHash)
+        requestContext.headers.putSingle("Fsc-Transaction-Id", transactionId.toString())
+
+        // Zonder deze transaction-id in de app-log is een call niet terug te vinden in de
+        // outway-/inway-logs, die 'm ongewijzigd doorgeven.
+        log.debugf(
+            "FSC-outway-call naar %s: Fsc-Transaction-Id=%s",
+            requestContext.uri,
+            transactionId,
+        )
+    }
+
+    companion object {
+        private val log = Logger.getLogger(FscOutwayHeadersFilter::class.java)
+    }
+}

--- a/libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/ProfielFscOutwayHeadersFilter.kt
+++ b/libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/ProfielFscOutwayHeadersFilter.kt
@@ -1,0 +1,42 @@
+package nl.rijksoverheid.moz.fbs.common.fsc
+
+import jakarta.ws.rs.client.ClientRequestContext
+import jakarta.ws.rs.client.ClientRequestFilter
+import org.eclipse.microprofile.config.ConfigProvider
+
+/**
+ * Zet de FSC-outway-headers op de Profiel-service-call, mits er een grant-hash geconfigureerd
+ * is. Zonder grant-hash doet de filter niets, zodat een deployment dat nog direct met de
+ * Profiel-service praat ongewijzigd blijft.
+ *
+ * De grant-hash komt uit config in plaats van uit een constructor-argument (zoals bij
+ * [FscOutwayHeadersFilter], waar elke magazijn-inschrijving een eigen hash heeft): deze filter
+ * wordt via `@RegisterProvider` door de rest-client-runtime geïnstantieerd, en die kan geen
+ * constructor-argument leveren. De no-arg constructor houdt de instantiatie daarmee
+ * onafhankelijk van CDI.
+ */
+class ProfielFscOutwayHeadersFilter internal constructor(
+    private val grantHashProvider: () -> String?,
+) : ClientRequestFilter {
+
+    constructor() : this({
+        ConfigProvider.getConfig().getOptionalValue(CONFIG_KEY, String::class.java).orElse(null)
+    })
+
+    // Eén keer lezen: config is boot-statisch, en dit zit op de hot-path van elke Profiel-call.
+    private val grantHash: String? by lazy {
+        grantHashProvider()?.trim()?.takeIf { it.isNotEmpty() }
+    }
+
+    override fun filter(requestContext: ClientRequestContext) {
+        grantHash?.let { FscOutwayHeaders.zet(requestContext, it) }
+    }
+
+    companion object {
+        /**
+         * Eigen prefix, niet onder `quarkus.rest-client.profiel-service.*`: dat is
+         * Quarkus-eigen namespace en een eigen sleutel daarin bijplaatsen is fragiel.
+         */
+        const val CONFIG_KEY = "profiel-service.grant-hash"
+    }
+}

--- a/libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/UuidV7.kt
+++ b/libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/UuidV7.kt
@@ -20,7 +20,13 @@ object UuidV7 {
     private const val RAND_A_MASK_12_BIT = 0x0FFF
     private const val RAND_B_MASK_62_BIT = 0x3FFFFFFFFFFFFFFFL
 
-    fun generate(epochMilli: Long = System.currentTimeMillis(), rnd: Random = SecureRandom()): UUID {
+    // Eén gedeelde instantie in plaats van een nieuwe per call: elke uitgaande magazijn- én
+    // Profiel-call genereert een transaction-id, en het opzetten van een SecureRandom kost
+    // een seeding-ronde. SecureRandom is thread-safe, dus delen is veilig bij gelijktijdige
+    // calls.
+    private val gedeeldeSecureRandom = SecureRandom()
+
+    fun generate(epochMilli: Long = System.currentTimeMillis(), rnd: Random = gedeeldeSecureRandom): UUID {
         val tijdstip = (epochMilli and TIJDSTIP_MASK_48_BIT) shl 16
         val randA = (rnd.nextInt() and RAND_A_MASK_12_BIT).toLong()
         val mostSigBits = tijdstip or (VERSION_7 shl 12) or randA

--- a/libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/UuidV7.kt
+++ b/libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/UuidV7.kt
@@ -1,0 +1,33 @@
+package nl.rijksoverheid.moz.fbs.common.fsc
+
+import java.security.SecureRandom
+import java.util.Random
+import java.util.UUID
+
+/**
+ * UUID-versie-7-generator (RFC 9562): een 48-bit unix-ms-tijdstip in de hoge bits maakt
+ * waarden tijd-geordend, wat de FSC-outway als `Fsc-Transaction-Id` eist. De JDK genereert
+ * zelf alleen v4 (`UUID.randomUUID()`); dit is de enige plek die het v7-bitpatroon opbouwt.
+ *
+ * `epochMilli`/`rnd` zijn injecteerbaar zodat tests het tijdstip- en random-deel deterministisch
+ * kunnen vastzetten.
+ */
+object UuidV7 {
+
+    private const val VERSION_7 = 0x7L
+    private const val VARIANT_RFC4122 = 0x2L
+    private const val TIJDSTIP_MASK_48_BIT = 0xFFFFFFFFFFFFL
+    private const val RAND_A_MASK_12_BIT = 0x0FFF
+    private const val RAND_B_MASK_62_BIT = 0x3FFFFFFFFFFFFFFFL
+
+    fun generate(epochMilli: Long = System.currentTimeMillis(), rnd: Random = SecureRandom()): UUID {
+        val tijdstip = (epochMilli and TIJDSTIP_MASK_48_BIT) shl 16
+        val randA = (rnd.nextInt() and RAND_A_MASK_12_BIT).toLong()
+        val mostSigBits = tijdstip or (VERSION_7 shl 12) or randA
+
+        val randB = rnd.nextLong() and RAND_B_MASK_62_BIT
+        val leastSigBits = randB or (VARIANT_RFC4122 shl 62)
+
+        return UUID(mostSigBits, leastSigBits)
+    }
+}

--- a/libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/profiel/ProfielServiceClient.kt
+++ b/libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/profiel/ProfielServiceClient.kt
@@ -8,7 +8,9 @@ import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
 import jakarta.ws.rs.ProcessingException
 import jakarta.ws.rs.core.MediaType
+import nl.rijksoverheid.moz.fbs.common.fsc.ProfielFscOutwayHeadersFilter
 import org.eclipse.microprofile.faulttolerance.Retry
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
 import java.net.UnknownHostException
 
@@ -25,7 +27,13 @@ import java.net.UnknownHostException
  * negeert velden die we niet gebruiken (createdAt, lastUpdated, contactgegevens, etc.)
  * zodat upstream-veldtoevoegingen onze deserialisatie niet breken.
  */
+/**
+ * Registratie hier en niet per service via `quarkus.rest-client.profiel-service.providers`:
+ * beide consumers delen deze interface, dus één plek voorkomt dat de registratie tussen
+ * services uit elkaar loopt. De filter is een no-op zolang er geen grant-hash geconfigureerd is.
+ */
 @RegisterRestClient(configKey = "profiel-service")
+@RegisterProvider(ProfielFscOutwayHeadersFilter::class)
 interface ProfielServiceClient {
 
     /**

--- a/libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/profiel/ProfielServiceClient.kt
+++ b/libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/profiel/ProfielServiceClient.kt
@@ -26,8 +26,7 @@ import java.net.UnknownHostException
  * DTO's zijn een minimale subset van de upstream-schema's; `@JsonIgnoreProperties`
  * negeert velden die we niet gebruiken (createdAt, lastUpdated, contactgegevens, etc.)
  * zodat upstream-veldtoevoegingen onze deserialisatie niet breken.
- */
-/**
+ *
  * Registratie hier en niet per service via `quarkus.rest-client.profiel-service.providers`:
  * beide consumers delen deze interface, dus één plek voorkomt dat de registratie tussen
  * services uit elkaar loopt. De filter is een no-op zolang er geen grant-hash geconfigureerd is.

--- a/libraries/fbs-common/src/test/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeadersFilterTest.kt
+++ b/libraries/fbs-common/src/test/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeadersFilterTest.kt
@@ -1,0 +1,54 @@
+package nl.rijksoverheid.moz.fbs.common.fsc
+
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.ws.rs.client.ClientRequestContext
+import jakarta.ws.rs.core.MultivaluedHashMap
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+import java.net.URI
+import java.util.UUID
+
+class FscOutwayHeadersFilterTest {
+
+    private fun runFilter(grantHash: String): MultivaluedHashMap<String, Any> {
+        val ctx = mockk<ClientRequestContext>()
+        val headers = MultivaluedHashMap<String, Any>()
+        every { ctx.headers } returns headers
+        every { ctx.uri } returns URI.create("https://outway.voorbeeld.test/api/v1/berichten")
+
+        FscOutwayHeadersFilter(grantHash).filter(ctx)
+
+        return headers
+    }
+
+    @Test
+    fun `filter zet Fsc-Grant-Hash gelijk aan de meegegeven waarde`() {
+        val headers = runFilter("abc123")
+
+        assertEquals(listOf("abc123"), headers["Fsc-Grant-Hash"])
+    }
+
+    @Test
+    fun `filter zet een Fsc-Transaction-Id die als UUID v7 parseert`() {
+        val headers = runFilter("abc123")
+
+        val transactionId = headers.getFirst("Fsc-Transaction-Id") as String
+        val uuid = UUID.fromString(transactionId)
+
+        assertEquals(7, uuid.version())
+        assertEquals(2, uuid.variant())
+    }
+
+    @Test
+    fun `twee invocaties leveren twee verschillende transaction-ids`() {
+        val eersteHeaders = runFilter("abc123")
+        val tweedeHeaders = runFilter("abc123")
+
+        assertNotEquals(
+            eersteHeaders.getFirst("Fsc-Transaction-Id"),
+            tweedeHeaders.getFirst("Fsc-Transaction-Id"),
+        )
+    }
+}

--- a/libraries/fbs-common/src/test/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeadersTest.kt
+++ b/libraries/fbs-common/src/test/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeadersTest.kt
@@ -4,13 +4,43 @@ import io.mockk.every
 import io.mockk.mockk
 import jakarta.ws.rs.client.ClientRequestContext
 import jakarta.ws.rs.core.MultivaluedHashMap
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.net.URI
 import java.util.UUID
+import java.util.logging.Handler
+import java.util.logging.Level
+import java.util.logging.LogRecord
+import java.util.logging.Logger
 
 class FscOutwayHeadersTest {
+
+    private val julLogger: Logger = Logger.getLogger(FscOutwayHeaders::class.java.name)
+    private val records = mutableListOf<LogRecord>()
+    private val handler = object : Handler() {
+        override fun publish(record: LogRecord) {
+            records.add(record)
+        }
+        override fun flush() {}
+        override fun close() {}
+    }
+
+    @BeforeEach
+    fun installHandler() {
+        julLogger.addHandler(handler)
+        julLogger.level = Level.ALL
+        records.clear()
+    }
+
+    @AfterEach
+    fun removeHandler() {
+        julLogger.removeHandler(handler)
+    }
 
     private fun zetHeaders(grantHash: String): MultivaluedHashMap<String, Any> {
         val ctx = mockk<ClientRequestContext>()
@@ -49,5 +79,23 @@ class FscOutwayHeadersTest {
             eerste.getFirst(FscOutwayHeaders.TRANSACTION_ID_HEADER),
             tweede.getFirst(FscOutwayHeaders.TRANSACTION_ID_HEADER),
         )
+    }
+
+    @Test
+    fun `debuglog bevat de host maar geen pad of query van de call`() {
+        // De Profiel-call draagt de BSN in het pad (zie zetHeaders); deze log-regel
+        // draait op DEBUG, dat in %dev/%test aanstaat. Een refactor die weer het
+        // volledige requestContext.uri logt, zou BSN's naar de applicatielog schrijven.
+        zetHeaders("abc123")
+
+        val debugRecords = records.filter { it.level == Level.FINE }
+        assertEquals(1, debugRecords.size, "verwacht 1 debug-regel — gevonden: $debugRecords")
+        val rendered = debugRecords.first().let { rec ->
+            rec.parameters?.let { runCatching { String.format(rec.message, *it) }.getOrDefault(rec.message) }
+                ?: rec.message
+        }
+        assertTrue(rendered.contains("outway.voorbeeld.test"), "host moet aanwezig zijn — gevonden: $rendered")
+        assertFalse(rendered.contains("999993653"), "BSN uit het pad mag NIET gelogd worden — gevonden: $rendered")
+        assertFalse(rendered.contains("/api/profielservice"), "pad mag NIET gelogd worden — gevonden: $rendered")
     }
 }

--- a/libraries/fbs-common/src/test/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeadersTest.kt
+++ b/libraries/fbs-common/src/test/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeadersTest.kt
@@ -1,0 +1,53 @@
+package nl.rijksoverheid.moz.fbs.common.fsc
+
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.ws.rs.client.ClientRequestContext
+import jakarta.ws.rs.core.MultivaluedHashMap
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+import java.net.URI
+import java.util.UUID
+
+class FscOutwayHeadersTest {
+
+    private fun zetHeaders(grantHash: String): MultivaluedHashMap<String, Any> {
+        val ctx = mockk<ClientRequestContext>()
+        val headers = MultivaluedHashMap<String, Any>()
+        every { ctx.headers } returns headers
+        every { ctx.uri } returns URI.create("https://outway.voorbeeld.test/api/profielservice/v1/BSN/999993653")
+
+        FscOutwayHeaders.zet(ctx, grantHash)
+
+        return headers
+    }
+
+    @Test
+    fun `zet de grant-hash ongewijzigd op de Fsc-Grant-Hash-header`() {
+        val headers = zetHeaders("abc123")
+
+        assertEquals(listOf("abc123"), headers[FscOutwayHeaders.GRANT_HASH_HEADER])
+    }
+
+    @Test
+    fun `zet een Fsc-Transaction-Id die als UUID v7 parseert`() {
+        val headers = zetHeaders("abc123")
+
+        val uuid = UUID.fromString(headers.getFirst(FscOutwayHeaders.TRANSACTION_ID_HEADER) as String)
+
+        assertEquals(7, uuid.version())
+        assertEquals(2, uuid.variant())
+    }
+
+    @Test
+    fun `twee invocaties leveren twee verschillende transaction-ids`() {
+        val eerste = zetHeaders("abc123")
+        val tweede = zetHeaders("abc123")
+
+        assertNotEquals(
+            eerste.getFirst(FscOutwayHeaders.TRANSACTION_ID_HEADER),
+            tweede.getFirst(FscOutwayHeaders.TRANSACTION_ID_HEADER),
+        )
+    }
+}

--- a/libraries/fbs-common/src/test/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/ProfielFscOutwayHeadersFilterTest.kt
+++ b/libraries/fbs-common/src/test/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/ProfielFscOutwayHeadersFilterTest.kt
@@ -1,0 +1,91 @@
+package nl.rijksoverheid.moz.fbs.common.fsc
+
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.ws.rs.client.ClientRequestContext
+import jakarta.ws.rs.core.MultivaluedHashMap
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.NullSource
+import org.junit.jupiter.params.provider.ValueSource
+import java.net.URI
+import java.util.UUID
+
+class ProfielFscOutwayHeadersFilterTest {
+
+    private fun runFilter(grantHash: String?): MultivaluedHashMap<String, Any> {
+        val ctx = mockk<ClientRequestContext>()
+        val headers = MultivaluedHashMap<String, Any>()
+        every { ctx.headers } returns headers
+        every { ctx.uri } returns URI.create("https://outway.voorbeeld.test/api/profielservice/v1/BSN/999993653")
+
+        ProfielFscOutwayHeadersFilter { grantHash }.filter(ctx)
+
+        return headers
+    }
+
+    /**
+     * De drie vormen waarin "niet geconfigureerd" binnenkomt: de key ontbreekt (null), of
+     * `${PROFIEL_SERVICE_GRANT_HASH:}` expandeert naar leeg/whitespace. Alle drie moeten de
+     * call byte-identiek laten aan de situatie vóór deze feature — een half gezette header
+     * zou de outway een onbruikbare route geven.
+     */
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = ["", "   ", "\t"])
+    fun `zonder bruikbare grant-hash worden geen FSC-headers gezet`(grantHash: String?) {
+        val headers = runFilter(grantHash)
+
+        assertFalse(headers.containsKey(FscOutwayHeaders.GRANT_HASH_HEADER))
+        assertFalse(headers.containsKey(FscOutwayHeaders.TRANSACTION_ID_HEADER))
+    }
+
+    @Test
+    fun `met grant-hash worden beide FSC-headers gezet`() {
+        val headers = runFilter("profiel-hash-1")
+
+        assertEquals(listOf("profiel-hash-1"), headers[FscOutwayHeaders.GRANT_HASH_HEADER])
+
+        val uuid = UUID.fromString(headers.getFirst(FscOutwayHeaders.TRANSACTION_ID_HEADER) as String)
+
+        assertEquals(7, uuid.version())
+        assertEquals(2, uuid.variant())
+    }
+
+    @Test
+    fun `omringende spaties in de config-waarde worden getrimd`() {
+        val headers = runFilter("  profiel-hash-1  ")
+
+        assertEquals(listOf("profiel-hash-1"), headers[FscOutwayHeaders.GRANT_HASH_HEADER])
+    }
+
+    @Test
+    fun `twee calls op dezelfde filter leveren verschillende transaction-ids`() {
+        val filter = ProfielFscOutwayHeadersFilter { "profiel-hash-1" }
+
+        val eerste = MultivaluedHashMap<String, Any>()
+        val tweede = MultivaluedHashMap<String, Any>()
+
+        listOf(eerste, tweede).forEach { headers ->
+            val ctx = mockk<ClientRequestContext>()
+            every { ctx.headers } returns headers
+            every { ctx.uri } returns URI.create("https://outway.voorbeeld.test/api/profielservice/v1/BSN/999993653")
+            filter.filter(ctx)
+        }
+
+        assertNotEquals(
+            eerste.getFirst(FscOutwayHeaders.TRANSACTION_ID_HEADER),
+            tweede.getFirst(FscOutwayHeaders.TRANSACTION_ID_HEADER),
+        )
+    }
+
+    @Test
+    fun `de config-key blijft de gepubliceerde sleutel`() {
+        // Pin de sleutel: application.properties van beide services hangt eraan, en een
+        // hernoeming zou de filter stil uitschakelen in plaats van te falen.
+        assertEquals("profiel-service.grant-hash", ProfielFscOutwayHeadersFilter.CONFIG_KEY)
+    }
+}

--- a/libraries/fbs-common/src/test/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/ProfielFscOutwayHeadersFilterTest.kt
+++ b/libraries/fbs-common/src/test/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/ProfielFscOutwayHeadersFilterTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import jakarta.ws.rs.client.ClientRequestContext
 import jakarta.ws.rs.core.MultivaluedHashMap
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -15,6 +16,21 @@ import java.net.URI
 import java.util.UUID
 
 class ProfielFscOutwayHeadersFilterTest {
+
+    // Vangnet naast de expliciete clear in elke ConfigProvider-test: een falende assertion
+    // mag de property nooit laten leken naar andere tests in deze module.
+    @AfterEach
+    fun clearGrantHashSystemProperty() {
+        System.clearProperty(ProfielFscOutwayHeadersFilter.CONFIG_KEY)
+    }
+
+    private fun mockContext(headers: MultivaluedHashMap<String, Any>): ClientRequestContext {
+        val ctx = mockk<ClientRequestContext>()
+        every { ctx.headers } returns headers
+        every { ctx.uri } returns URI.create("https://outway.voorbeeld.test/api/profielservice/v1/BSN/999993653")
+
+        return ctx
+    }
 
     private fun runFilter(grantHash: String?): MultivaluedHashMap<String, Any> {
         val ctx = mockk<ClientRequestContext>()
@@ -87,5 +103,38 @@ class ProfielFscOutwayHeadersFilterTest {
         // Pin de sleutel: application.properties van beide services hangt eraan, en een
         // hernoeming zou de filter stil uitschakelen in plaats van te falen.
         assertEquals("profiel-service.grant-hash", ProfielFscOutwayHeadersFilter.CONFIG_KEY)
+    }
+
+    /**
+     * Dekt de no-arg constructor, het daadwerkelijke integratiepunt dat de rest-client-runtime
+     * via `@RegisterProvider` instantieert: die kan geen constructor-argument leveren, dus deze
+     * vorm leest de grant-hash via de echte `ConfigProvider` in plaats van via de test-lambda.
+     */
+    @Test
+    fun `zonder geconfigureerde system property zet de no-arg constructor geen FSC-headers`() {
+        System.clearProperty(ProfielFscOutwayHeadersFilter.CONFIG_KEY)
+
+        val headers = MultivaluedHashMap<String, Any>()
+
+        ProfielFscOutwayHeadersFilter().filter(mockContext(headers))
+
+        assertFalse(headers.containsKey(FscOutwayHeaders.GRANT_HASH_HEADER))
+        assertFalse(headers.containsKey(FscOutwayHeaders.TRANSACTION_ID_HEADER))
+    }
+
+    @Test
+    fun `met geconfigureerde system property leest de no-arg constructor de grant-hash via ConfigProvider`() {
+        System.setProperty(ProfielFscOutwayHeadersFilter.CONFIG_KEY, "profiel-hash-config-provider")
+
+        val headers = MultivaluedHashMap<String, Any>()
+
+        ProfielFscOutwayHeadersFilter().filter(mockContext(headers))
+
+        assertEquals(listOf("profiel-hash-config-provider"), headers[FscOutwayHeaders.GRANT_HASH_HEADER])
+
+        val uuid = UUID.fromString(headers.getFirst(FscOutwayHeaders.TRANSACTION_ID_HEADER) as String)
+
+        assertEquals(7, uuid.version())
+        assertEquals(2, uuid.variant())
     }
 }

--- a/libraries/fbs-common/src/test/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/UuidV7Test.kt
+++ b/libraries/fbs-common/src/test/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/UuidV7Test.kt
@@ -1,0 +1,57 @@
+package nl.rijksoverheid.moz.fbs.common.fsc
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.Random
+
+class UuidV7Test {
+
+    @Test
+    fun `generate levert version 7 en variant 2 (RFC 4122)`() {
+        val uuid = UuidV7.generate()
+
+        assertEquals(7, uuid.version())
+        assertEquals(2, uuid.variant())
+    }
+
+    @Test
+    fun `twee opeenvolgende aanroepen leveren verschillende waarden`() {
+        val eerste = UuidV7.generate()
+        val tweede = UuidV7.generate()
+
+        assertNotEquals(eerste, tweede)
+    }
+
+    @Test
+    fun `oplopende epochMilli levert lexicografisch niet-dalende waarden (tijd-geordend)`() {
+        val rnd = Random(42)
+
+        val vroeg = UuidV7.generate(epochMilli = 1_000_000L, rnd = rnd)
+        val laat = UuidV7.generate(epochMilli = 2_000_000L, rnd = rnd)
+
+        assertTrue(vroeg.toString() <= laat.toString()) {
+            "verwacht $vroeg <= $laat (tijd-geordend op oplopende epochMilli)"
+        }
+    }
+
+    @Test
+    fun `epochMilli = 0 levert een geldige v7-uuid met tijdstip-deel op nul`() {
+        val uuid = UuidV7.generate(epochMilli = 0L)
+
+        assertEquals(7, uuid.version())
+        assertEquals(2, uuid.variant())
+        assertTrue(uuid.toString().startsWith("00000000-0000-7")) {
+            "verwacht dat het 48-bit tijdstip-deel nul is: $uuid"
+        }
+    }
+
+    @Test
+    fun `deterministische random levert reproduceerbare uuid bij gelijke epochMilli`() {
+        val eerste = UuidV7.generate(epochMilli = 500_000L, rnd = Random(7))
+        val tweede = UuidV7.generate(epochMilli = 500_000L, rnd = Random(7))
+
+        assertEquals(eerste, tweede)
+    }
+}

--- a/libraries/fbs-magazijnregister/src/main/kotlin/nl/rijksoverheid/moz/fbs/magazijnregister/ConfigMagazijnregister.kt
+++ b/libraries/fbs-magazijnregister/src/main/kotlin/nl/rijksoverheid/moz/fbs/magazijnregister/ConfigMagazijnregister.kt
@@ -9,9 +9,10 @@ import nl.rijksoverheid.moz.fbs.common.identificatie.Oin
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
 import java.net.URI
+import java.util.Optional
 
 /**
- * Config-backed [Magazijnregister]: leest `magazijnen."<OIN>".{url,naam}` en
+ * Config-backed [Magazijnregister]: leest `magazijnen."<OIN>".{url,naam,grantHash}` en
  * valideert fail-fast bij opstart — een ongeldige OIN-key, ongeldige of
  * niet-versleutelde URL of een leeg register hoort de boot te blokkeren,
  * niet pas een runtime-fout bij het eerste verkeer te veroorzaken.
@@ -44,7 +45,12 @@ internal class ConfigMagazijnregister(
                 )
             }
 
-            oin to Magazijninschrijving(oin = oin, url = parseUrl(oin, entry.url()), naam = entry.naam().orElse(null))
+            oin to Magazijninschrijving(
+                oin = oin,
+                url = parseUrl(oin, entry.url()),
+                naam = entry.naam().orElse(null),
+                grantHash = parseGrantHash(oin, entry.grantHash()),
+            )
         }
     }
 
@@ -87,5 +93,21 @@ internal class ConfigMagazijnregister(
         OutboundTlsValidator.requireHttps(profile = profile, endpoint = url, configKey = configKey)
 
         return uri
+    }
+
+    /**
+     * Getrimd doorgeven i.p.v. rauw: een grantHash met omringende whitespace
+     * (kopieerfout in de env-var) zou anders stilzwijgend een andere header-
+     * waarde opleveren dan bedoeld, in plaats van fail-fast te falen of exact
+     * te matchen.
+     */
+    private fun parseGrantHash(oin: Oin, grantHash: Optional<String>): String? {
+        val ruw = grantHash.orElse(null) ?: return null
+        val configKey = "magazijnen.\"${oin.waarde}\".grantHash"
+        val getrimd = ruw.trim()
+
+        check(getrimd.isNotBlank()) { "$configKey mag niet leeg of alleen whitespace zijn, was: '$ruw'" }
+
+        return getrimd
     }
 }

--- a/libraries/fbs-magazijnregister/src/main/kotlin/nl/rijksoverheid/moz/fbs/magazijnregister/Magazijnregister.kt
+++ b/libraries/fbs-magazijnregister/src/main/kotlin/nl/rijksoverheid/moz/fbs/magazijnregister/Magazijnregister.kt
@@ -21,10 +21,12 @@ data class Magazijninschrijving(
     val oin: Oin,
     val url: URI,
     val naam: String?,
+    val grantHash: String? = null,
 ) {
     init {
         require(url.scheme == "http" || url.scheme == "https") { "magazijn-URL moet http(s) zijn, was: '$url'" }
         require(url.host != null) { "magazijn-URL moet een host bevatten, was: '$url'" }
+        require(grantHash == null || grantHash.isNotBlank()) { "grantHash mag niet leeg of alleen whitespace zijn" }
     }
 }
 

--- a/libraries/fbs-magazijnregister/src/main/kotlin/nl/rijksoverheid/moz/fbs/magazijnregister/MagazijnregisterConfig.kt
+++ b/libraries/fbs-magazijnregister/src/main/kotlin/nl/rijksoverheid/moz/fbs/magazijnregister/MagazijnregisterConfig.kt
@@ -1,11 +1,12 @@
 package nl.rijksoverheid.moz.fbs.magazijnregister
 
 import io.smallrye.config.ConfigMapping
+import io.smallrye.config.WithName
 import io.smallrye.config.WithParentName
 import java.util.Optional
 
 /**
- * Config-bron van het register: `magazijnen."<OIN>".{url,naam}`. De map-key
+ * Config-bron van het register: `magazijnen."<OIN>".{url,naam,grantHash}`. De map-key
  * ís de afzender-OIN — daarmee is de 1:1-koppeling OIN↔magazijn structureel
  * afgedwongen: een dubbele OIN kan in een properties-map niet bestaan.
  * Key- en URL-validatie gebeurt fail-fast in [ConfigMagazijnregister];
@@ -21,5 +22,15 @@ internal interface MagazijnregisterConfig {
     interface Inschrijving {
         fun url(): String
         fun naam(): Optional<String>
+
+        /**
+         * FSC-grant-hash voor magazijnen achter een FSC-outway. Aanwezig ⇒
+         * uitgaand verkeer stuurt de `Fsc-Grant-Hash`-header mee zodat de
+         * outway kan routeren; afwezig ⇒ ongewijzigd direct verkeer.
+         * `@WithName` voorkomt dat SmallRye's default kebab-case-naamgeving
+         * de camelCase-configkey `grantHash` omzet naar `grant-hash`.
+         */
+        @WithName("grantHash")
+        fun grantHash(): Optional<String>
     }
 }

--- a/libraries/fbs-magazijnregister/src/test/kotlin/nl/rijksoverheid/moz/fbs/magazijnregister/ConfigMagazijnregisterTest.kt
+++ b/libraries/fbs-magazijnregister/src/test/kotlin/nl/rijksoverheid/moz/fbs/magazijnregister/ConfigMagazijnregisterTest.kt
@@ -121,6 +121,57 @@ class ConfigMagazijnregisterTest {
         assertDoesNotThrow { register("prod", oinA to inschrijving("https://magazijn.intern:8443", "Magazijn")) }
     }
 
+    @Test
+    fun `grantHash is null zonder configwaarde`() {
+        val register = register("test", oinA to inschrijving("http://localhost:8081", null))
+
+        assertNull(register.voorOin(Oin(oinA))!!.grantHash)
+    }
+
+    @Test
+    fun `grantHash wordt doorgegeven vanuit config`() {
+        val register = register("test", oinA to inschrijving("http://localhost:8081", null, grantHash = "abc123"))
+
+        assertEquals("abc123", register.voorOin(Oin(oinA))!!.grantHash)
+    }
+
+    @Test
+    fun `meerdere magazijnen waarvan er een grantHash heeft en een niet`() {
+        val register = register(
+            "test",
+            oinA to inschrijving("http://localhost:8081", null, grantHash = "abc123"),
+            oinB to inschrijving("http://localhost:8082", null),
+        )
+
+        assertEquals("abc123", register.voorOin(Oin(oinA))!!.grantHash)
+        assertNull(register.voorOin(Oin(oinB))!!.grantHash)
+    }
+
+    @Test
+    fun `grantHash wordt getrimd`() {
+        val register = register("test", oinA to inschrijving("http://localhost:8081", null, grantHash = "  abc123  "))
+
+        assertEquals("abc123", register.voorOin(Oin(oinA))!!.grantHash)
+    }
+
+    @Test
+    fun `lege grantHash faalt fail-fast met de config-key in de melding`() {
+        val ex = assertThrows<IllegalStateException> {
+            register("test", oinA to inschrijving("http://localhost:8081", null, grantHash = ""))
+        }
+
+        assertTrue(ex.message!!.contains("magazijnen.\"$oinA\".grantHash"))
+    }
+
+    @Test
+    fun `whitespace-only grantHash faalt fail-fast met de config-key in de melding`() {
+        val ex = assertThrows<IllegalStateException> {
+            register("test", oinA to inschrijving("http://localhost:8081", null, grantHash = "   "))
+        }
+
+        assertTrue(ex.message!!.contains("magazijnen.\"$oinA\".grantHash"))
+    }
+
     private fun register(profiel: String, vararg entries: Pair<String, MagazijnregisterConfig.Inschrijving>): Magazijnregister {
         val config = object : MagazijnregisterConfig {
             override fun inschrijvingen(): Map<String, MagazijnregisterConfig.Inschrijving> = mapOf(*entries)
@@ -129,9 +180,10 @@ class ConfigMagazijnregisterTest {
         return ConfigMagazijnregister(config, profiel).apply { init() }
     }
 
-    private fun inschrijving(url: String, naam: String?): MagazijnregisterConfig.Inschrijving =
+    private fun inschrijving(url: String, naam: String?, grantHash: String? = null): MagazijnregisterConfig.Inschrijving =
         object : MagazijnregisterConfig.Inschrijving {
             override fun url(): String = url
             override fun naam(): Optional<String> = Optional.ofNullable(naam)
+            override fun grantHash(): Optional<String> = Optional.ofNullable(grantHash)
         }
 }

--- a/libraries/fbs-magazijnregister/src/test/kotlin/nl/rijksoverheid/moz/fbs/magazijnregister/ConfigMagazijnregisterTest.kt
+++ b/libraries/fbs-magazijnregister/src/test/kotlin/nl/rijksoverheid/moz/fbs/magazijnregister/ConfigMagazijnregisterTest.kt
@@ -1,6 +1,8 @@
 package nl.rijksoverheid.moz.fbs.magazijnregister
 
 import io.quarkus.runtime.StartupEvent
+import io.smallrye.config.PropertiesConfigSource
+import io.smallrye.config.SmallRyeConfigBuilder
 import nl.rijksoverheid.moz.fbs.common.identificatie.Oin
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -170,6 +172,37 @@ class ConfigMagazijnregisterTest {
         }
 
         assertTrue(ex.message!!.contains("magazijnen.\"$oinA\".grantHash"))
+    }
+
+    /**
+     * Boot-regressietest voor `magazijnen."<OIN>".grantHash=${MAGAZIJN_A_GRANT_HASH:}`
+     * (de vorm in productie-config) met de env-var ongezet: SmallRye expandeert dat naar
+     * een lege string die op `Optional.empty()` bindt, dus [ConfigMagazijnregister] mag
+     * hier niet fail-fast falen — het handgebouwde mock-object in [inschrijving] hierboven
+     * omzeilt SmallRye's expressie-expansie en kan dit gedrag niet aantonen; deze test
+     * gaat via een echte `SmallRyeConfigBuilder`-binding om de volledige keten te dekken.
+     */
+    @Test
+    fun `onbeantwoorde grantHash-expressie met lege default boot niet fail-fast`() {
+        val config = SmallRyeConfigBuilder()
+            .addDefaultInterceptors() // activeert SmallRye's `${...}`-expressie-expansie
+            .withMapping(MagazijnregisterConfig::class.java)
+            .withSources(
+                PropertiesConfigSource(
+                    mapOf(
+                        "magazijnen.\"$oinA\".url" to "http://localhost:8081",
+                        "magazijnen.\"$oinA\".grantHash" to "\${MAGAZIJN_A_GRANT_HASH:}",
+                    ),
+                    "test",
+                    100,
+                ),
+            )
+            .build()
+            .getConfigMapping(MagazijnregisterConfig::class.java)
+
+        val register = assertDoesNotThrow { ConfigMagazijnregister(config, "test").apply { init() } }
+
+        assertNull(register.voorOin(Oin(oinA))!!.grantHash)
     }
 
     private fun register(profiel: String, vararg entries: Pair<String, MagazijnregisterConfig.Inschrijving>): Magazijnregister {

--- a/libraries/fbs-magazijnregister/src/test/kotlin/nl/rijksoverheid/moz/fbs/magazijnregister/MagazijninschrijvingTest.kt
+++ b/libraries/fbs-magazijnregister/src/test/kotlin/nl/rijksoverheid/moz/fbs/magazijnregister/MagazijninschrijvingTest.kt
@@ -40,4 +40,32 @@ class MagazijninschrijvingTest {
 
         assertTrue(ex.message!!.contains("host"))
     }
+
+    @Test
+    fun `grantHash is optioneel en niet-blanco waarden zijn construeerbaar`() {
+        assertDoesNotThrow {
+            Magazijninschrijving(oin, URI.create("http://localhost:8081"), naam = null, grantHash = null)
+        }
+        assertDoesNotThrow {
+            Magazijninschrijving(oin, URI.create("http://localhost:8081"), naam = null, grantHash = "abc123")
+        }
+    }
+
+    @Test
+    fun `lege grantHash is niet construeerbaar`() {
+        val ex = assertThrows<IllegalArgumentException> {
+            Magazijninschrijving(oin, URI.create("http://localhost:8081"), naam = null, grantHash = "")
+        }
+
+        assertTrue(ex.message!!.contains("grantHash"))
+    }
+
+    @Test
+    fun `whitespace-only grantHash is niet construeerbaar`() {
+        val ex = assertThrows<IllegalArgumentException> {
+            Magazijninschrijving(oin, URI.create("http://localhost:8081"), naam = null, grantHash = "   ")
+        }
+
+        assertTrue(ex.message!!.contains("grantHash"))
+    }
 }

--- a/libraries/fbs-magazijnregister/src/test/kotlin/nl/rijksoverheid/moz/fbs/magazijnregister/MagazijnregisterConfigMappingTest.kt
+++ b/libraries/fbs-magazijnregister/src/test/kotlin/nl/rijksoverheid/moz/fbs/magazijnregister/MagazijnregisterConfigMappingTest.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test
 
 /**
  * Roundtrip-test van de `@ConfigMapping`-binding zelf: borgt dat de
- * properties-notatie `magazijnen."<OIN>".{url,naam}` daadwerkelijk op de
+ * properties-notatie `magazijnen."<OIN>".{url,naam,grantHash}` daadwerkelijk op de
  * map-onder-prefix landt (en niet stilletjes op een andere structuur na een
  * refactor van de mapping-interface).
  */

--- a/libraries/fbs-magazijnregister/src/test/kotlin/nl/rijksoverheid/moz/fbs/magazijnregister/MagazijnregisterConfigMappingTest.kt
+++ b/libraries/fbs-magazijnregister/src/test/kotlin/nl/rijksoverheid/moz/fbs/magazijnregister/MagazijnregisterConfigMappingTest.kt
@@ -37,6 +37,23 @@ class MagazijnregisterConfigMappingTest {
         assertTrue(mapping.inschrijvingen()[oinA]!!.naam().isEmpty)
     }
 
+    @Test
+    fun `grantHash bindt op de map onder de magazijnen-prefix`() {
+        val mapping = mapping(
+            "magazijnen.\"$oinA\".url" to "http://localhost:8081",
+            "magazijnen.\"$oinA\".grantHash" to "abc123",
+        )
+
+        assertEquals("abc123", mapping.inschrijvingen()[oinA]!!.grantHash().get())
+    }
+
+    @Test
+    fun `grantHash is optioneel in de properties-notatie`() {
+        val mapping = mapping("magazijnen.\"$oinA\".url" to "http://localhost:8081")
+
+        assertTrue(mapping.inschrijvingen()[oinA]!!.grantHash().isEmpty)
+    }
+
     private fun mapping(vararg properties: Pair<String, String>): MagazijnregisterConfig =
         SmallRyeConfigBuilder()
             .withMapping(MagazijnregisterConfig::class.java)

--- a/libraries/fbs-magazijnregister/src/test/kotlin/nl/rijksoverheid/moz/fbs/magazijnregister/MagazijnregisterConfigMappingTest.kt
+++ b/libraries/fbs-magazijnregister/src/test/kotlin/nl/rijksoverheid/moz/fbs/magazijnregister/MagazijnregisterConfigMappingTest.kt
@@ -54,8 +54,44 @@ class MagazijnregisterConfigMappingTest {
         assertTrue(mapping.inschrijvingen()[oinA]!!.grantHash().isEmpty)
     }
 
+    /**
+     * Pint het gedrag van `magazijnen."<OIN>".grantHash=${MAGAZIJN_A_GRANT_HASH:}` in
+     * productie-config wanneer de env-var niet gezet is: SmallRye's expressie-expansie
+     * levert dan een lege string, en die wordt door de `Optional<String>`-binding als
+     * afwezig behandeld (`Optional.empty()`), niet als een aanwezige lege waarde. Deze
+     * asymmetrie is boot-kritisch — [ConfigMagazijnregister] faalt fail-fast op een
+     * *aanwezige* blanco grantHash, dus een stille wijziging in SmallRye's expansie- of
+     * Optional-binding-gedrag zou de boot breken in elke omgeving waar deze env-var
+     * niet gezet is.
+     */
+    @Test
+    fun `onbeantwoorde expressie met lege default levert Optional-empty op, geen aanwezige lege waarde`() {
+        val mapping = mappingMetExpressieExpansie(
+            "magazijnen.\"$oinA\".url" to "http://localhost:8081",
+            "magazijnen.\"$oinA\".grantHash" to "\${MAGAZIJN_A_GRANT_HASH:}",
+        )
+
+        assertTrue(
+            mapping.inschrijvingen()[oinA]!!.grantHash().isEmpty,
+            "een onbeantwoorde expressie met lege default hoort op Optional.empty() te binden, niet op een aanwezige lege string",
+        )
+    }
+
     private fun mapping(vararg properties: Pair<String, String>): MagazijnregisterConfig =
         SmallRyeConfigBuilder()
+            .withMapping(MagazijnregisterConfig::class.java)
+            .withSources(PropertiesConfigSource(mapOf(*properties), "test", 100))
+            .build()
+            .getConfigMapping(MagazijnregisterConfig::class.java)
+
+    /**
+     * Zoals [mapping], maar mét `addDefaultInterceptors()` — nodig om SmallRye's
+     * `${...}`-expressie-expansie te activeren, zodat deze test de echte
+     * expansiestap doorloopt in plaats van de rauwe `${...}`-string te binden.
+     */
+    private fun mappingMetExpressieExpansie(vararg properties: Pair<String, String>): MagazijnregisterConfig =
+        SmallRyeConfigBuilder()
+            .addDefaultInterceptors()
             .withMapping(MagazijnregisterConfig::class.java)
             .withSources(PropertiesConfigSource(mapOf(*properties), "test", 100))
             .build()

--- a/services/berichtenmagazijn/src/main/resources/application.properties
+++ b/services/berichtenmagazijn/src/main/resources/application.properties
@@ -206,6 +206,12 @@ quarkus.rest-client.profiel-service.connection-pool-size=20
 quarkus.rest-client.profiel-service.connection-ttl=300
 quarkus.rest-client.profiel-service.keep-alive-enabled=true
 
+# FSC-outway-routering naar de Profiel-service. Met een grant-hash stuurt de client
+# Fsc-Grant-Hash + Fsc-Transaction-Id mee en kiest de outway daarop de doel-inway; leeg
+# betekent een directe call zonder FSC-headers. Eigen prefix (niet onder
+# quarkus.rest-client.*): die namespace is van Quarkus zelf.
+profiel-service.grant-hash=${PROFIEL_SERVICE_GRANT_HASH:}
+
 # @Retry-tuning per omgeving (MP Fault Tolerance config-override).
 # Dev/test: jitter=0 voor deterministisch test-gedrag. Prod/staging/acceptatie:
 # jitter > 0 spreidt retry-pieken bij upstream-storm (thundering-herd-protection).

--- a/services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/ApplicationPropertiesTest.kt
+++ b/services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/ApplicationPropertiesTest.kt
@@ -1,0 +1,30 @@
+package nl.rijksoverheid.moz.fbs.berichtenmagazijn
+
+import nl.rijksoverheid.moz.fbs.common.fsc.ProfielFscOutwayHeadersFilter
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.util.Properties
+
+/**
+ * Pint dat `application.properties` de FSC-grant-hash-configsleutel van
+ * [ProfielFscOutwayHeadersFilter] daadwerkelijk bevat, in de expressie-vorm die de
+ * env-var optioneel maakt. Zonder deze regel schakelt de filter stilzwijgend uit —
+ * geen `Fsc-Grant-Hash`-header, en de outway antwoordt "service not found" — zonder
+ * dat een bestaande test dat opmerkt. Bewust géén `@QuarkusTest`: dit leest het
+ * bestand rechtstreeks van disk, zodat de test ook zonder Docker draait.
+ */
+class ApplicationPropertiesTest {
+
+    @Test
+    fun `profiel-service grant-hash-configsleutel staat in application-properties met env-var-expansie`() {
+        val properties = Properties().apply {
+            File("src/main/resources/application.properties").inputStream().use { load(it) }
+        }
+
+        assertEquals(
+            "\${PROFIEL_SERVICE_GRANT_HASH:}",
+            properties.getProperty(ProfielFscOutwayHeadersFilter.CONFIG_KEY),
+        )
+    }
+}

--- a/services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/validatie/ProfielFscOutwayHeadersWireMockTest.kt
+++ b/services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/validatie/ProfielFscOutwayHeadersWireMockTest.kt
@@ -1,0 +1,82 @@
+package nl.rijksoverheid.moz.fbs.berichtenmagazijn.validatie
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.matching
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import jakarta.inject.Inject
+import nl.rijksoverheid.moz.fbs.common.profiel.ProfielServiceClient
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Bewijst dat de FSC-outway-headers op de échte, door CDI gebouwde Profiel-client staan —
+ * niet alleen dat de filter-logica klopt (dat dekt ProfielFscOutwayHeadersFilterTest).
+ * Het negatieve geval staat in ProfielServiceClientWireMockTest, dat zonder grant-hash draait.
+ */
+@QuarkusTest
+@TestProfile(ProfielFscGrantHashTestProfile::class)
+@QuarkusTestResource(WireMockProfielServiceResource::class)
+class ProfielFscOutwayHeadersWireMockTest {
+
+    @Inject
+    @RestClient
+    lateinit var client: ProfielServiceClient
+
+    private val wireMock get() = WireMockProfielServiceResource.server!!
+
+    @BeforeEach
+    fun resetStubs() {
+        wireMock.resetAll()
+    }
+
+    @Test
+    fun `met grant-hash draagt de Profiel-call Fsc-Grant-Hash en een v7 Fsc-Transaction-Id`() {
+        wireMock.stubFor(
+            get(urlEqualTo(PROFIEL_PAD)).willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("""{"voorkeuren":[]}""")
+            )
+        )
+
+        client.getPartij("BSN", "999993653")
+
+        wireMock.verify(
+            getRequestedFor(urlEqualTo(PROFIEL_PAD))
+                .withHeader("Fsc-Grant-Hash", equalTo(ProfielFscGrantHashTestProfile.GRANT_HASH))
+                .withHeader("Fsc-Transaction-Id", matching(UUID_V7_REGEX))
+        )
+    }
+
+    companion object {
+        const val PROFIEL_PAD = "/api/profielservice/v1/BSN/999993653"
+
+        // De version-nibble "7" wordt expliciet gepind: de outway wijst v4 af, dus een
+        // test die alleen "is een UUID" controleert vangt precies die fout niet.
+        const val UUID_V7_REGEX =
+            "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-7[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}"
+    }
+}
+
+class ProfielFscGrantHashTestProfile : QuarkusTestProfile {
+
+    override fun getConfigOverrides(): Map<String, String> = mapOf(
+        // Sluit de @Mock-bean uit zodat de échte REST-client (mét de geregistreerde filter)
+        // wordt geïnjecteerd en het HTTP-pad onder test komt.
+        "quarkus.arc.exclude-types" to MockProfielServiceClient::class.java.name,
+        "profiel-service.grant-hash" to GRANT_HASH,
+    )
+
+    companion object {
+        const val GRANT_HASH = "profiel-grant-hash-test"
+    }
+}

--- a/services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/validatie/ProfielServiceClientWireMockTest.kt
+++ b/services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/validatie/ProfielServiceClientWireMockTest.kt
@@ -3,6 +3,7 @@ package nl.rijksoverheid.moz.fbs.berichtenmagazijn.validatie
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import io.quarkus.test.common.QuarkusTestResource
@@ -192,6 +193,26 @@ class ProfielServiceClientWireMockTest {
         // hierboven is de echte assert: als de client-implementatie spaties of
         // path-segmenten zou veranderen, kwam er hier een 404 terug en zou de call
         // met NotFoundException falen.
+    }
+
+    @Test
+    fun `zonder grant-hash draagt de Profiel-call geen FSC-outway-headers`() {
+        wireMock.stubFor(
+            get(urlEqualTo("/api/profielservice/v1/BSN/999993653")).willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("""{"voorkeuren":[]}""")
+            )
+        )
+
+        client.getPartij("BSN", "999993653")
+
+        wireMock.verify(
+            getRequestedFor(urlEqualTo("/api/profielservice/v1/BSN/999993653"))
+                .withoutHeader("Fsc-Grant-Hash")
+                .withoutHeader("Fsc-Transaction-Id")
+        )
     }
 }
 

--- a/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/MagazijnRouter.kt
+++ b/services/berichtenuitvraag/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/MagazijnRouter.kt
@@ -3,6 +3,7 @@ package nl.rijksoverheid.moz.fbs.berichtenuitvraag.uitvraag
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.ws.rs.WebApplicationException
 import jakarta.ws.rs.core.Response
+import nl.rijksoverheid.moz.fbs.common.fsc.FscOutwayHeadersFilter
 import nl.rijksoverheid.moz.fbs.common.identificatie.Oin
 import nl.rijksoverheid.moz.fbs.magazijnregister.Magazijninschrijving
 import nl.rijksoverheid.moz.fbs.magazijnregister.Magazijnregister
@@ -46,11 +47,14 @@ class MagazijnRouter(
             // LinkageError) moeten omhoog propageren naar het JVM-vangnet, niet als
             // upstream-storing gemaskeerd worden.
             try {
-                RestClientBuilder.newBuilder()
+                val builder = RestClientBuilder.newBuilder()
                     .baseUri(inschrijving.url)
                     .connectTimeout(config.connectTimeout().toMillis(), TimeUnit.MILLISECONDS)
                     .readTimeout(config.readTimeout().toMillis(), TimeUnit.MILLISECONDS)
-                    .build(MagazijnClient::class.java)
+
+                fscFilterVoor(inschrijving)?.let { builder.register(it) }
+
+                builder.build(MagazijnClient::class.java)
             } catch (e: Exception) {
                 log.errorf(e, "Magazijn-routering: kon REST-client niet bouwen voor magazijnId=%s url=%s", id, inschrijving.url)
 
@@ -84,7 +88,14 @@ class MagazijnRouter(
         }
     }
 
-    private companion object {
+    companion object {
         private val log: Logger = Logger.getLogger(MagazijnRouter::class.java)
+
+        // Losgetrokken van forMagazijn() zodat de registratie-beslissing unit-testbaar is
+        // zonder de RestClientBuilder (die buiten CDI-context een proxy-klasse genereert).
+        // Niet elk magazijn draait al achter een FSC-outway; grantHash blijft optioneel
+        // totdat de volledige federatie is overgestapt.
+        internal fun fscFilterVoor(inschrijving: Magazijninschrijving): FscOutwayHeadersFilter? =
+            inschrijving.grantHash?.let { FscOutwayHeadersFilter(it) }
     }
 }

--- a/services/berichtenuitvraag/src/main/resources/application.properties
+++ b/services/berichtenuitvraag/src/main/resources/application.properties
@@ -113,6 +113,10 @@ berichtensessiecache.startup-redisearch-timeout-seconds=5
 # https:// af buiten dev/test (BIO 13.2.1) en valideert keys/URLs fail-fast.
 magazijnen."00000001003214345000".url=${MAGAZIJN_A_URL}
 magazijnen."00000001003214345000".naam=Magazijn A
+# FSC-outway-routering: aanwezig → Fsc-Grant-Hash/-Transaction-Id op elke call naar dit
+# magazijn (zie FscOutwayHeadersFilter); lege default (geen env-var) → geen header, magazijn
+# blijft direct/zonder outway bereikbaar. Magazijn B heeft nog geen outway-contract.
+magazijnen."00000001003214345000".grantHash=${MAGAZIJN_A_GRANT_HASH:}
 magazijnen."00000001823288444000".url=${MAGAZIJN_B_URL}
 magazijnen."00000001823288444000".naam=Magazijn B
 %test.magazijnen."00000001003214345000".url=http://localhost:8081

--- a/services/berichtenuitvraag/src/main/resources/application.properties
+++ b/services/berichtenuitvraag/src/main/resources/application.properties
@@ -172,6 +172,12 @@ quarkus.rest-client.profiel-service.connection-pool-size=20
 quarkus.rest-client.profiel-service.connection-ttl=300
 quarkus.rest-client.profiel-service.keep-alive-enabled=true
 
+# FSC-outway-routering naar de Profiel-service. Met een grant-hash stuurt de client
+# Fsc-Grant-Hash + Fsc-Transaction-Id mee en kiest de outway daarop de doel-inway; leeg
+# betekent een directe call zonder FSC-headers. Eigen prefix (niet onder
+# quarkus.rest-client.*): die namespace is van Quarkus zelf.
+profiel-service.grant-hash=${PROFIEL_SERVICE_GRANT_HASH:}
+
 # @Retry-tuning per omgeving (MP Fault Tolerance config-override).
 # Dev/test: jitter=0 voor deterministisch test-gedrag (geen flakiness in retry-timing-asserties).
 # Prod/staging/acceptatie: jitter > 0 spreidt retry-pieken bij upstream-storm

--- a/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/ApplicationPropertiesTest.kt
+++ b/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/ApplicationPropertiesTest.kt
@@ -1,0 +1,30 @@
+package nl.rijksoverheid.moz.fbs.berichtenuitvraag
+
+import nl.rijksoverheid.moz.fbs.common.fsc.ProfielFscOutwayHeadersFilter
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.util.Properties
+
+/**
+ * Pint dat `application.properties` de FSC-grant-hash-configsleutel van
+ * [ProfielFscOutwayHeadersFilter] daadwerkelijk bevat, in de expressie-vorm die de
+ * env-var optioneel maakt. Zonder deze regel schakelt de filter stilzwijgend uit —
+ * geen `Fsc-Grant-Hash`-header, en de outway antwoordt "service not found" — zonder
+ * dat een bestaande test dat opmerkt. Bewust géén `@QuarkusTest`: dit leest het
+ * bestand rechtstreeks van disk, zodat de test ook zonder Docker draait.
+ */
+class ApplicationPropertiesTest {
+
+    @Test
+    fun `profiel-service grant-hash-configsleutel staat in application-properties met env-var-expansie`() {
+        val properties = Properties().apply {
+            File("src/main/resources/application.properties").inputStream().use { load(it) }
+        }
+
+        assertEquals(
+            "\${PROFIEL_SERVICE_GRANT_HASH:}",
+            properties.getProperty(ProfielFscOutwayHeadersFilter.CONFIG_KEY),
+        )
+    }
+}

--- a/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/MagazijnRouterFscFilterTest.kt
+++ b/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/uitvraag/MagazijnRouterFscFilterTest.kt
@@ -1,0 +1,36 @@
+package nl.rijksoverheid.moz.fbs.berichtenuitvraag.uitvraag
+
+import nl.rijksoverheid.moz.fbs.common.identificatie.Oin
+import nl.rijksoverheid.moz.fbs.magazijnregister.Magazijninschrijving
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.net.URI
+
+/**
+ * Dekt alleen de registratie-beslissing (`fscFilterVoor`), niet `forMagazijn` zelf: die
+ * bouwt via `RestClientBuilder`, wat buiten CDI-context een proxy-klasse genereert.
+ */
+class MagazijnRouterFscFilterTest {
+
+    private fun inschrijving(grantHash: String?): Magazijninschrijving = Magazijninschrijving(
+        oin = Oin("00000001003214345000"),
+        url = URI.create("http://localhost:8081"),
+        naam = null,
+        grantHash = grantHash,
+    )
+
+    @Test
+    fun `grantHash aanwezig levert een FscOutwayHeadersFilter`() {
+        val filter = MagazijnRouter.fscFilterVoor(inschrijving(grantHash = "abc123"))
+
+        assertNotNull(filter)
+    }
+
+    @Test
+    fun `grantHash afwezig levert geen filter`() {
+        val filter = MagazijnRouter.fscFilterVoor(inschrijving(grantHash = null))
+
+        assertNull(filter)
+    }
+}


### PR DESCRIPTION
## Wat

FSC-outway-routering voor uitgaande calls, in twee delen op één branch.

**Deel 1 — magazijnen** (`MinBZK/MijnOverheidZakelijk#552`): berichtenuitvraag laat magazijn-a via de FSC-outway lopen door `Fsc-Grant-Hash` + een UUID-v7 `Fsc-Transaction-Id` mee te sturen.

**Deel 2 — Profiel-service** (`MinBZK/MijnOverheidZakelijk#730`): dezelfde routering voor de Profiel-service, zodat naast de URL ook een grant-hash configureerbaar is.

## Ontwerpkeuzes

**Magazijnen**
- Grant-hash uit statische config (`magazijnen."<OIN>".grantHash`, optioneel/env-var).
- `Fsc-Transaction-Id` zelf als UUID v7 genereren en meesturen.
- Headers alleen als `grantHash` gezet is; direct-magazijnen ongewijzigd.
- `grantHash` op `Magazijninschrijving` (register-lib); filter + v7-util in `fbs-common`; geregistreerd in beide client-bouwplekken (sessiecache-factory + `MagazijnRouter`).

**Profiel-service**
- `ProfielServiceClient` is een *declaratieve* `@RegisterRestClient`-interface — er is geen builder om een filter op te registreren zoals bij de magazijn-clients, en de client-bean draagt de MP-Fault-Tolerance-`@Retry` op `getPartij`. Een programmatisch gebouwde client zou die interceptor verliezen.
- Daarom: `@RegisterProvider` op de interface in `fbs-common`, met een filter die zijn grant-hash zelf uit config leest (`profiel-service.grant-hash`, env `PROFIEL_SERVICE_GRANT_HASH`). Eén registratieplek voor beide consumers, dus de services kunnen niet driften.
- Leeg/afwezig/whitespace = géén enkele FSC-header = ongewijzigd gedrag. De filter zit in de chain van elke Profiel-call in beide services; de bestaande suites bewijzen dat de no-op echt een no-op is.
- Header-contract (headernamen + v7-eis) staat op één plek (`FscOutwayHeaders`); magazijn- en profiel-filter zijn dunne wrappers.

## Scope t.o.v. `MinBZK/MijnOverheidZakelijk#730`

Deze PR implementeert dat ticket **niet volledig** — dat is bewust en het is goed om het expliciet te hebben.

#730 gaat primair over het opzetten van `profiel` als provider/inway-peer in de FSC-mesh: peer met eigen OIN en test-CA-cert, announce bij de directory, dienstpublicatie via ServicePublicationGrant, contract consumer→profiel, en lokaal bewijs via `deploy/local/`. Dat werk zit grotendeels buiten deze repo en staat hier nog open.

Wat deze PR levert is de FBS-kant die dat mogelijk maakt. Eén kanttekening daarbij: #730 omschrijft de FBS-kant als "config-only, #726-patroon". Dat blijkt niet houdbaar. De OpenFSC-outway kiest de doel-inway op de `Fsc-Grant-Hash`-header en niet op het pad, dus een URL-flip alleen levert "service not found" — precies wat bij de magazijnen al bleek (zie `docs/plans/2026-07-17-fsc-outway-grant-hash-header.md`). Bij de magazijnen kon de header via de programmatisch gebouwde client; bij de declaratieve Profiel-client was nieuwe code onvermijdelijk.

Gevolg: de grant-hash-config is nu aanwezig maar nog niet invulbaar — er is nog geen contract met een profiel-inway, dus geen hash. Leeg is het huidige, directe gedrag, dus dit is veilig te mergen en levert waarde zodra de peer er staat.

## Verificatie

- `libraries/fbs-common`: volledige suite groen (211 tests), JaCoCo-gate gehaald, detekt 0 bevindingen.
- Beide services compileren; `test-compile` schoon in alle geraakte modules.
- **Nog niet uitgevoerd:** de `@QuarkusTest`/Testcontainers-suites van sessiecache, uitvraag en magazijn — inclusief de vier nieuwe WireMock-integratietests die de FSC-headers op de wire pinnen. Die zijn hier alleen gecompileerd; de CI-run op deze PR is hun eerste echte uitvoering.

## Reviewaandacht

Twee bevindingen uit de eindreview die de moeite waard zijn om na te lopen:

- `FscOutwayHeaders` logde aanvankelijk het volledige request-URI. Onschuldig voor magazijn-calls, maar de Profiel-service zet de BSN ín het pad, en de DEBUG-categorie staat in `%dev`/`%test` aan — dat schreef dus BSN's naar de applicatielog. Nu wordt alleen de host gelogd (`fix(common): geen upstream-URI met BSN in de FSC-debuglog`).
- De nieuwe config-regel in beide `application.properties` was door geen enkele test gepind: weghalen of vertypen liet de suite groen en de feature stil dood. Er staat nu per service een test die de regel aan de `CONFIG_KEY`-constante koppelt.

## Plannen

- `docs/plans/2026-07-17-fsc-outway-grant-hash-header.md` (magazijnen)
- `docs/plans/2026-07-21-fsc-outway-grant-hash-profielservice.md` (ontwerp Profiel)
- `docs/plans/2026-07-21-fsc-outway-grant-hash-profielservice-implementatie.md` (implementatieplan Profiel)
