### PR TITLE
ci: gestapelde PR's laten toetsen zonder deploy-gate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,20 @@
 # En op magazijnen: AANMELD_URL → uitvraag-webhook (POST /api/v1/aanmeldingen),
 # NOTIFICATIE_URL → notificatie-stub (POST /events).
 #
+# GESTAPELDE PR'S (base != main) deployen niet — zie het `branches`-filter hieronder. Hun
+# wijzigingen belanden alsnog in een preview zodra ze de PR bereiken die wél op main mikt: die
+# krijgt dan een `synchronize` en rolt zijn eigen pr-<n> opnieuw uit. Wat zo'n PR aan controles
+# houdt: test, detekt-gate en infra-image-pins (die workflows filteren niet op de doelbranch).
+# CodeQL en de fuzz-check draaien er NIET — codeql.yml en cflite_pr.yml filteren nog wel op main,
+# dus die dekking komt pas bij de PR naar main. Een gestapelde PR is dus inhoudelijk getoetst,
+# maar niet security-gescand; weeg dat mee bij het reviewen ervan.
+#
+# BEKENDE BEPERKING: wordt een PR ná een preview-deploy handmatig weggericht van main, dan valt
+# hij buiten dit filter en ruimt het sluiten zijn pr-<n>-deployments en ghcr-tags niet meer op.
+# Handmatig opruimen (of de base terugzetten vóór het sluiten). De omgekeerde beweging —
+# GitHub's automatische retarget náár main bij het mergen van de parent — is veilig: de checks
+# zijn dan afwezig i.p.v. groen, en `strict: true` op main dwingt sowieso een verse run af.
+#
 # Repo-secrets (Settings → Secrets and variables → Actions):
 #   ZAD_API_KEY_UITVRAAG    — API-key project mpfb-8wh
 #   ZAD_API_KEY_PROFIEL     — API-key project mpfpsm-lcl (externe-stubs)
@@ -39,7 +53,19 @@
 name: Deploy ZAD
 
 on:
+  # `branches` filtert op de DOELbranch: alleen PR's naar main bouwen en deployen. Een gestapelde
+  # PR (base = een feature-branch) draait deze workflow dus helemaal niet — geen build, geen
+  # preview, en daarmee ook niets te gaten. Bewust hier en niet als `if:` per job: een job die via
+  # `if:` overslaat rapporteert `skipped`, en dat telt als succes voor branch protection. De drie
+  # `deploy-preview-*` zijn required contexts op main, dus zouden gestapelde PR's groene vinkjes
+  # verzamelen voor deploys die nooit gedraaid hebben. GitHub herricht een gestapelde PR
+  # automatisch naar main zodra de parent merget, zónder nieuw event — die stale vinkjes zouden
+  # dan blijven staan. Zonder run zijn de checks afwezig, wat de merge wél blokkeert.
+  #
+  # Let op de bewuste asymmetrie met test.yml/detekt.yml: die hebben juist géén branch-filter,
+  # want een gestapelde PR verdient wél inhoudelijke toetsing. Alleen de deploy valt weg.
   pull_request:
+    branches: [main]
     types: [opened, synchronize, reopened, closed]
   push:
     branches: [main]

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -3,8 +3,12 @@ name: detekt
 on:
   push:
     branches: [main]
+  # Géén branch-filter op pull_request: die filtert op de DOELbranch, waardoor een gestapelde
+  # PR (base = een feature-branch i.p.v. main) helemaal geen detekt-analyse zou draaien. Zo'n PR
+  # wordt op eigen merites gereviewd en gemerged; zonder analyse komen bevindingen pas aan het
+  # licht op de PR naar main, vermengd met de rest van de stapel. deploy.yml filtert juist wél op
+  # de doelbranch — die deployt niet vanaf een feature-branch. Die asymmetrie is opzet.
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions: read-all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,12 @@ name: Test
 on:
   push:
     branches: [main]
+  # Géén branch-filter op pull_request: die filtert op de DOELbranch, waardoor een gestapelde
+  # PR (base = een feature-branch i.p.v. main) helemaal geen tests zou draaien. Zo'n PR wordt op
+  # eigen merites gereviewd en gemerged; zonder tests komt breuk pas aan het licht op de PR naar
+  # main, vermengd met de wijzigingen van de rest van de stapel. deploy.yml filtert juist wél op
+  # de doelbranch — die deployt niet vanaf een feature-branch. Die asymmetrie is opzet.
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions: read-all


### PR DESCRIPTION
## Wat

Een pull request die niet op `main` mikt maar op een andere branch — een *gestapelde* PR — kan op dit moment niet groen worden. Deze PR haalt die blokkade weg, en regelt tegelijk dat zo'n PR wél inhoudelijk getoetst wordt.

## Wat er misgaat

De `gate`-job in `deploy.yml` bewaakt dat er niets naar ZAD gaat voordat de kwaliteitscontroles geslaagd zijn. Hij wacht daarvoor, met een limiet van 15 minuten, op vier controles: `test`, `detekt-gate`, `infra-image-pins` en de fuzz-controle `PR`.

Twee daarvan konden bij een gestapelde PR nooit binnenkomen. `test.yml` en `detekt.yml` startten namelijk alleen bij een PR *naar* `main` — en zo'n filter kijkt naar de doelbranch, niet naar de branch waar je op werkt. `deploy.yml` had die beperking niet en draaide wel. Gevolg: een kwartier wachten op iets wat niet kon komen, daarna een rode PR.

Op #163 (de eerste gestapelde PR in deze repo) ziet dat er zo uit:

```
Timeout na 900s — nog niet afgerond: test(afwezig) detekt-gate(afwezig) PR(afwezig)
```

Alle controles die wél draaiden waren groen.

