### PR TITLE
Demo-platform: ontwerp + fase 0 (containerisatie)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,34 @@ De vroegere losse berichtensessiecache-service is opgegaan in `berichtenuitvraag
 als in-process library (`libraries/fbs-berichtensessiecache`) met Redis als
 gedeelde backing store.
 
+## Demo-stack (alles in containers)
+
+Voor demonstraties draait de volledige keten in containers, zodat opstarten één commando
+is. Bouw eerst de images met jib — opnieuw nodig na elke codewijziging:
+
+```bash
+./mvnw clean package -DskipTests \
+  -pl services/berichtenmagazijn,services/berichtenuitvraag -am \
+  -Dquarkus.container-image.build=true \
+  -Dquarkus.container-image.group=fbs-demo \
+  -Dquarkus.container-image.tag=demo
+```
+
+Start daarna de stack en controleer de keten:
+
+```bash
+docker compose --profile demo up -d   # alles in containers
+./demo/smoke.sh                       # rookproef: aanleveren + ophalen
+```
+
+Zónder `--profile demo` start compose alleen de infrastructuur (Redis, Postgres, WireMock,
+ClickHouse). Gebruik die modus tijdens het ontwikkelen en draai de services met
+`quarkus:dev` zoals hierboven — in een container kost elke codewijziging een image-build.
+
+De poorten zijn in beide modi gelijk (8090, 8091, 8086), dus de Bruno-collectie en de
+omgeving `lokaal` werken ongewijzigd. Draai niet beide modi tegelijk: dat geeft een
+poortconflict.
+
 ### Tests draaien
 
 ```bash

--- a/compose.yaml
+++ b/compose.yaml
@@ -110,6 +110,80 @@ services:
       timeout: 3s
       retries: 5
 
+  # Demo-stack: alleen actief met `--profile demo`. Zonder profiel start compose de infra
+  # en draai je de services met `quarkus:dev` (hot reload behouden; in een container kost
+  # elke codewijziging een image-build). QUARKUS_PROFILE=dev is bewust: OutboundTlsValidator
+  # staat plaintext http alleen toe in dev en test, en de stubs spreken geen https.
+  #
+  # Images bouwen met jib (geen Dockerfile):
+  #   ./mvnw clean package -DskipTests \
+  #     -pl services/berichtenmagazijn,services/berichtenuitvraag -am \
+  #     -Dquarkus.container-image.build=true \
+  #     -Dquarkus.container-image.group=fbs-demo -Dquarkus.container-image.tag=demo
+  #
+  # QUARKUS_HTTP_HOST staat expliciet op 0.0.0.0: in NORMAL launch mode is dat al de
+  # default, maar Quarkus bindt in dev *mode* op localhost. Bij de combinatie "profiel
+  # dev, launch mode normal" sluit dit die twijfel uit — bindt de service op localhost,
+  # dan is de gepubliceerde poort dood.
+  berichtenmagazijn-a:
+    image: fbs-demo/fbs-berichtenmagazijn:demo
+    profiles: [demo]
+    ports:
+      - "8090:8090"
+    depends_on:
+      postgres-a:
+        condition: service_healthy
+    environment:
+      QUARKUS_PROFILE: dev
+      QUARKUS_HTTP_HOST: 0.0.0.0
+      DB_JDBC_URL: jdbc:postgresql://postgres-a:5432/berichtenmagazijn
+      MAGAZIJN_OIN: "00000001003214345000"
+      AANMELD_URL: http://aanmeld-stub:8080/events
+      NOTIFICATIE_URL: http://notificatie-stub:8080/events
+      PROFIEL_SERVICE_URL: http://profiel-service:8080
+      LDV_CLICKHOUSE_ENDPOINT: http://clickhouse:8123
+
+  # Beide magazijn-containers luisteren intern op 8090; alleen de gepubliceerde poort
+  # verschilt. MAGAZIJN_B_URL wijst daarom naar berichtenmagazijn-b:8090, niet naar 8091.
+  berichtenmagazijn-b:
+    image: fbs-demo/fbs-berichtenmagazijn:demo
+    profiles: [demo]
+    ports:
+      - "8091:8090"
+    depends_on:
+      postgres-b:
+        condition: service_healthy
+    environment:
+      QUARKUS_PROFILE: dev
+      QUARKUS_HTTP_HOST: 0.0.0.0
+      DB_JDBC_URL: jdbc:postgresql://postgres-b:5432/berichtenmagazijn
+      MAGAZIJN_OIN: "00000001823288444000"
+      AANMELD_URL: http://aanmeld-stub:8080/events
+      NOTIFICATIE_URL: http://notificatie-stub:8080/events
+      PROFIEL_SERVICE_URL: http://profiel-service:8080
+      LDV_CLICKHOUSE_ENDPOINT: http://clickhouse:8123
+
+  berichtenuitvraag:
+    image: fbs-demo/fbs-berichtenuitvraag:demo
+    profiles: [demo]
+    ports:
+      - "8086:8086"
+    depends_on:
+      redis:
+        condition: service_healthy
+      berichtenmagazijn-a:
+        condition: service_started
+      berichtenmagazijn-b:
+        condition: service_started
+    environment:
+      QUARKUS_PROFILE: dev
+      QUARKUS_HTTP_HOST: 0.0.0.0
+      REDIS_HOSTS: redis://redis:6379
+      MAGAZIJN_A_URL: http://berichtenmagazijn-a:8090
+      MAGAZIJN_B_URL: http://berichtenmagazijn-b:8090
+      PROFIEL_SERVICE_URL: http://profiel-service:8080
+      LDV_CLICKHOUSE_ENDPOINT: http://clickhouse:8123
+
 volumes:
   postgres-data-a:
   postgres-data-b:

--- a/demo/smoke.sh
+++ b/demo/smoke.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Rookproef voor de demo-stack: levert een bericht aan bij magazijn A en controleert dat
+# het via de uitvraag terugkomt. Health-endpoints bewijzen alleen dat processen leven;
+# deze proef rijdt de keten door.
+#
+# Vereist een draaiende stack:  docker compose --profile demo up -d
+set -euo pipefail
+
+MAGAZIJN_A="${MAGAZIJN_A:-http://localhost:8090}"
+UITVRAAG="${UITVRAAG:-http://localhost:8086}"
+BSN="${BSN:-999993653}"
+ONTVANGER="BSN:$BSN"
+
+# Afzender-OIN vast op het test-OIN: de profiel-stub geeft daarvoor een actieve
+# OntvangViaBerichtenbox-voorkeur. Wijk hier niet van af zonder de mapping in
+# wiremock/externe-stubs/mappings/ mee te veranderen, anders volgt een 403.
+AFZENDER_OIN="${AFZENDER_OIN:-00000001003214345000}"
+
+echo "1/3 health"
+for url in "$MAGAZIJN_A" "$UITVRAAG"; do
+    curl -sf "$url/q/health/ready" > /dev/null \
+        || { echo "FOUT: $url niet gezond"; exit 1; }
+done
+
+echo "2/3 bericht aanleveren"
+# Het magazijn kent het berichtId zelf toe; de aanlever-request bevat er geen. We
+# herkennen ons bericht daarom aan een uniek onderwerp.
+onderwerp="Rookproef demo-stack $(date +%s)"
+status=$(curl -s -o /tmp/smoke-aanlever.json -w '%{http_code}' \
+    -X POST "$MAGAZIJN_A/api/v1/berichten" \
+    -H 'Content-Type: application/json' \
+    -d "{
+          \"afzender\": \"$AFZENDER_OIN\",
+          \"ontvanger\": {\"type\": \"BSN\", \"waarde\": \"$BSN\"},
+          \"onderwerp\": \"$onderwerp\",
+          \"inhoud\": \"Aangemaakt door demo/smoke.sh\"
+        }")
+
+if [[ "$status" != "201" ]]; then
+    echo "FOUT: aanleveren gaf HTTP $status (verwacht 201)"
+    cat /tmp/smoke-aanlever.json
+    exit 1
+fi
+
+bericht_id=$(grep -o '"berichtId"[[:space:]]*:[[:space:]]*"[^"]*"' /tmp/smoke-aanlever.json \
+    | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+echo "    magazijn kende berichtId $bericht_id toe"
+
+echo "3/3 ophalen via uitvraag"
+# De sessiecache vult zich pas na een ophaal-ronde; GET /berichten leest alleen de cache.
+curl -sf -N --max-time 30 "$UITVRAAG/api/v1/berichten/_ophalen" \
+    -H "X-Ontvanger: $ONTVANGER" > /dev/null
+
+curl -sf "$UITVRAAG/api/v1/berichten" -H "X-Ontvanger: $ONTVANGER" \
+    | grep -q "$onderwerp" \
+    || { echo "FOUT: '$onderwerp' niet gevonden in de uitvraag"; exit 1; }
+
+echo "OK: keten werkt end-to-end"

--- a/docs/plans/2026-07-21-demo-platform-design.md
+++ b/docs/plans/2026-07-21-demo-platform-design.md
@@ -1,0 +1,294 @@
+**Status:** Concept
+
+# Demo-platform PoC Berichtenbox — ontwerp
+
+Doel: de PoC demonstreerbaar maken voor Product Owner en stakeholders — zowel de
+ondernemer-flows in een Berichtenbox-UI als de technische degradatie-scenario's
+van het stelsel.
+
+## Context
+
+De PoC heeft vandaag geen manier om zichzelf te tonen. `docs/architecture/workspace-docs/03-poc-afwijkingen.md`
+stelt vast: "Er is geen browser-/portaal-laag." Daarnaast ontbreekt demo-datamanagement
+(legen/vullen) en is er geen manier om storingen op te wekken zonder handmatig
+containers te stoppen.
+
+Dit ontwerp voegt één wegwerp-module toe (`services/demo-console`) plus Toxiproxy in
+de compose-stack. **De bestaande services krijgen geen demo-logica in hun gedragspad.**
+
+### Uitgangspunten (vastgesteld in overleg)
+
+| Vraag | Keuze |
+|---|---|
+| UI-laag | Wegwerp demo-UI; geen NL Design System, geen productiekwaliteit |
+| Aanleiding | Demo aan PO/stakeholders — happy flow eerst, degradatie daarna |
+| Omgeving | Lokaal (docker compose), niet ZAD |
+| Magazijnen | 2 echt (bestaand) + 15 lichtgewicht stubs in één WireMock-container |
+| Bediening | Klikbaar bedieningspaneel, bediend door de ontwikkelaar |
+| Kwaliteitsgates | `demo-console` valt buiten de 90%-JaCoCo-gate |
+
+## Architectuur
+
+```
+browser
+  └─> demo-console (nieuwe Quarkus-module, :8095)
+        ├── / .............. wegwerp-Berichtenbox-UI
+        ├── /console ....... bedieningspaneel
+        └── /api/demo/* .... seed / reset / scenario's
+              │
+              ├─> berichtenuitvraag (:8086) ..... berichten ophalen/tonen
+              ├─> berichtenmagazijn a/b ......... aanleveren
+              ├─> Postgres a/b (JDBC) ........... legen
+              ├─> Toxiproxy admin (:8474) ....... storingen op echte componenten
+              └─> WireMock admin ................ storingen op stub-magazijnen
+```
+
+Toxiproxy komt tussen `berichtenuitvraag` en zijn afhankelijkheden. Dat is puur een
+config-wijziging: in `%dev` is elke afhankelijkheid al een losse URL of host.
+
+| Afhankelijkheid | Nu (`%dev`) | Straks (via Toxiproxy) |
+|---|---|---|
+| Magazijn A / B | `localhost:8090` / `:8091` | `localhost:18090` / `:18091` |
+| Redis | `redis://localhost:6379` | `redis://localhost:16379` |
+| Profielservice | `localhost:8089` | `localhost:18089` |
+| Aanmeld-stub | `localhost:8083` | `localhost:18083` |
+| Notificatie-stub | `localhost:8084` | `localhost:18084` |
+
+### Containerisatie en het TLS-obstakel
+
+De demo draait volledig in containers, zodat opstarten tijdens een sessie één commando is.
+
+`OutboundTlsValidator` (`libraries/fbs-common`) staat `http://` alleen toe in de profielen
+`dev` en `test`:
+
+```kotlin
+private val PROFIELEN_ZONDER_TLS_EIS = setOf("dev", "test")
+```
+
+Een nieuw `%demo`-profiel zou dus https eisen op elke magazijn-URL en elke stub. Dat
+betekent zelfondertekende certificaten in de demo-stack — fragiel, en de validator
+uitzetten is een security-regressie omwille van een demo.
+
+**Besluit:** containers draaien óók met `QUARKUS_PROFILE=dev`; alleen de URL's worden
+via omgevingsvariabelen overschreven. De `%dev`-regels krijgen daarvoor een env-var
+met default:
+
+```properties
+%dev.magazijnen."00000001003214345000".url=${MAGAZIJN_A_URL:http://localhost:8090}
+%dev.quarkus.redis.hosts=${REDIS_HOSTS:redis://localhost:6379}
+```
+
+Buiten containers verandert er niets (de default grijpt). `%test` en `%prod` blijven
+ongemoeid, dus testsuite en ZAD merken hier niets van.
+
+### Twee compose-profielen
+
+In een container is Quarkus' hot reload weg; elke codewijziging wordt dan een image-build.
+Daarom twee modi met dezelfde Toxiproxy en dezelfde stub-mappings:
+
+| Commando | Wat draait | Wanneer |
+|---|---|---|
+| `docker compose up -d` | Infra: Redis, Postgres, WireMock, Toxiproxy | **Bouwen** — services in `quarkus:dev` |
+| `docker compose --profile demo up -d` | Alles, inclusief services en demo-console | **Demo** |
+
+Images via jib — `quarkus-container-image-jib` zit al in beide service-POM's met
+`quarkus.container-image.name` ingevuld. De demo-console krijgt dezelfde dependency.
+Geen Dockerfiles nodig.
+
+## Demo-datamanagement
+
+### Legen — JDBC-truncate vanuit de demo-console
+
+De magazijn-API kent alleen soft-delete; dat is opzettelijk (zie `CLAUDE.md`, sectie
+Database & migraties) en geeft geen schone lei voor een volgende demo. De demo-console
+verbindt daarom direct met beide Postgres-databases:
+
+```sql
+TRUNCATE berichten, bijlagen, bericht_status, publicatie_deliveries
+  RESTART IDENTITY CASCADE;
+```
+
+**Waarom niet een reset-endpoint in `berichtenmagazijn`:** een `DELETE /alles` in
+productiecode is een voetkanon dat nooit meer weggaat. De demo-console is wegwerp en
+mag deze kennis dragen.
+
+### Basisvulling — via de echte aanlever-API
+
+Vaste dataset in `demo/dataset/basis.json` (~40 berichten over beide magazijnen), die
+via `POST /berichten` naar binnen gaat. Trager dan `INSERT`, maar loopt door echte
+validatie, de publicatie-outbox en de notificatieketen — het vullen demonstreert de
+keten dus al.
+
+Herkenbare afzenders (Belastingdienst, KVK, RVO, UWV) en een gespreid
+`publicatietijdstip`, zodat sorteren en filteren in de UI betekenis hebben.
+
+**Vaste bericht-ID's** in de dataset. Dat maakt demo's herhaalbaar en reduceert het
+ontdubbelingsscenario tot één knop. Gevolg: twee keer vullen zonder legen levert
+terecht ontdubbeling op.
+
+### Random berichten — dezelfde weg, met generator
+
+Eén knop die N random berichten aanlevert. Dit is tegelijk het scenario "tijdens zijn
+ingelogde sessie komen er nieuwe berichten beschikbaar": je klikt tijdens de demo, en
+de UI toont ze — of juist niet, omdat de sessiecache ze nog niet heeft. Dat laatste is
+het gedrag dat uitgelegd moet worden.
+
+De generator respecteert bestaande invarianten: elfproef-geldige BSN/RSIN via `Bsn`/`Rsin`
+uit `fbs-common`, en ruim onder `Bericht.MAX_INHOUD_BYTES`.
+
+## Berichtenbox-UI
+
+| UI-eis | Status backend | Aanpak |
+|---|---|---|
+| Zoeken | `GET /berichten/_zoeken` bestaat | Direct gebruiken |
+| Verwijderen | `DELETE /berichten/{id}` bestaat | Direct gebruiken |
+| Gelezen/ongelezen | `PATCH` met `status` | Direct gebruiken |
+| Bijlage-indicatie | `aantalBijlagen` in samenvatting | Direct gebruiken |
+| Eigen map aanmaken | `map` is vrij tekstveld (max 128) | UI houdt mappenlijst bij |
+| Archiveren | Bestaat niet | Gereserveerde mapnaam `Archief` |
+| Sorteren | Geen sorteerparameter | Client-side |
+| Filteren | Geen filterparameter, `map` niet geïndexeerd | Client-side |
+| Rode vlag | Bestaat niet | **Uitgesteld naar fase 7** |
+
+### Ontwerpkeuzes en hun schulden
+
+**Archiveren als gereserveerde mapnaam.** Een bericht naar map `Archief` verplaatsen ís
+archiveren; `PATCH` kan dat vandaag. Nul backend-werk. Als archiveren later andere
+retentie of zichtbaarheid moet krijgen, is dat een echte feature.
+
+**Mappen bestaan alleen in de UI.** Er is geen mappen-entiteit: de mappenlijst is de
+verzameling `map`-waarden in de berichten. Gevolg: **een lege map kan niet bestaan.**
+De demo-UI houdt daarom zelf een lijstje mapnamen bij in de browser. Dat is een illusie
+en wordt niet verstopt.
+
+**Sorteren en filteren client-side.** De spec stelt vast dat filteren per map nog niet
+kan omdat de sessiecache `map` niet indexeert (issue #571). Met enkele tientallen
+berichten haalt de UI de hele lijst op en sorteert/filtert lokaal.
+
+> Dit toont dat de *interactie* werkt, niet dat het *stelsel* kan filteren op schaal.
+> Bij de vraag "en met 10.000 berichten?" is het antwoord: issue #571, en dat is echt
+> werk. De filterbalk krijgt een zichtbaar "demo"-label.
+
+**De rode vlag kan niet gefaket worden.** Een bericht kan tegelijk gemarkeerd zijn én
+in een map zitten, dus het is geen mapnaam. Het vraagt een echt veld `gemarkeerd` door
+de hele keten: OpenAPI-spec van beide services, Flyway-migratie `V8` op `bericht_status`,
+serialisatie in de sessiecache, mapping in beide services, tests per laag. Dat raakt
+productiecode inclusief de 90%-coveragegate. Uitgesteld: het PO-verhaal staat zonder
+vlag, en een half afgemaakte markering is duurder dan zijn demowaarde.
+
+## Scenario-besturing
+
+| # | Scenario | Mechanisme |
+|---|---|---|
+| 1 | Berichten succesvol opgehaald | Basisvulling + normale flow |
+| 2 | Trager dan normaal (>5s) | Toxiproxy `latency` op alle magazijnen |
+| 3 | Magazijnen onbereikbaar (weinig/veel) | WireMock per stub / Toxiproxy per echt magazijn |
+| 4 | Enkele magazijnen antwoorden pas laat | Idem, per magazijn |
+| 5 | Nieuwe berichten tijdens sessie | Random-generator |
+| 6 | Cache-tijd verloopt | Zie hieronder |
+| 7 | Bijlage wordt niet opgehaald | Toxiproxy `disable` tijdens download |
+| 8 | Foutieve aanlevering | Demo-console stuurt ongeldige payloads |
+| 9 | Profielservice weg | Toxiproxy `disable` |
+| 10 | Notificatieservice weg | Toxiproxy `disable` |
+| 11 | Uitvraagsysteem eruit | Toxiproxy `disable` op aanmeld-stub |
+| 12 | Redis weg | Toxiproxy `disable` |
+| 13 | Ontdubbeling | Bestaat al (`aanmeld.deduplicatie.*`) — nogmaals aanleveren |
+| 14 | Load/stress | k6, aparte fase |
+
+Elf van de veertien zijn dezelfde bouwsteen: één knop die één toxic aan- of uitzet.
+Na de eerste is elke volgende een configuratieregel.
+
+### Cache-verloop (scenario 6)
+
+De cache verloopt tijdgebaseerd, niet sessiegebaseerd. De TTL is config
+(`berichtensessiecache.ttl`) en dus niet tijdens runtime te wijzigen. Beide varianten
+worden gebouwd, omdat ze verschillende dingen bewijzen:
+
+- **"Laat nu verlopen"-knop** — de demo-console verwijdert de sessie-keys uit Redis.
+  Instant, demonstreert het gevolg. Bewijst niet dat de TTL zelf werkt.
+- **Korte TTL in de demo-stack** (90 seconden, via env-var) — echte sliding expiry,
+  inclusief verlenging bij elke read.
+
+### Storingen op stub-magazijnen: WireMock, niet Toxiproxy
+
+De stub-magazijnen delen één WireMock-container met pad-gebaseerde routering
+(`/m01` … `/m15`). Ze delen dus één TCP-endpoint, en **Toxiproxy kan daar niet per
+magazijn schakelen** — een toxic raakt alle stubs tegelijk.
+
+WireMock kan dat wél, per stub en tijdens runtime via de admin-API:
+
+| Wat te tonen | WireMock per stub |
+|---|---|
+| Magazijn is traag | `fixedDelayMilliseconds: 6000` |
+| Magazijn geeft fout | `status: 503` |
+| Verbinding valt weg | `fault: CONNECTION_RESET_BY_PEER` |
+| Antwoordt nooit | delay van 30s (loopt in de timeout) |
+| Corrupte respons | `fault: MALFORMED_RESPONSE_CHUNK` |
+
+**Wat je hiermee niet dekt:** `connection refused` — geen server om te antwoorden. Dat
+raakt connect-timeouts en de circuit breaker op verbindingsniveau in plaats van op
+responsniveau. Dat gat wordt gedekt door de twee echte magazijnen, die elk wél achter
+een eigen Toxiproxy zitten.
+
+Verdeling: **echte verbindingsuitval** demonstreren op magazijn A of B (Toxiproxy),
+**volume** demonstreren op de stubs (WireMock). Geen enkel scenario uit de eisen valt af.
+
+Mocht tijdens het bouwen blijken dat TCP-uitval ook op de stubs nodig is, dan is
+opsplitsen naar drie stub-containers (5 magazijnen elk) een wijziging van de basis-URL's
+in het magazijnregister.
+
+### Load/stress (scenario 14)
+
+k6, als los scriptbestand. **Een loadtest op een laptop met twee Quarkus-instanties en
+twee Postgressen bewijst niets over productiecapaciteit.** Wat hij wél toont is relatieve
+degradatie: waar circuit breakers openslaan, hoe de bulkhead zich onder druk gedraagt.
+Dat is een legitiem verhaal, maar het is geen capaciteitsbewijs. Hoort daarom in de
+laatste fase en los van de PO-demo.
+
+## Fasering
+
+Elke fase eindigt in iets dat draait en getoond kan worden. Eerste demo-waardige
+mijlpaal is fase 2.
+
+| Fase | Inhoud | Omvang | Werkend geheel na afloop |
+|---|---|---|---|
+| 0 | Containeriseren: env-vars met default, compose-profiel `demo`, jib-images | klein | Bestaande keten draait volledig in containers; verifieerbaar met Bruno |
+| 1 | Randvoorwaarden: legen (JDBC), basisvulling, random-generator; kaal bedieningspaneel | middel | Magazijnen in seconden te legen en vullen |
+| 2 | Berichtenbox-UI happy flow: lijst, detail, bijlage, zoeken, gelezen/ongelezen, verwijderen, sorteren, filteren, mappen + archief | groot | **Eerste PO-demo.** Ondernemer-flow 1 + 7 van 8 Berichtenbox-functies |
+| 3 | Toxiproxy voor alle afhankelijkheden; knoppen traagheid, magazijn uit, bijlage onbereikbaar | middel | Ondernemer-flows 2, 4, 7 en scenario 3 op de twee echte magazijnen (het weinig-versus-veel-plaatje volgt in fase 6) |
+| 4 | Sessie en cache: nieuwe berichten tijdens sessie, cache laten verlopen, korte TTL | klein | **Ondernemer-lijst compleet** (alle 7 flows) |
+| 5 | Technische verantwoording: profiel/notificatie/aanmeld/Redis uit, foutieve aanlevering, ontdubbeling | middel | 6 van 7 technische punten |
+| 6 | Veel magazijnen: één WireMock met 15 pad-gebaseerde magazijnen, schuifje weinig/veel | middel | Scenario 3 volledig |
+| 7 | Uitgesteld werk: rode vlag door de keten; k6-loadtest | groot | Twee losse brokken, onafhankelijk van elkaar |
+
+Fase 0 gaat bewust eerst: alles daarna leunt erop en het is de goedkoopste fase. Loopt
+het daar mis, dan weet je dat vóór er iets bovenop staat.
+
+Geen doorlooptijden in dagen: de relatieve maten kloppen, een dagschatting niet zolang
+de beschikbare tijd onbekend is.
+
+Elke fase krijgt een eigen implementatieplan in `docs/plans/`. Dit document is het
+overkoepelende ontwerp, niet het uitvoeringsplan van fase 0.
+
+## Bewust buiten scope
+
+- **Issue #571** (filteren op map in de sessiecache) blijft open. De demo werkt eromheen
+  met client-side filteren; dat is een bewuste schuld, geen vergeten werk.
+- **ZAD-deployment van het demo-platform.** De demo draait lokaal. Op ZAD zou Toxiproxy
+  niet werken zoals bedoeld: Argo CD draait met `selfHeal: true` + `prune: true`, dus
+  handmatige ingrepen worden teruggedraaid.
+- **Productiekwaliteit van de demo-console.** Geen 90%-coveragegate, geen NL Design
+  System, geen toegankelijkheidstraject. De module is expliciet wegwerp.
+
+## Verificatie
+
+| Fase | Verificatie |
+|---|---|
+| 0 | `docker compose --profile demo up -d`; bestaande Bruno-collectie draait groen tegen de containers. `./mvnw clean test` blijft groen (bewijst dat `%test`/`%prod` ongemoeid zijn) |
+| 1 | Legen → lijst is leeg; vullen → 40 berichten; nogmaals vullen → ontdubbeling zichtbaar |
+| 2 | Handmatige doorloop van alle 8 Berichtenbox-functies in de UI |
+| 3 | Per knop: gedrag in de UI komt overeen met het scenario; circuit breaker-logs bevestigen het foutpad |
+| 4 | Cache-verloop zichtbaar via zowel de knop als het aflopen van de korte TTL |
+| 5 | Per uitgeschakelde afhankelijkheid: de UI degradeert zoals ontworpen, geen 500 zonder correlation-id |
+| 6 | 1 van 17 uit versus 9 van 17 uit geeft zichtbaar verschillende gebruikerservaring |
+| 7 | Vlag: unit- + integratietests per laag, coveragegate blijft gehaald. k6: rapport met latency-percentielen |

--- a/docs/plans/2026-07-21-demo-platform-design.md
+++ b/docs/plans/2026-07-21-demo-platform-design.md
@@ -23,7 +23,7 @@ de compose-stack. **De bestaande services krijgen geen demo-logica in hun gedrag
 | UI-laag | Wegwerp demo-UI; geen NL Design System, geen productiekwaliteit |
 | Aanleiding | Demo aan PO/stakeholders — happy flow eerst, degradatie daarna |
 | Omgeving | Lokaal (docker compose), niet ZAD |
-| Magazijnen | 2 echt (bestaand) + 15 lichtgewicht stubs in één WireMock-container |
+| Magazijnen | 2 echt (bestaand) + een **variabel** aantal lichtgewicht stubs in één WireMock-container |
 | Bediening | Klikbaar bedieningspaneel, bediend door de ontwikkelaar |
 | Kwaliteitsgates | `demo-console` valt buiten de 90%-JaCoCo-gate |
 
@@ -209,10 +209,31 @@ worden gebouwd, omdat ze verschillende dingen bewijzen:
 - **Korte TTL in de demo-stack** (90 seconden, via env-var) — echte sliding expiry,
   inclusief verlenging bij elke read.
 
+### Het aantal stub-magazijnen is variabel
+
+Het aantal ligt niet vast. Er is één harde beperking: `ConfigMagazijnregister` valideert
+het register **fail-fast bij boot**, dus een magazijn toevoegen vraagt een herstart. Het
+aantal is daarmee op twee niveaus instelbaar:
+
+| Niveau | Wat | Wanneer |
+|---|---|---|
+| **Ingericht aantal** | `DEMO_MAGAZIJN_STUBS=<n>` genereert n register-entries en n WireMock-stubs | Bij opstarten van de stack |
+| **Actief aantal** | Bedieningspaneel zet stubs aan/uit via de WireMock-admin-API | Tijdens de demo, direct |
+
+Praktische werkwijze: richt het ingerichte aantal ruim in (bijvoorbeeld 25) en varieer
+tijdens de demo het *actieve* aantal. Zo schuif je live van "2 magazijnen" naar "27
+magazijnen" zonder herstart.
+
+Dat vraagt dat register-entries en stub-mappings **gegenereerd** worden uit één getal,
+niet handmatig uitgeschreven. De demo-console genereert ze bij het opstarten; er staat
+dus geen lijst van 25 magazijnen in `application.properties` of in de compose-stack.
+De OIN's worden afgeleid uit een vast patroon met geldige elfproef, zodat ze door
+`Magazijnregister` geaccepteerd worden.
+
 ### Storingen op stub-magazijnen: WireMock, niet Toxiproxy
 
 De stub-magazijnen delen één WireMock-container met pad-gebaseerde routering
-(`/m01` … `/m15`). Ze delen dus één TCP-endpoint, en **Toxiproxy kan daar niet per
+(`/m01`, `/m02`, …). Ze delen dus één TCP-endpoint, en **Toxiproxy kan daar niet per
 magazijn schakelen** — een toxic raakt alle stubs tegelijk.
 
 WireMock kan dat wél, per stub en tijdens runtime via de admin-API:
@@ -258,7 +279,7 @@ mijlpaal is fase 2.
 | 3 | Toxiproxy voor alle afhankelijkheden; knoppen traagheid, magazijn uit, bijlage onbereikbaar | middel | Ondernemer-flows 2, 4, 7 en scenario 3 op de twee echte magazijnen (het weinig-versus-veel-plaatje volgt in fase 6) |
 | 4 | Sessie en cache: nieuwe berichten tijdens sessie, cache laten verlopen, korte TTL | klein | **Ondernemer-lijst compleet** (alle 7 flows) |
 | 5 | Technische verantwoording: profiel/notificatie/aanmeld/Redis uit, foutieve aanlevering, ontdubbeling | middel | 6 van 7 technische punten |
-| 6 | Veel magazijnen: één WireMock met 15 pad-gebaseerde magazijnen, schuifje weinig/veel | middel | Scenario 3 volledig |
+| 6 | Veel magazijnen: één WireMock met een variabel aantal pad-gebaseerde magazijnen (gegenereerd uit `DEMO_MAGAZIJN_STUBS`), schuifje voor het actieve aantal | middel | Scenario 3 volledig |
 | 7 | Uitgesteld werk: rode vlag door de keten; k6-loadtest | groot | Twee losse brokken, onafhankelijk van elkaar |
 
 Fase 0 gaat bewust eerst: alles daarna leunt erop en het is de goedkoopste fase. Loopt
@@ -290,5 +311,5 @@ overkoepelende ontwerp, niet het uitvoeringsplan van fase 0.
 | 3 | Per knop: gedrag in de UI komt overeen met het scenario; circuit breaker-logs bevestigen het foutpad |
 | 4 | Cache-verloop zichtbaar via zowel de knop als het aflopen van de korte TTL |
 | 5 | Per uitgeschakelde afhankelijkheid: de UI degradeert zoals ontworpen, geen 500 zonder correlation-id |
-| 6 | 1 van 17 uit versus 9 van 17 uit geeft zichtbaar verschillende gebruikerservaring |
+| 6 | Aantal instelbaar bij opstarten (test met minstens 2, 10 en 25 stubs); tijdens de demo geeft "1 van de N uit" een zichtbaar andere gebruikerservaring dan "meer dan de helft uit" |
 | 7 | Vlag: unit- + integratietests per laag, coveragegate blijft gehaald. k6: rapport met latency-percentielen |

--- a/docs/plans/2026-07-21-demo-platform-design.md
+++ b/docs/plans/2026-07-21-demo-platform-design.md
@@ -122,9 +122,12 @@ keten dus al.
 Herkenbare afzenders (Belastingdienst, KVK, RVO, UWV) en een gespreid
 `publicatietijdstip`, zodat sorteren en filteren in de UI betekenis hebben.
 
-**Vaste bericht-ID's** in de dataset. Dat maakt demo's herhaalbaar en reduceert het
-ontdubbelingsscenario tot één knop. Gevolg: twee keer vullen zonder legen levert
-terecht ontdubbeling op.
+**Geen vaste bericht-ID's.** `BerichtAanleverenRequest` vereist `[afzender, ontvanger,
+onderwerp, inhoud]` en accepteert géén `berichtId`: het magazijn kent de UUID zelf toe.
+Herhaalbaarheid komt daarom uit vaste *inhoud*, niet uit vaste ID's. Twee keer vullen
+zonder legen geeft dus dubbele berichten met verschillende ID's — dat is geen
+ontdubbeling maar dubbele data, en daarom is legen vóór vullen verplicht in het
+bedieningspaneel.
 
 ### Random berichten — dezelfde weg, met generator
 
@@ -192,8 +195,15 @@ vlag, en een half afgemaakte markering is duurder dan zijn demowaarde.
 | 10 | Notificatieservice weg | Toxiproxy `disable` |
 | 11 | Uitvraagsysteem eruit | Toxiproxy `disable` op aanmeld-stub |
 | 12 | Redis weg | Toxiproxy `disable` |
-| 13 | Ontdubbeling | Bestaat al (`aanmeld.deduplicatie.*`) — nogmaals aanleveren |
+| 13 | Ontdubbeling | Bestaat al — dezelfde CloudEvent (zelfde `id`) nogmaals naar de aanmeld-webhook |
 | 14 | Load/stress | k6, aparte fase |
+
+**Ontdubbeling (scenario 13) zit op de webhook, niet op het aanleveren.**
+`AanmeldDeduplicatie.eerstgezien(eventId)` markeert verwerkte CloudEvents op hun `id`
+in een eigen Redis-keyspace, los van de `Sessiecache`-facade. De demo is dus: stuur
+tweemaal dezelfde CloudEvent naar `POST /api/v1/aanmeldingen` op de uitvraag en toon
+dat er één bericht ontstaat. Tweemaal hetzelfde bericht *aanleveren* bij het magazijn
+levert géén ontdubbeling op — dat geeft twee berichten met verschillende ID's.
 
 Elf van de veertien zijn dezelfde bouwsteen: één knop die één toxic aan- of uitzet.
 Na de eerste is elke volgende een configuratieregel.
@@ -306,7 +316,7 @@ overkoepelende ontwerp, niet het uitvoeringsplan van fase 0.
 | Fase | Verificatie |
 |---|---|
 | 0 | `docker compose --profile demo up -d`; bestaande Bruno-collectie draait groen tegen de containers. `./mvnw clean test` blijft groen (bewijst dat `%test`/`%prod` ongemoeid zijn) |
-| 1 | Legen → lijst is leeg; vullen → 40 berichten; nogmaals vullen → ontdubbeling zichtbaar |
+| 1 | Legen → lijst is leeg; vullen → 40 berichten; nogmaals vullen zonder legen → 80 berichten (bewijst dat het magazijn eigen ID's toekent en dat legen verplicht is) |
 | 2 | Handmatige doorloop van alle 8 Berichtenbox-functies in de UI |
 | 3 | Per knop: gedrag in de UI komt overeen met het scenario; circuit breaker-logs bevestigen het foutpad |
 | 4 | Cache-verloop zichtbaar via zowel de knop als het aflopen van de korte TTL |

--- a/docs/plans/2026-07-21-demo-platform-fase-0-containerisatie.md
+++ b/docs/plans/2026-07-21-demo-platform-fase-0-containerisatie.md
@@ -1,0 +1,553 @@
+**Status:** Concept
+
+# Demo-platform fase 0 — containerisatie — implementatieplan
+
+> **Voor agentic workers:** VERPLICHTE SUB-SKILL: gebruik `superpowers:subagent-driven-development`
+> (aanbevolen) of `superpowers:executing-plans` om dit plan taak voor taak uit te voeren.
+> Stappen gebruiken checkbox-syntax (`- [ ]`) voor voortgang.
+
+**Ontwerp:** `docs/plans/2026-07-21-demo-platform-design.md` (fase 0)
+
+**Doel:** de bestaande keten volledig in containers laten draaien met één commando,
+zonder het gedrag van `%test` of `%prod` te wijzigen.
+
+**Architectuur:** de `%dev`-regels van beide services krijgen een env-var-met-default,
+zodat dezelfde image lokaal (default grijpt) én in compose (env-var overschrijft) werkt.
+Containers draaien met `QUARKUS_PROFILE=dev` omdat `OutboundTlsValidator` alleen in
+`dev`/`test` plaintext http toestaat. Images via jib; geen Dockerfiles.
+
+**Tech stack:** Quarkus 3.x, Kotlin, Docker Compose, jib (`quarkus-container-image-jib`),
+PostgreSQL 18, Redis, WireMock.
+
+## Global Constraints
+
+- **Geen wijziging aan `%test`- of `%prod`-regels.** De testsuite en ZAD moeten
+  aantoonbaar ongemoeid blijven.
+- **Geen nieuw Quarkus-profiel.** `OutboundTlsValidator.PROFIELEN_ZONDER_TLS_EIS` bevat
+  alleen `dev` en `test`; een `%demo`-profiel zou https eisen op alle stub-URL's.
+- **Env-varnamen hergebruiken uit `%prod`** waar ze al bestaan: `DB_JDBC_URL`,
+  `DB_USERNAME`, `DB_PASSWORD`, `MAGAZIJN_OIN`, `AANMELD_URL`, `NOTIFICATIE_URL`,
+  `PROFIEL_SERVICE_URL`, `LDV_CLICKHOUSE_ENDPOINT`, `REDIS_HOSTS`, `MAGAZIJN_A_URL`,
+  `MAGAZIJN_B_URL`.
+- **Altijd `clean` vóór `test`/`verify`** (projectregel: stale `target/` van een andere
+  branch geeft misleidende fouten).
+- **Nederlands** in comments en commit-messages; Engelse technische idiomen blijven Engels.
+- **Nooit direct naar `main`.** Werk op een feature branch.
+- Bestaande compose-servicenamen `magazijn-a`/`magazijn-b` zijn **WireMock-stubs** voor
+  `%test`. De echte magazijnen krijgen daarom de namen `berichtenmagazijn-a`/`-b`.
+
+## Bestandsoverzicht
+
+| Bestand | Verantwoordelijkheid | Actie |
+|---|---|---|
+| `services/berichtenmagazijn/src/main/resources/application.properties` | `%dev`-regels overschrijfbaar maken | Wijzigen |
+| `services/berichtenuitvraag/src/main/resources/application.properties` | idem | Wijzigen |
+| `compose.yaml` | drie app-containers onder profiel `demo` | Wijzigen |
+| `demo/smoke.sh` | rookproef tegen de draaiende demo-stack | Aanmaken |
+| `README.md` | opstartinstructies voor beide modi | Wijzigen |
+
+## Waarom hier geen unit-tests bij komen
+
+Dit is uitsluitend configuratie- en compose-werk. Een unit-test die controleert dat
+`${DB_JDBC_URL:...}` naar zijn default resolvet, test Quarkus' config-implementatie en
+niet onze code — dat is ceremonie zonder waarde.
+
+De echte regressietest is dat **`./mvnw clean test` groen blijft**: dat bewijst dat de
+`%test`-regels ongemoeid zijn. Het echte gedragsbewijs is `demo/smoke.sh` (taak 5), die
+de volledige keten door de containers heen rijdt. Beide zijn opgenomen als verplichte
+stappen.
+
+---
+
+### Taak 1: Magazijn-config overschrijfbaar maken
+
+Zonder deze taak kan magazijn B niet uit dezelfde image draaien: `%dev` pint database
+én organisatie-OIN hard op magazijn A.
+
+**Bestanden:**
+- Wijzigen: `services/berichtenmagazijn/src/main/resources/application.properties`
+  (regels 62-64, 119, 138, 156-157, 190)
+
+**Interfaces:**
+- Produceert (env-vars die taak 4 zet): `DB_JDBC_URL`, `DB_USERNAME`, `DB_PASSWORD`,
+  `MAGAZIJN_OIN`, `AANMELD_URL`, `NOTIFICATIE_URL`, `PROFIEL_SERVICE_URL`,
+  `LDV_CLICKHOUSE_ENDPOINT`
+
+- [ ] **Stap 1: Leg de huidige testuitslag vast als vergelijkingspunt**
+
+```bash
+./mvnw clean test -pl services/berichtenmagazijn -am 2>&1 | tail -20
+```
+
+Verwacht: `BUILD SUCCESS`. Noteer het aantal tests (`Tests run: N`) — dat getal moet na
+de wijziging identiek zijn.
+
+- [ ] **Stap 2: Vervang de acht `%dev`-regels**
+
+Vervang exact deze regels (laat commentaar eromheen staan):
+
+```properties
+%dev.quarkus.datasource.jdbc.url=${DB_JDBC_URL:jdbc:postgresql://localhost:5432/berichtenmagazijn}
+%dev.quarkus.datasource.username=${DB_USERNAME:berichtenmagazijn}
+%dev.quarkus.datasource.password=${DB_PASSWORD:berichtenmagazijn}
+%dev.logboekdataverwerking.clickhouse.endpoint=${LDV_CLICKHOUSE_ENDPOINT:http://localhost:8123}
+%dev.magazijn.publicatie.organisatie.oin=${MAGAZIJN_OIN:00000001003214345000}
+%dev.magazijn.publicatie.downstreams.aanmeld.url=${AANMELD_URL:http://localhost:8083/events}
+%dev.magazijn.publicatie.downstreams.notificatie.url=${NOTIFICATIE_URL:http://localhost:8084/events}
+%dev.quarkus.rest-client.profiel-service.url=${PROFIEL_SERVICE_URL:http://localhost:8089}
+```
+
+Voeg boven het blok deze toelichting toe:
+
+```properties
+# Env-var met default: buiten containers grijpt de default (ongewijzigd dev-gedrag),
+# in de demo-compose overschrijft de env-var naar container-DNS. Dezelfde varnamen als
+# %prod, zodat lokaal en ZAD dezelfde knoppen hebben. Een eigen %demo-profiel kan niet:
+# OutboundTlsValidator staat plaintext http alleen toe in dev en test.
+```
+
+- [ ] **Stap 3: Bevestig dat de defaults ongewijzigd gedrag geven**
+
+```bash
+./mvnw clean test -pl services/berichtenmagazijn -am 2>&1 | tail -20
+```
+
+Verwacht: `BUILD SUCCESS` met hetzelfde aantal tests als in stap 1.
+
+- [ ] **Stap 4: Bevestig dat dev-mode nog steeds zonder env-vars start**
+
+```bash
+docker compose up -d postgres-a clickhouse profiel-service aanmeld-stub notificatie-stub
+./mvnw quarkus:dev -pl services/berichtenmagazijn
+```
+
+Verwacht in de log: `Listening on: http://localhost:8090` en géén
+`Failed to start quarkus`. Controleer in een tweede terminal:
+
+```bash
+curl -s localhost:8090/q/health/ready
+```
+
+Verwacht: JSON met `"status": "UP"`. Stop dev-mode daarna met Ctrl-C.
+
+- [ ] **Stap 5: Commit**
+
+```bash
+git add services/berichtenmagazijn/src/main/resources/application.properties
+git commit -m "config(magazijn): %dev-regels overschrijfbaar via env-vars
+
+Zodat twee magazijn-instanties uit dezelfde container-image kunnen draaien:
+database en organisatie-OIN stonden hard op magazijn A."
+```
+
+---
+
+### Taak 2: Uitvraag-config overschrijfbaar maken
+
+**Bestanden:**
+- Wijzigen: `services/berichtenuitvraag/src/main/resources/application.properties`
+  (regels 55, 156, 213-214, 254)
+
+**Interfaces:**
+- Produceert (env-vars die taak 4 zet): `REDIS_HOSTS`, `MAGAZIJN_A_URL`, `MAGAZIJN_B_URL`,
+  `PROFIEL_SERVICE_URL`, `LDV_CLICKHOUSE_ENDPOINT`
+
+- [ ] **Stap 1: Leg de huidige testuitslag vast**
+
+```bash
+./mvnw clean test -pl services/berichtenuitvraag -am 2>&1 | tail -20
+```
+
+Verwacht: `BUILD SUCCESS`. Noteer `Tests run: N`.
+
+- [ ] **Stap 2: Vervang de vijf `%dev`-regels**
+
+```properties
+%dev.quarkus.redis.hosts=${REDIS_HOSTS:redis://localhost:6379}
+%dev.quarkus.rest-client.profiel-service.url=${PROFIEL_SERVICE_URL:http://localhost:8089}
+%dev.magazijnen."00000001003214345000".url=${MAGAZIJN_A_URL:http://localhost:8090}
+%dev.magazijnen."00000001823288444000".url=${MAGAZIJN_B_URL:http://localhost:8091}
+%dev.logboekdataverwerking.clickhouse.endpoint=${LDV_CLICKHOUSE_ENDPOINT:http://localhost:8123}
+```
+
+**Let op:** overschrijf de magazijn-URL's uitsluitend via deze `${...}`-vorm, níet via
+impliciete env-var-mapping (`MAGAZIJNEN__..._URL`). De mapping van env-varnamen naar
+map-sleutels met aanhalingstekens is niet gegarandeerd; de expliciete vorm werkt zeker
+en is bovendien leesbaar in het bestand zelf.
+
+Laat `%test.magazijnen.*` (regels 118-119, poorten 8081/8082) ongemoeid — die wijzen
+naar de WireMock-stubs en horen bij de testsuite.
+
+- [ ] **Stap 3: Bevestig ongewijzigd gedrag**
+
+```bash
+./mvnw clean test -pl services/berichtenuitvraag -am 2>&1 | tail -20
+```
+
+Verwacht: `BUILD SUCCESS` met hetzelfde aantal tests als in stap 1.
+
+- [ ] **Stap 4: Commit**
+
+```bash
+git add services/berichtenuitvraag/src/main/resources/application.properties
+git commit -m "config(uitvraag): %dev-regels overschrijfbaar via env-vars
+
+Redis, magazijn-URL's, profielservice en LDV-endpoint krijgen een env-var met
+default, zodat de container-variant dezelfde image kan gebruiken."
+```
+
+---
+
+### Taak 3: Container-images bouwen
+
+**Bestanden:** geen — jib zit al in beide POM's (`quarkus-container-image-jib`), met
+`quarkus.container-image.name` ingevuld. Group en tag komen van de commandoregel, net
+als in `.github/workflows/deploy.yml`.
+
+**Interfaces:**
+- Produceert (image-namen die taak 4 gebruikt): `fbs-demo/fbs-berichtenmagazijn:demo`,
+  `fbs-demo/fbs-berichtenuitvraag:demo`
+
+- [ ] **Stap 1: Bouw beide images**
+
+```bash
+./mvnw clean package -DskipTests \
+  -pl services/berichtenmagazijn,services/berichtenuitvraag -am \
+  -Dquarkus.container-image.build=true \
+  -Dquarkus.container-image.group=fbs-demo \
+  -Dquarkus.container-image.tag=demo
+```
+
+Verwacht: `BUILD SUCCESS` en per module een regel als
+`Created container image fbs-demo/fbs-berichtenmagazijn:demo`.
+
+- [ ] **Stap 2: Bevestig dat de images bestaan**
+
+```bash
+docker images --filter=reference='fbs-demo/*:demo'
+```
+
+Verwacht: twee regels, `fbs-berichtenmagazijn` en `fbs-berichtenuitvraag`, beide met tag
+`demo`.
+
+- [ ] **Stap 3: Leg het bouwcommando vast in de README**
+
+Voeg onder "Snel starten" toe:
+
+````markdown
+### Demo-stack (alles in containers)
+
+Bouw eerst de images (opnieuw nodig na elke codewijziging):
+
+```bash
+./mvnw clean package -DskipTests \
+  -pl services/berichtenmagazijn,services/berichtenuitvraag -am \
+  -Dquarkus.container-image.build=true \
+  -Dquarkus.container-image.group=fbs-demo \
+  -Dquarkus.container-image.tag=demo
+```
+````
+
+- [ ] **Stap 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): bouwcommando voor de demo-images"
+```
+
+---
+
+### Taak 4: Compose-profiel `demo`
+
+**Bestanden:**
+- Wijzigen: `compose.yaml` (drie services toevoegen vóór het `volumes:`-blok)
+
+**Interfaces:**
+- Consumeert: de env-vars uit taak 1 en 2, de images uit taak 3
+- Produceert (voor taak 5): `berichtenuitvraag` op `localhost:8086`,
+  `berichtenmagazijn-a` op `:8090`, `berichtenmagazijn-b` op `:8091`
+
+- [ ] **Stap 1: Voeg de drie services toe**
+
+```yaml
+  # Demo-stack: alleen actief met `--profile demo`. Zonder profiel start compose de
+  # infra en draai je de services met `quarkus:dev` (hot reload behouden).
+  # QUARKUS_PROFILE=dev is bewust: OutboundTlsValidator staat plaintext http alleen toe
+  # in dev en test, en de stubs spreken geen https.
+  berichtenmagazijn-a:
+    image: fbs-demo/fbs-berichtenmagazijn:demo
+    profiles: [demo]
+    ports:
+      - "8090:8090"
+    depends_on:
+      postgres-a:
+        condition: service_healthy
+    environment:
+      QUARKUS_PROFILE: dev
+      QUARKUS_HTTP_HOST: 0.0.0.0
+      DB_JDBC_URL: jdbc:postgresql://postgres-a:5432/berichtenmagazijn
+      MAGAZIJN_OIN: "00000001003214345000"
+      AANMELD_URL: http://aanmeld-stub:8080/events
+      NOTIFICATIE_URL: http://notificatie-stub:8080/events
+      PROFIEL_SERVICE_URL: http://profiel-service:8080
+      LDV_CLICKHOUSE_ENDPOINT: http://clickhouse:8123
+
+  berichtenmagazijn-b:
+    image: fbs-demo/fbs-berichtenmagazijn:demo
+    profiles: [demo]
+    ports:
+      - "8091:8090"
+    depends_on:
+      postgres-b:
+        condition: service_healthy
+    environment:
+      QUARKUS_PROFILE: dev
+      QUARKUS_HTTP_HOST: 0.0.0.0
+      DB_JDBC_URL: jdbc:postgresql://postgres-b:5432/berichtenmagazijn
+      MAGAZIJN_OIN: "00000001823288444000"
+      AANMELD_URL: http://aanmeld-stub:8080/events
+      NOTIFICATIE_URL: http://notificatie-stub:8080/events
+      PROFIEL_SERVICE_URL: http://profiel-service:8080
+      LDV_CLICKHOUSE_ENDPOINT: http://clickhouse:8123
+
+  berichtenuitvraag:
+    image: fbs-demo/fbs-berichtenuitvraag:demo
+    profiles: [demo]
+    ports:
+      - "8086:8086"
+    depends_on:
+      redis:
+        condition: service_healthy
+      berichtenmagazijn-a:
+        condition: service_started
+      berichtenmagazijn-b:
+        condition: service_started
+    environment:
+      QUARKUS_PROFILE: dev
+      QUARKUS_HTTP_HOST: 0.0.0.0
+      REDIS_HOSTS: redis://redis:6379
+      MAGAZIJN_A_URL: http://berichtenmagazijn-a:8090
+      MAGAZIJN_B_URL: http://berichtenmagazijn-b:8090
+      PROFIEL_SERVICE_URL: http://profiel-service:8080
+      LDV_CLICKHOUSE_ENDPOINT: http://clickhouse:8123
+```
+
+**Twee dingen om te weten bij deze YAML:**
+
+`QUARKUS_HTTP_HOST: 0.0.0.0` staat er als verzekering. In `NORMAL` launch mode is
+`0.0.0.0` al de default, maar Quarkus bindt in *dev mode* op localhost — en de combinatie
+"profiel dev, launch mode normal" is precies de rand waar dat verwarrend wordt. Bindt de
+service op localhost in de container, dan is de gepubliceerde poort dood. Expliciet zetten
+kost niets en sluit die twijfel uit.
+
+Beide magazijn-containers luisteren intern op **8090**; alleen de gepubliceerde poort
+verschilt. Daarom wijst `MAGAZIJN_B_URL` naar `berichtenmagazijn-b:8090` en niet naar 8091.
+
+- [ ] **Stap 2: Controleer dat het standaardgedrag ongewijzigd is**
+
+```bash
+docker compose config --services
+docker compose --profile demo config --services
+```
+
+Verwacht: de eerste lijst bevat **niet** `berichtenuitvraag`, `berichtenmagazijn-a` of
+`berichtenmagazijn-b`; de tweede lijst bevat ze alle drie. Dat bewijst dat
+`docker compose up -d` de infra-modus blijft.
+
+- [ ] **Stap 3: Start de volledige stack**
+
+```bash
+docker compose --profile demo up -d
+docker compose --profile demo ps
+```
+
+Verwacht: alle containers `running`; `postgres-a`/`postgres-b`/`redis` tonen `(healthy)`.
+
+- [ ] **Stap 4: Controleer de health-endpoints**
+
+```bash
+curl -sf localhost:8090/q/health/ready && echo " magazijn-a OK"
+curl -sf localhost:8091/q/health/ready && echo " magazijn-b OK"
+curl -sf localhost:8086/q/health/ready && echo " uitvraag OK"
+```
+
+Verwacht: drie regels met `OK`.
+
+Bij een falende container: `docker compose logs berichtenmagazijn-b`. De twee meest
+waarschijnlijke oorzaken zijn een niet-resolvende container-DNS-naam (typefout in een
+env-var) en Flyway die de migraties op een lege database nog niet af heeft.
+
+- [ ] **Stap 5: Commit**
+
+```bash
+git add compose.yaml
+git commit -m "build(compose): demo-profiel met beide magazijnen en uitvraag
+
+Zonder profiel blijft compose de infra-modus voor quarkus:dev; met
+--profile demo draait de volledige keten in containers."
+```
+
+---
+
+### Taak 5: Rookproef over de keten
+
+Health-endpoints bewijzen dat processen leven, niet dat de keten werkt. Deze taak levert
+het bewijs dat een aangeleverd bericht ook via de uitvraag terugkomt — precies het gedrag
+waarop fase 1 gaat bouwen.
+
+**Bestanden:**
+- Aanmaken: `demo/smoke.sh`
+- Wijzigen: `README.md`
+
+**Interfaces:**
+- Consumeert: de draaiende stack uit taak 4
+- Produceert: `demo/smoke.sh`, exit 0 bij succes — herbruikbaar als regressiecheck in
+  latere fases
+
+- [ ] **Stap 1: Schrijf de rookproef**
+
+```bash
+#!/usr/bin/env bash
+# Rookproef voor de demo-stack: levert een bericht aan bij magazijn A en controleert
+# dat het via de uitvraag terugkomt. Draait tegen `docker compose --profile demo up -d`.
+set -euo pipefail
+
+MAGAZIJN_A="${MAGAZIJN_A:-http://localhost:8090}"
+UITVRAAG="${UITVRAAG:-http://localhost:8086}"
+ONTVANGER="${ONTVANGER:-BSN:999993653}"
+
+echo "1/3 health"
+for url in "$MAGAZIJN_A" "$UITVRAAG"; do
+    curl -sf "$url/q/health/ready" > /dev/null || { echo "FOUT: $url niet gezond"; exit 1; }
+done
+
+echo "2/3 bericht aanleveren"
+# Het magazijn kent het berichtId zelf toe; de aanlever-request bevat er geen. We
+# herkennen ons bericht daarom aan een uniek onderwerp.
+onderwerp="Rookproef demo-stack $(date +%s)"
+status=$(curl -s -o /tmp/smoke-aanlever.json -w '%{http_code}' \
+    -X POST "$MAGAZIJN_A/api/v1/berichten" \
+    -H 'Content-Type: application/json' \
+    -d "{
+          \"afzender\": \"00000001003214345000\",
+          \"ontvanger\": {\"type\": \"BSN\", \"waarde\": \"999993653\"},
+          \"onderwerp\": \"$onderwerp\",
+          \"inhoud\": \"Aangemaakt door demo/smoke.sh\"
+        }")
+
+if [[ "$status" != "201" ]]; then
+    echo "FOUT: aanleveren gaf HTTP $status (verwacht 201)"
+    cat /tmp/smoke-aanlever.json
+    exit 1
+fi
+
+bericht_id=$(grep -o '"berichtId"[[:space:]]*:[[:space:]]*"[^"]*"' /tmp/smoke-aanlever.json \
+    | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+echo "    magazijn kende berichtId $bericht_id toe"
+
+echo "3/3 ophalen via uitvraag"
+# De sessiecache vult zich pas na een ophaal-ronde; GET /berichten leest alleen de cache.
+curl -sf -N --max-time 30 "$UITVRAAG/api/v1/berichten/_ophalen" \
+    -H "X-Ontvanger: $ONTVANGER" > /dev/null
+
+curl -sf "$UITVRAAG/api/v1/berichten" -H "X-Ontvanger: $ONTVANGER" \
+    | grep -q "$onderwerp" \
+    || { echo "FOUT: '$onderwerp' niet gevonden in de uitvraag"; exit 1; }
+
+echo "OK: keten werkt end-to-end"
+```
+
+- [ ] **Stap 2: Maak het script uitvoerbaar en draai het**
+
+```bash
+chmod +x demo/smoke.sh
+./demo/smoke.sh
+```
+
+Verwacht: `OK: keten werkt end-to-end`, exit code 0.
+
+De payload volgt `BerichtAanleverenRequest` uit
+`services/berichtenmagazijn/src/main/resources/openapi/berichtenmagazijn-api.yaml:339`:
+verplicht zijn `afzender` (OIN, 20 cijfers), `ontvanger`, `onderwerp` en `inhoud`. Dat
+schema is gelezen, maar het script is **niet uitgevoerd** — dit is de eerste taak waarin
+het draait.
+
+Twee dingen die kunnen tegenvallen:
+
+- **HTTP 403 bij aanleveren.** Het magazijn controleert via de Profiel-service of de
+  ontvanger een `OntvangViaBerichtenbox`-voorkeur heeft voor deze afzender-OIN. De
+  WireMock-stub geeft die standaard voor OIN `00000001003214345000` — vandaar precies
+  die afzender in de payload. Wijk daar niet van af zonder de stub-mapping in
+  `wiremock/externe-stubs/mappings/` mee te veranderen.
+- **BSN afgekeurd.** `999993653` is met de hand tegen de elfproef gecontroleerd
+  (gewogen som 352 = 11 × 32) en zou moeten worden geaccepteerd. Wordt hij toch
+  geweigerd, pak dan een BSN uit de bestaande tests
+  (`grep -rn "BSN" services/berichtenmagazijn/src/test`).
+
+- [ ] **Stap 3: Documenteer beide opstartmodi in de README**
+
+Voeg toe onder de sectie uit taak 3:
+
+````markdown
+Start daarna de volledige stack:
+
+```bash
+docker compose --profile demo up -d   # alles in containers — demo
+./demo/smoke.sh                       # rookproef over de keten
+```
+
+Zonder `--profile demo` start compose alleen de infrastructuur (Redis, Postgres,
+WireMock, ClickHouse); draai de services dan met `./mvnw quarkus:dev` zodat hot reload
+behouden blijft. Gebruik die modus tijdens het ontwikkelen — in een container kost elke
+codewijziging een image-build.
+````
+
+- [ ] **Stap 4: Volledige testsuite als eindcontrole**
+
+```bash
+./mvnw clean test 2>&1 | tail -30
+```
+
+Verwacht: `BUILD SUCCESS`. Dit is het sluitstuk van de belofte dat `%test` en `%prod`
+ongemoeid zijn gebleven. Controleer ook op nieuwe waarschuwingen: die blokkeren volgens
+de projectregels een PR tot ze getrieerd zijn.
+
+- [ ] **Stap 5: Commit**
+
+```bash
+git add demo/smoke.sh README.md
+git commit -m "test(demo): rookproef over de containerketen
+
+Health-endpoints bewijzen alleen dat processen leven; deze proef levert een
+bericht aan en controleert dat het via de uitvraag terugkomt."
+```
+
+---
+
+## Definition of done
+
+- [ ] `docker compose up -d` start onveranderd alleen de infrastructuur
+- [ ] `docker compose --profile demo up -d` start de volledige keten
+- [ ] `./demo/smoke.sh` eindigt met exit 0
+- [ ] De bestaande Bruno-collectie (`bruno/berichtenuitvraag/`, `bruno/berichtenmagazijn/`)
+      draait groen tegen de containers met de omgeving `lokaal` — de poorten zijn
+      identiek aan dev-mode, dus dit hoort zonder aanpassing te werken
+- [ ] `./mvnw clean test` is groen, met hetzelfde aantal tests als vóór fase 0
+- [ ] `./mvnw quarkus:dev` werkt nog zonder env-vars te zetten
+- [ ] Geen wijziging in `%test`- of `%prod`-regels (`git diff main` controleren)
+- [ ] README beschrijft beide opstartmodi
+
+## Risico's
+
+| Risico | Signaal | Mitigatie |
+|---|---|---|
+| Service bindt in de container op localhost | Poort gepubliceerd maar `curl` weigert verbinding | `QUARKUS_HTTP_HOST=0.0.0.0` staat al in de compose-config |
+| Flyway nog bezig bij eerste start | `berichtenmagazijn-b` faalt kort na `up` | Herstart de container; `depends_on` wacht op Postgres-health, niet op migraties |
+| Aanlever-payload afgekeurd | HTTP 400 met `Problem`-body | Payload corrigeren aan de hand van het antwoord (zie taak 5, stap 2) |
+| Ontvanger heeft geen berichtenbox-voorkeur | HTTP 403 bij aanleveren | Afzender-OIN `00000001003214345000` aanhouden; de profiel-stub geeft daarvoor een actieve voorkeur |
+| Poortconflict tussen dev-mode en containers | `port is already allocated` | Beide modi gebruiken dezelfde poorten; draai er één tegelijk |
+
+## Niet in deze fase
+
+Toxiproxy (fase 3), de demo-console-module (fase 1), de Berichtenbox-UI (fase 2) en de
+stub-magazijnen (fase 6). Fase 0 levert uitsluitend een containeriseerbare bestaande keten.

--- a/docs/plans/2026-07-21-demo-platform-fase-0-containerisatie.md
+++ b/docs/plans/2026-07-21-demo-platform-fase-0-containerisatie.md
@@ -1,4 +1,21 @@
-**Status:** Concept
+**Status:** Deels uitgevoerd — verificatie openstaand
+
+> **Uitvoerstatus 2026-07-21.** Alle codewijzigingen zijn gemaakt (commits `750e09c`,
+> `77931e5`, `f434bc7`). De ontwikkelomgeving had **geen container-runtime** (Docker
+> afwezig; podman faalt op `cannot clone: Operation not permitted`), waardoor de
+> verificatiestappen niet konden draaien.
+>
+> **Wel uitgevoerd:** `mvn package -DskipTests` inclusief Quarkus-augmentatie voor beide
+> services (groen, geen nieuwe waarschuwingen); `fbs-common` 189 tests en
+> `fbs-magazijnregister` 17 tests groen; compose-YAML parst en de drie app-containers
+> zitten uitsluitend in het `demo`-profiel; `bash -n demo/smoke.sh` groen; de diff raakt
+> aantoonbaar geen `%test`- of `%prod`-regel.
+>
+> **Nog te doen op een machine mét Docker** — dit is de resterende definition of done:
+> `./mvnw clean test` (beide services), `./mvnw quarkus:dev` zonder env-vars, de
+> jib-image-build, `docker compose --profile demo up -d`, `./demo/smoke.sh` en de
+> Bruno-collectie. Reken erop dat `smoke.sh` bijgesteld moet worden: dat script is nog
+> nooit uitgevoerd.
 
 # Demo-platform fase 0 — containerisatie — implementatieplan
 

--- a/docs/plans/2026-07-21-demo-platform-fase-0-containerisatie.md
+++ b/docs/plans/2026-07-21-demo-platform-fase-0-containerisatie.md
@@ -1,21 +1,13 @@
-**Status:** Deels uitgevoerd — verificatie openstaand
+**Status:** Uitgevoerd
 
-> **Uitvoerstatus 2026-07-21.** Alle codewijzigingen zijn gemaakt (commits `750e09c`,
-> `77931e5`, `f434bc7`). De ontwikkelomgeving had **geen container-runtime** (Docker
-> afwezig; podman faalt op `cannot clone: Operation not permitted`), waardoor de
-> verificatiestappen niet konden draaien.
+> **Uitvoerstatus.** Alle codewijzigingen gemaakt (commits `750e09c`, `77931e5`,
+> `f434bc7`) en op een machine mét Docker volledig geverifieerd door de gebruiker:
+> images gebouwd (jib), `./mvnw clean test` groen, `docker compose --profile demo up -d`
+> gestart en `./demo/smoke.sh` doorlopen — de keten werkt end-to-end.
 >
-> **Wel uitgevoerd:** `mvn package -DskipTests` inclusief Quarkus-augmentatie voor beide
-> services (groen, geen nieuwe waarschuwingen); `fbs-common` 189 tests en
-> `fbs-magazijnregister` 17 tests groen; compose-YAML parst en de drie app-containers
-> zitten uitsluitend in het `demo`-profiel; `bash -n demo/smoke.sh` groen; de diff raakt
-> aantoonbaar geen `%test`- of `%prod`-regel.
->
-> **Nog te doen op een machine mét Docker** — dit is de resterende definition of done:
-> `./mvnw clean test` (beide services), `./mvnw quarkus:dev` zonder env-vars, de
-> jib-image-build, `docker compose --profile demo up -d`, `./demo/smoke.sh` en de
-> Bruno-collectie. Reken erop dat `smoke.sh` bijgesteld moet worden: dat script is nog
-> nooit uitgevoerd.
+> De codewijzigingen zijn in de ontwikkelomgeving (zonder container-runtime) al
+> voorbereid en gecontroleerd met `mvn package` inclusief augmentatie en een YAML-/
+> profielcheck; de container-afhankelijke verificatie is daarna door de gebruiker gedaan.
 
 # Demo-platform fase 0 — containerisatie — implementatieplan
 

--- a/services/berichtenmagazijn/src/main/resources/application.properties
+++ b/services/berichtenmagazijn/src/main/resources/application.properties
@@ -59,9 +59,15 @@ quarkus.smallrye-openapi.always-run-filter=true
 # service in productie komt.
 quarkus.datasource.db-kind=postgresql
 quarkus.datasource.devservices.image-name=postgres:18
-%dev.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/berichtenmagazijn
-%dev.quarkus.datasource.username=berichtenmagazijn
-%dev.quarkus.datasource.password=berichtenmagazijn
+# Env-var met default: buiten containers grijpt de default (ongewijzigd dev-gedrag), in
+# de demo-compose overschrijft de env-var naar container-DNS. Dezelfde varnamen als %prod,
+# zodat lokaal en ZAD dezelfde knoppen hebben. Een eigen %demo-profiel kan niet:
+# OutboundTlsValidator staat plaintext http alleen toe in dev en test, en de stubs
+# spreken geen https. Zonder deze indirectie kan een tweede magazijn-instantie niet uit
+# dezelfde container-image draaien, omdat database en OIN hier op magazijn A gepind staan.
+%dev.quarkus.datasource.jdbc.url=${DB_JDBC_URL:jdbc:postgresql://localhost:5432/berichtenmagazijn}
+%dev.quarkus.datasource.username=${DB_USERNAME:berichtenmagazijn}
+%dev.quarkus.datasource.password=${DB_PASSWORD:berichtenmagazijn}
 # %prod: geen default — de deploy MOET een (centraal beheerde) Postgres aanwijzen,
 # anders faalt de service te starten i.p.v. stilletjes localhost te proberen. Elk
 # deployable magazijn krijgt een eigen database/schema via deze env-vars.
@@ -116,7 +122,7 @@ logboekdataverwerking.clickhouse.table=logboek_dataverwerkingen
 # In %prod blijft de basisproperty `${LDV_CLICKHOUSE_ENDPOINT}` zonder default; operators
 # MOETEN een TLS-endpoint (https://) zetten conform BIO 13.2.1 (persoonsgegevens
 # versleuteld over netwerk).
-%dev.logboekdataverwerking.clickhouse.endpoint=http://localhost:8123
+%dev.logboekdataverwerking.clickhouse.endpoint=${LDV_CLICKHOUSE_ENDPOINT:http://localhost:8123}
 %dev.logboekdataverwerking.clickhouse.username=ldv
 %dev.logboekdataverwerking.clickhouse.password=ldv
 %test.logboekdataverwerking.clickhouse.endpoint=http://localhost:8123
@@ -135,7 +141,7 @@ quarkus.index-dependency.ldv.artifact-id=logboekdataverwerking-wrapper
 # MAGAZIJN_OIN faalt te starten i.p.v. stil onder een verkeerde organisatie-identiteit
 # te publiceren. Dev/test gebruiken een vaste test-OIN voor lokaal draaien.
 magazijn.publicatie.organisatie.oin=${MAGAZIJN_OIN}
-%dev.magazijn.publicatie.organisatie.oin=00000001003214345000
+%dev.magazijn.publicatie.organisatie.oin=${MAGAZIJN_OIN:00000001003214345000}
 %test.magazijn.publicatie.organisatie.oin=00000001003214345000
 magazijn.publicatie.polling.interval=60s
 magazijn.publicatie.polling.max-opeenvolgende-fouten=3
@@ -153,8 +159,8 @@ magazijn.publicatie.verwerkingsregister-publiceren=https://register.example.com/
 magazijn.publicatie.verwerkingsregister-aanleveren=https://register.example.com/verwerkingen/berichtenmagazijn-aanleveren
 # Downstreams: nieuwe entries toevoegen = config-only (geen schema-/code-wijziging).
 # In dev draaien Aanmeld en Notificatie als WireMock-stubs uit compose.yaml.
-%dev.magazijn.publicatie.downstreams.aanmeld.url=http://localhost:8083/events
-%dev.magazijn.publicatie.downstreams.notificatie.url=http://localhost:8084/events
+%dev.magazijn.publicatie.downstreams.aanmeld.url=${AANMELD_URL:http://localhost:8083/events}
+%dev.magazijn.publicatie.downstreams.notificatie.url=${NOTIFICATIE_URL:http://localhost:8084/events}
 # In %prod komen de downstream-URL's uit env-vars; de keys staan hier omdat SmallRye
 # map-keys niet uit losse env-vars ontdekt. aanmeld = de echte uitvraag-webhook
 # (POST /api/v1/aanmeldingen), notificatie = WireMock-stub. De ZAD-deploymentnaam
@@ -187,7 +193,7 @@ retentie.hard-delete.batch-grootte=1000
 # %prod-deploy zonder env-var faalt te starten (i.p.v. stilletjes localhost te
 # proberen). ProfielServiceEndpointValidator dwingt TLS af in non-dev/test.
 quarkus.rest-client.profiel-service.url=${PROFIEL_SERVICE_URL}
-%dev.quarkus.rest-client.profiel-service.url=http://localhost:8089
+%dev.quarkus.rest-client.profiel-service.url=${PROFIEL_SERVICE_URL:http://localhost:8089}
 %test.quarkus.rest-client.profiel-service.url=http://localhost:8089
 
 # Time-outs op de Profiel-Service-call (waarde in milliseconden): bij gebrek aan

--- a/services/berichtenuitvraag/src/main/resources/application.properties
+++ b/services/berichtenuitvraag/src/main/resources/application.properties
@@ -52,7 +52,11 @@ quarkus.jackson.serialization-inclusion=non_null
 
 # Redis — backing store van de in-process sessiecache (fbs-berichtensessiecache).
 # Dev/prod: compose Redis, geen Dev Services; tests schakelen Dev Services per profiel in.
-%dev.quarkus.redis.hosts=redis://localhost:6379
+# Env-var met default: buiten containers grijpt de default (ongewijzigd dev-gedrag), in
+# de demo-compose overschrijft de env-var naar container-DNS. Dezelfde varnamen als %prod,
+# zodat lokaal en ZAD dezelfde knoppen hebben. Een eigen %demo-profiel kan niet:
+# OutboundTlsValidator staat plaintext http alleen toe in dev en test.
+%dev.quarkus.redis.hosts=${REDIS_HOSTS:redis://localhost:6379}
 # Geen %prod-default: ontbreekt REDIS_HOSTS, dan faalt de start met een duidelijke melding
 # over de missende var i.p.v. stil naar localhost te verbinden (consistent met de fail-fast
 # van REDIS_PASSWORD/DB_* hieronder; een localhost-fallback gaf juist een verwarrende
@@ -153,7 +157,7 @@ berichtensessiecache.magazijn-circuit.open-seconds=30
 # client op JVM-default trust-store; ProfielServiceEndpointValidator dwingt
 # wel https:// af in prod/staging/acceptatie, maar niet de certificaat-keten.
 quarkus.rest-client.profiel-service.url=${PROFIEL_SERVICE_URL}
-%dev.quarkus.rest-client.profiel-service.url=http://localhost:8089
+%dev.quarkus.rest-client.profiel-service.url=${PROFIEL_SERVICE_URL:http://localhost:8089}
 %test.quarkus.rest-client.profiel-service.url=http://localhost:8089
 # Time-outs op de Profiel-Service-call (waarde in milliseconden). Vaste Quarkus
 # RestClient-sleutels: de naam draagt geen `-ms`-suffix zoals onze eigen properties,
@@ -210,8 +214,11 @@ profiel.resolver.cache.max-size=10000
 # %dev: twee lokaal-draaiende berichtenmagazijn-instances. Magazijn A op de
 # default-poort (8090); magazijn B start je in een tweede terminal op 8091 met:
 #     ./mvnw quarkus:dev -pl services/berichtenmagazijn -Dquarkus.http.port=8091
-%dev.magazijnen."00000001003214345000".url=http://localhost:8090
-%dev.magazijnen."00000001823288444000".url=http://localhost:8091
+# In de demo-compose wijzen MAGAZIJN_A_URL/MAGAZIJN_B_URL naar de container-DNS-namen.
+# Overschrijf uitsluitend via deze ${...}-vorm: de impliciete env-var-mapping naar
+# map-sleutels met aanhalingstekens is niet gegarandeerd.
+%dev.magazijnen."00000001003214345000".url=${MAGAZIJN_A_URL:http://localhost:8090}
+%dev.magazijnen."00000001823288444000".url=${MAGAZIJN_B_URL:http://localhost:8091}
 
 # Begrensde timeouts op de magazijn-REST-client van MagazijnRouter
 # (bijlage-download + patch/verwijder) zodat een hangende magazijn-connectie een
@@ -251,7 +258,7 @@ logboekdataverwerking.clickhouse.table=logboek_dataverwerkingen
 # In %prod blijft de basisproperty `${LDV_CLICKHOUSE_ENDPOINT}` zonder default; operators
 # MOETEN een TLS-endpoint (https://) zetten conform BIO 13.2.1 (persoonsgegevens
 # versleuteld over netwerk).
-%dev.logboekdataverwerking.clickhouse.endpoint=http://localhost:8123
+%dev.logboekdataverwerking.clickhouse.endpoint=${LDV_CLICKHOUSE_ENDPOINT:http://localhost:8123}
 %dev.logboekdataverwerking.clickhouse.username=ldv
 %dev.logboekdataverwerking.clickhouse.password=ldv
 %test.logboekdataverwerking.clickhouse.endpoint=http://localhost:8123


### PR DESCRIPTION
## Wat

Ontwerp voor een **demo-platform** waarmee de PoC gedemonstreerd kan worden — zowel de ondernemer-flows (Berichtenbox-UI) als de technische degradatie-scenario's — plus de volledige uitvoering van **fase 0: containerisatie**.

De aanpak houdt demo-logica bewust buiten het gedragspad van de bestaande services: een latere wegwerp `demo-console`-module plus Toxiproxy in de compose-stack. Deze PR bevat daar nog niets van; fase 0 maakt alleen de bestaande keten containeriseerbaar.

## Documenten

- `docs/plans/2026-07-21-demo-platform-design.md` — overkoepelend ontwerp, gefaseerd in 8 stappen (status Concept)
- `docs/plans/2026-07-21-demo-platform-fase-0-containerisatie.md` — implementatieplan fase 0 (status Uitgevoerd)

## Fase 0 — wijzigingen

- **`%dev`-regels van beide services overschrijfbaar via env-vars** met default. Buiten containers grijpt de default (ongewijzigd dev-gedrag); in de demo-compose overschrijft de env-var naar container-DNS. Dezelfde varnamen als `%prod`. Geen nieuw `%demo`-profiel, omdat `OutboundTlsValidator` plaintext http alleen in `dev`/`test` toestaat.
- **Compose-profiel `demo`**: zonder profiel blijft compose de infra-modus voor `quarkus:dev`; met `--profile demo` draait de volledige keten in containers (beide magazijnen + uitvraag). Images via jib, geen Dockerfiles.
- **`demo/smoke.sh`**: rookproef die een bericht aanlevert bij magazijn A en het terugvindt via de uitvraag.
- **README**: beide opstartmodi gedocumenteerd.

De diff raakt geen enkele `%test`- of `%prod`-regel; elke default is letterlijk gelijk aan de vorige waarde.

## Ontwerpcorrecties tijdens het plannen

Twee aannames uit het ontwerp bleken niet te kloppen tegen de echte contracten en zijn gecorrigeerd:

- `BerichtAanleverenRequest` accepteert **geen** `berichtId` — het magazijn kent de UUID zelf toe. Herhaalbaarheid van de demo-dataset komt daarom uit vaste inhoud, en legen vóór vullen wordt verplicht.
- Ontdubbeling zit op het CloudEvents-`id` van de aanmeld-webhook (`AanmeldDeduplicatie`), niet op het aanleveren bij het magazijn.

## Verificatie

Lokaal op een machine mét Docker gedraaid en akkoord bevonden: jib-images gebouwd, `./mvnw clean test` groen, `docker compose --profile demo up -d` gestart en `./demo/smoke.sh` doorlopen — de keten werkt end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
