### PR TITLE
chore(deps): dependabot wekelijks en gegroepeerd per ecosysteem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,36 @@ updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
-      interval: "daily"
+      # Wekelijks i.p.v. dagelijks: bij `daily` force-pusht Dependabot een open groep-PR bij
+      # elke
+      # nieuwe upstream-release, en elke force-push is een volle CI-ronde (test + detekt + drie
+      # preview-deploys). Niet langer dan wekelijks: een maandbatch levert één PR op die te
+      # groot is
+      # om nog te reviewen. Beveiliging hangt hier niet aan: "Dependabot security updates"
+      # staat op de
+      # repo aan, dus een advisory levert direct een fix-PR op, los van dit interval.
+      interval: "weekly"
+    groups:
+      # Quarkus apart: een platform-bump raakt tientallen artefacten in één keer en verdient
+      # een
+      # eigen PR met eigen testrun.
+      quarkus:
+        patterns:
+          - "io.quarkus*"
+          - "quarkus.platform*"
+      # Alle overige minor/patch-bumps in één PR. Majors vallen hier expres buiten en komen dus
+      # als
+      # losse PR — die hebben individuele aandacht nodig (zie de networknt-ignore hieronder
+      # voor waarom).
+      maven-minor-patch:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "io.quarkus*"
+          - "quarkus.platform*"
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
       # openapi-request-validator 3.0.0 is gecompileerd tegen json-schema-validator
       # 2.0.1; networknt 3.x breekt de publieke API (NoSuchMethodError in de
@@ -20,11 +49,19 @@ updates:
   - package-ecosystem: "docker-compose"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      # Eén PR voor de compose-images (postgres, clickhouse, stubs): losse PR's per image
+      # leverden
+      # bumps op die los gemerged werden terwijl de pins in deploy.yml er synchroon mee moeten
+      # blijven.
+      docker-compose:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     groups:
       # codeql-action publiceert init/autobuild/analyze/upload-sarif als losse
       # sub-actions onder één versie. Ze MOETEN samen bewegen: een enkele


### PR DESCRIPTION
Dagelijkse, ongegroepeerde updates leverden de afgelopen 30 dagen **40 gemergede Dependabot-PR's** op.
Twee oorzaken: `maven` en `docker-compose` hadden geen `groups`, dus elke dependency en elke image kreeg
z'n eigen PR; en bij `interval: daily` force-pusht Dependabot een open PR bij elke nieuwe
upstream-release — elke force-push is een volle CI-ronde (`test` + `detekt-gate` + drie
preview-deploys).

## Wat er verandert

| ecosysteem | vóór | na |
|---|---|---|
| `maven` | daily, ongegroepeerd | weekly, groep `quarkus` + groep `maven-minor-patch` (majors los) |
| `docker-compose` | daily, ongegroepeerd | weekly, één groep |
| `github-actions` | daily, al gegroepeerd | weekly |

- **Quarkus apart**: een platform-bump raakt tientallen artefacten in één keer en verdient een eigen PR
  met eigen testrun.
- **Majors expres buiten de groep**: die hebben individuele aandacht nodig. De bestaande
  `com.networknt:json-schema-validator`-ignore is precies zo'n geval, en die regel blijft ongewijzigd.
- **`docker-compose` in één PR**: voorkomt dat een image-bump los gemerged wordt terwijl de pins in
  `deploy.yml` ermee synchroon moeten blijven (waar `infra-image-pins` op controleert).

## Waarom niet maandelijks

Dan wordt de gegroepeerde PR zo groot dat hij niet meer te reviewen is — dat verplaatst de review-ruis
in plaats van 'm te beperken.

## Beveiliging hangt niet aan dit interval

**Dependabot security updates** staat sinds 2026-07-30 aan op deze repo
(`gh api repos/MinBZK/moza-poc-fbs-berichtenbox` → `security_and_analysis.dependabot_security_updates.status: enabled`).
Advisories leveren daardoor direct een fix-PR op, los van het version-updateschema. Zou die instelling
ooit weer uitgaan, dan is dit schema het énige automatische remediatiekanaal en mag het interval niet
langer worden.

Aanleiding: dezelfde afweging in `moza-fsc-testnet`
([#36](https://github.com/MinBZK/moza-fsc-testnet/pull/36)), waar de instelling ook is aangezet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)