### PR TITLE
fix(ci): sync ClickHouse-pin in deploy.yml naar 26.7

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,7 @@ env:
   # "Permission denied". Kan uit: de sessiecache is ephemeral en rekent nergens op
   # persistence (idempotente RediSearch-bootstrap, TTL-entries, crash-safe vangnet-lock).
   REDIS_IMAGE: redis/redis-stack-server:7.4.0-v3
-  CLICKHOUSE_IMAGE: clickhouse/clickhouse-server:26.6
+  CLICKHOUSE_IMAGE: clickhouse/clickhouse-server:26.7
   # Verse preview-provisioning (`clone-from: test` maakt nieuwe volumes + ingress aan) duurt
   # structureel langer dan het bijwerken van een bestaande deployment. De action-default van
   # 300s is daarvoor te krap: uitvraag en externe-stubs time-outen er reproduceerbaar op


### PR DESCRIPTION
## Aanleiding

`Pin consistency` staat rood op `main` sinds het mergen van #151:

```
clickhouse/clickhouse-server pin(s): clickhouse/clickhouse-server:26.6 clickhouse/clickhouse-server:26.7
::error::clickhouse/clickhouse-server-pin niet uniform
```

Dependabot's docker-compose-ecosystem ziet alléén `compose.yaml`, dus
`CLICKHOUSE_IMAGE` in `.github/workflows/deploy.yml` bleef op 26.6 achter. Dat is
precies de drift die `pin-consistency.yml` moet vangen — de guard doet dus zijn werk.

## Wijziging

`CLICKHOUSE_IMAGE` in `deploy.yml` naar `clickhouse/clickhouse-server:26.7`, gelijk
aan `compose.yaml`.

## Verificatie

Guard-script lokaal gedraaid op deze branch:

```
redis/redis-stack-server pin(s): redis/redis-stack-server:7.4.0-v3
clickhouse/clickhouse-server pin(s): clickhouse/clickhouse-server:26.7
guard-exit=0
```

## Opmerking

`infra-image-pins` is geen required status check, waardoor #151 met een rode guard
kon mergen. Overweging voor later: de check required maken, of Dependabot's
compose-bump aan de andere pins koppelen — nu is een rode `main` de enige melding.
