### PR TITLE
fix(magazijn): dubbele smallrye-openapi.path uit application.properties

### DIFF
--- a/services/berichtenmagazijn/src/main/resources/application.properties
+++ b/services/berichtenmagazijn/src/main/resources/application.properties
@@ -15,7 +15,9 @@ quarkus.http.port=8090
 # http binnen de mesh/ingress-grens. Zie HttpTlsValidator (BIO 13.2.1).
 %prod.fbs.http.tls.termination=${HTTP_TLS_TERMINATION:app}
 
-# OpenAPI / Swagger UI (ADR: spec MOET op /openapi.json beschikbaar zijn)
+# OpenAPI / Swagger UI (ADR: spec MOET op /openapi.json beschikbaar zijn). Dit
+# is tevens het runtime-endpoint voor NeRDS `/core/publish-openapi` en discovery
+# via developer.overheid.nl.
 quarkus.smallrye-openapi.path=/openapi.json
 quarkus.swagger-ui.always-include=true
 
@@ -43,9 +45,6 @@ quarkus.http.limits.max-body-size=40M
 # `/core/transport/cors` vereist een expliciete policy (mag dus ook "uit").
 quarkus.http.cors.enabled=false
 
-# OpenAPI runtime endpoint — vereist voor NeRDS `/core/publish-openapi` en voor
-# discovery via developer.overheid.nl. Stand-alone YAML/JSON i.p.v. Swagger UI.
-quarkus.smallrye-openapi.path=/openapi
 # Bron-spec wordt door OpenAPI-generator als interface gegenereerd; SmallRye
 # regenereert hem hier vanuit de gegenereerde JAX-RS-resources zodat runtime-
 # gemigreerde paths exact getoond worden.


### PR DESCRIPTION
## Aanleiding

De configuratie van berichtenmagazijn zette het OpenAPI-pad twee keer: eerst op `/openapi.json` (de ADR-vereiste waarde) en verderop nogmaals op `/openapi`. Bij elke start van de service leverde dat een `SRCFG01007`-waarschuwing op, en formeel won de laatste waarde — de spec stond dus op `/openapi`.

Dat `/openapi.json` in de praktijk tóch werkt (bevestigd op de test-deployment: beide paden geven 200) komt doordat SmallRye bij `path=/openapi` ook het `.json`-suffix meeserveert. Dat is een neveneffect, geen contract. Bij berichtenuitvraag — dat maar één regel heeft — geeft `/openapi` juist een 404, wat het verschil laat zien.

## Wijziging

- De tweede regel (`/openapi`) is verwijderd; `/openapi.json` blijft staan, gelijk aan berichtenuitvraag.
- De rationale uit het verwijderde blok (NeRDS `/core/publish-openapi`, discovery via developer.overheid.nl) is samengevoegd met het overgebleven commentaarblok, zodat die reden niet verdwijnt.

Alleen commentaar en één configuratieregel; geen gedragsverandering op `/openapi.json`.

## Verificatie

- Geen enkele consumer (tests, Bruno-collecties, workflows, docs) verwijst naar het kale `/openapi`-pad — gecontroleerd met grep over de repo.
- `./mvnw clean compile -pl services/berichtenmagazijn -am` → BUILD SUCCESS.
- De volledige testsuite vereist Docker (Dev Services/Testcontainers) en kon lokaal niet draaien; CI dekt dat af.

🤖 Generated with [Claude Code](https://claude.com/claude-code)