### PR TITLE
chore(deps): Maven-version-updates naar wekelijks + preview-timeout 900s

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,15 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
+# Version-updates lopen wekelijks. Dependabot security updates staan aan en komen
+# los van dit schema binnen zodra er een advisory verschijnt; een dagelijkse
+# version-update-ronde voegt daar niets aan toe behalve review-ruis.
 version: 2
 updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     ignore:
       # openapi-request-validator 3.0.0 is gecompileerd tegen json-schema-validator
       # 2.0.1; networknt 3.x breekt de publieke API (NoSuchMethodError in de
@@ -20,11 +23,11 @@ updates:
   - package-ecosystem: "docker-compose"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     groups:
       # codeql-action publiceert init/autobuild/analyze/upload-sarif als losse
       # sub-actions onder één versie. Ze MOETEN samen bewegen: een enkele

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,14 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
-# Version-updates lopen wekelijks. Dependabot security updates staan aan en komen
-# los van dit schema binnen zodra er een advisory verschijnt; een dagelijkse
-# version-update-ronde voegt daar niets aan toe behalve review-ruis.
+# Cadans per ecosystem hangt af van de vraag of Dependabot security updates het
+# betreffende ecosystem dekken: alleen dán is een dagelijkse version-update-ronde
+# overbodige review-ruis. Zie de motivatie per blok hieronder.
 version: 2
 updates:
+  # Wekelijks: security updates staan aan voor dit repo en dekken Maven, dus een
+  # advisory landt hier hoe dan ook meteen — los van dit schema. Het merendeel van
+  # de version-update-ruis komt uit dit blok.
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
@@ -20,14 +23,20 @@ updates:
       # https://github.com/atlassian/openapi-request-validator/pull/24
       - dependency-name: "com.networknt:json-schema-validator"
         update-types: ["version-update:semver-major"]
+  # Dagelijks: Dependabot genereert geen alerts voor container-images, dus voor de
+  # images uit compose.yaml (die via pin-consistency.yml ook de ZAD-runtime-pins
+  # sturen) is deze version-update-ronde het enige signaal dat er een nieuwe versie is.
   - package-ecosystem: "docker-compose"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+  # Dagelijks: alerts komen er alleen voor semver-referenties, en alle `uses:` in dit
+  # repo zijn op commit-SHA gepind (supply-chain-eis). Ook hier is de version-update
+  # dus het enige kanaal; de groepering hieronder houdt het bij hooguit twee PR's.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     groups:
       # codeql-action publiceert init/autobuild/analyze/upload-sarif als losse
       # sub-actions onder één versie. Ze MOETEN samen bewegen: een enkele

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,8 +77,12 @@ env:
   # structureel langer dan het bijwerken van een bestaande deployment. De action-default van
   # 300s is daarvoor te krap: uitvraag en externe-stubs time-outen er reproduceerbaar op
   # ("Task did not complete within 300s"), terwijl de test-deploys (bestaande deployment) in
-  # <100s klaar zijn en de default houden.
-  PREVIEW_TASK_TIMEOUT: '600'
+  # <100s klaar zijn en de default houden. Gelijkgetrokken met de gate-timeout (900s) zodat
+  # er één marge-getal in deze workflow rondgaat.
+  # Let op: dit is de wachttijd van de runner op de OM-task. De melding "timed out waiting for
+  # application to be created" komt daarentegen van OM zelf (Argo-Application-wait) en wordt
+  # NIET door deze waarde beïnvloed — die deploys landen alsnog gezond; opnieuw draaien volstaat.
+  PREVIEW_TASK_TIMEOUT: '900'
 
 jobs:
   # Docs-only PR's (alleen docs/ of *.md) hoeven niet naar ZAD te deployen. Deze job bepaalt dat


### PR DESCRIPTION
## Waarom

Dependabot **security updates** zijn inmiddels aangezet (`automated-security-fixes` = enabled, `vulnerability-alerts` = 204). Daarmee is de dagelijkse version-update-ronde overbodige review-ruis — **maar alleen voor de ecosystems die security updates daadwerkelijk dekken.**

| Ecosystem | Cadans | Reden |
|---|---|---|
| `maven` | **weekly** | Advisory landt via security updates, los van dit schema. Grootste bron van version-update-ruis. |
| `docker-compose` | daily (ongewijzigd) | Dependabot genereert geen alerts voor container-images → version-update is het enige signaal. Voedt via `pin-consistency.yml` ook de ZAD-runtime-pins. |
| `github-actions` | daily (ongewijzigd) | Alerts alleen bij semver; dit repo pint alle `uses:` op commit-SHA → nooit alerts. Groepering houdt het bij hooguit twee PR's. |

## Daarnaast: `PREVIEW_TASK_TIMEOUT` 600 → 900

Gelijkgetrokken met de `gate`-job (`TIMEOUT_SECONDS: '900'`) zodat er één marge-getal in `deploy.yml` rondgaat.

Let op — vastgelegd als comment in de workflow: de deploy-fout `mpfpsm-lcl-pr-159: timed out waiting for application to be created` ontstaat **server-side in de Operations Manager** (Argo-Application-wait) en staat los van deze waarde. Die deployments landen alsnog gezond op ZAD; opnieuw draaien volstaat.

## Ongewijzigd

`ignore`-pin op `com.networknt:json-schema-validator` (major) en de `codeql-action`/`github-actions`-groepering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