## De vraag eronder

Niet: welke controles moet de gate eisen? Maar: waarom zou een PR die niets uitrolt door een deploy-poort moeten? Een gestapelde PR hoort niet naar ZAD te gaan. Zijn wijzigingen belanden er alsnog, want zodra ze de PR bereiken die wél op `main` mikt, rolt díe zijn eigen omgeving opnieuw uit. Een eigen omgeving per tussenstap voegt daar niets aan toe.

De knip ligt dus bij wat er wanneer draait, niet bij wat de gate eist.

## Wat deze PR verandert

- **`test.yml` en `detekt.yml` draaien voortaan op elke pull request.** Een gestapelde PR wordt op eigen merites gereviewd en gemerged; zonder toetsing komt breuk pas boven water op de PR naar `main`, vermengd met de rest van de stapel.
- **`deploy.yml` draait juist alleen nog op PR's naar `main`.** Eén regel op de trigger: geen bouwstap, geen omgeving, geen gate.

Die asymmetrie is opzet en staat als zodanig in alle drie de bestanden toegelicht — anders "repareert" iemand hem later uit symmetrie-overwegingen.

## Waarom op de trigger en niet per job

Dit was de belangrijkste afweging, en de eerste versie van deze PR had hem verkeerd.

Een job die via `if:` wordt overgeslagen rapporteert `skipped`, en dat telt voor branch protection als **geslaagd**. De drie `deploy-preview-*` zijn verplichte controles op `main`. Met voorwaarden per job zou een gestapelde PR dus groene vinkjes verzamelen voor uitrollen die nooit gebeurd zijn. GitHub richt zo'n PR bovendien automatisch op `main` zodra de bovenliggende PR merget, zónder dat daar een nieuwe controle-run bij hoort — die verouderde vinkjes zouden dan blijven staan.

Draait de workflow helemaal niet, dan zijn die controles *afwezig* in plaats van groen. En afwezig blokkeert de merge wél. Dat is het verschil tussen een poort die stil openstaat en een poort die dicht is.

## Effect

| | vóór | ná |
|---|---|---|
| PR naar `main` | bouwen, gate, uitrollen, test, detekt, fuzz, CodeQL, pins | ongewijzigd |
| PR naar een feature-branch | alleen pins → gate faalt na 15 min | test, detekt, pins → groen, geen uitrol |
| push naar `main` | ongewijzigd | ongewijzigd |

Geen enkele job-voorwaarde in `deploy.yml` is aangeraakt; de wijziging daar is één regel plus toelichting.

## Wat een gestapelde PR niet krijgt

Bewust vastgelegd in de kop van `deploy.yml`, want een reviewer moet dit weten:

- **Geen CodeQL en geen fuzzing.** Die twee workflows filteren nog wel op de doelbranch. Een gestapelde PR is dus inhoudelijk getoetst maar niet security-gescand; die dekking komt bij de PR naar `main`.
- **Geen containerisatie-controle.** Compileren en testen gebeurt wel; het bouwen van de images komt eveneens pas bij de PR naar `main`.

## Bekende beperking

Wordt een PR ná een uitrol handmatig wéggericht van `main`, dan valt hij buiten het filter en ruimt het sluiten zijn omgevingen en images niet meer op. Handmatig opruimen, of de doelbranch terugzetten vóór het sluiten. Staat als waarschuwing in het bestand.

De omgekeerde beweging — GitHub's automatische omrichting náár `main` bij het mergen van de bovenliggende PR — is veilig: de controles zijn dan afwezig in plaats van groen, en `strict: true` op `main` dwingt sowieso een verse run af.

## Reviewaanwijzing

De diff is klein maar de redenering zit in de toelichting. Twee dingen zijn de moeite van het narekenen waard: dat `skipped` inderdaad als geslaagd telt voor de verplichte controles, en dat de drie `deploy-preview-*` daadwerkelijk verplicht zijn op `main` (`gh api repos/{owner}/{repo}/branches/main/protection`).

## Verificatie

Deze PR gaat zelf naar `main` en is daarmee de regressietest op de normale route. Alle controles
groen, met de deploy-keten volledig doorlopen:

```
gate                          pass   7m13s
test                          pass    7m6s
Analyze (kotlin)              pass   4m10s
detekt-gate                   pass     55s
infra-image-pins              pass      6s
build (berichtenmagazijn)     pass   1m10s
build (berichtenuitvraag)     pass   1m24s
build-externe-stubs           pass     28s
deploy-preview-uitvraag       pass     36s
deploy-preview-magazijnen     pass     41s
deploy-preview-externe-stubs  pass     31s
PR (fuzz)                     skipping — de workflow skipt intern; telt als geslaagd
```

Dat gate, build en de drie preview-uitrollen hier gewoon draaien en slagen, is het bewijs dat het
nieuwe `branches`-filter een PR naar `main` niet raakt.

Eén ruis in de historie: de eerste run op deze commit zag `build` twee keer falen op een 403 van
ghcr (*"You have exceeded a secondary rate limit"*) bij het pushen van het manifest. Gevolg van
drie pushes kort achter elkaar op dezelfde `pr-164`-tag, niet van deze wijziging — de fout valt ná
een geslaagde build, puur op het uploaden. Opnieuw gedraaid na een pauze: beide groen.

De andere helft — een gestapelde PR die groen wordt zonder uit te rollen — is nog niet waar te nemen. #163 draait de workflows uit zijn eigen basis, en die bevat deze wijziging pas nadat #150 met `main` gesynchroniseerd is. Volgorde: deze PR mergen → #150 syncen → #163 opnieuw laten draaien. Pas dan is bewezen dat `deploy.yml` daar netjes wegblijft en `test`/`detekt-gate` verschijnen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

