### PR TITLE
fix(ci): preview rolt uit per commit via unieke image-tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -156,6 +156,18 @@ jobs:
           fi
 
   # Afgeleide waarden op één plek: image-tag + lowercase GHCR-owner (GHCR eist lowercase).
+  #
+  # De PR-tag draagt de head-sha en is dus UNIEK per commit — dat is de kern van de
+  # preview-uitrol, geen cosmetica. De deploy zet de image-referentie in het door Operations
+  # Manager gerenderde k8s-manifest, en Argo CD rolt alleen uit bij een verschil in dát
+  # manifest. Met een vaste tag `pr-<n>` blijft het manifest bij elke volgende commit
+  # byte-identiek: de deploy-check wordt groen terwijl de pod op de image-laag van de eerste
+  # build blijft draaien. `imagePullPolicy: Always` vangt dat niet af — dat werkt pas bij een
+  # herstart, en die komt niet vanzelf. Op main speelde het niet: `main-<sha7>` wijzigt al
+  # per commit.
+  #
+  # Elke build krijgt zo zijn eigen tag; `cleanup-preview-images` ruimt ze bij PR-sluiten
+  # allemaal op (op prefix, niet op één exacte tag).
   meta:
     runs-on: ubuntu-latest
     outputs:
@@ -163,9 +175,16 @@ jobs:
       owner: ${{ steps.m.outputs.owner }}
     steps:
       - id: m
+        # Variabele waarden via env i.p.v. inline interpolatie (defense-in-depth injectie).
+        env:
+          EVENT: ${{ github.event_name }}
+          PR: ${{ github.event.number }}
+          # Op een pull_request-event is GITHUB_SHA de (efemere) merge-commit; de head-sha is
+          # wat in de PR-tijdlijn staat en waar een reviewer op kan matchen.
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "tag=pr-${{ github.event.number }}" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT" = "pull_request" ]; then
+            echo "tag=pr-${PR}-${HEAD_SHA::7}" >> "$GITHUB_OUTPUT"
           else
             echo "tag=main-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
           fi
@@ -425,16 +444,16 @@ jobs:
               {"name": "magazijnb", "image": "${{ env.REGISTRY }}/${{ needs.meta.outputs.owner }}/fbs-berichtenmagazijn:${{ needs.meta.outputs.tag }}"}
             ]
 
-  # Opruimen bij PR-sluiten: per project een eigen (parallelle) job, elk ruimt zijn eigen
-  # deployment + ÓNZE images op. De GitHub-environment (één per PR) ruimt alleen de
-  # uitvraag-job op; de andere zetten delete-github-env uit.
+  # Opruimen bij PR-sluiten: per project een eigen (parallelle) job die zijn eigen deployment
+  # opruimt. De GitHub-environment (één per PR) ruimt alleen de uitvraag-job op; de andere
+  # zetten delete-github-env uit. De images gaan in één aparte job (cleanup-preview-images):
+  # de `delete-container`-stap van zad-actions verwijdert precies één exacte tag per package,
+  # en een PR heeft er sinds de unieke tags één per commit.
   cleanup-preview-uitvraag:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    needs: meta
     runs-on: ubuntu-latest
     permissions:
       deployments: write
-      packages: write
       pull-requests: write
     steps:
       # Pre-flight: een ontbrekende GH_ADMIN_TOKEN zou de env-/deployment-cleanup pas
@@ -455,19 +474,12 @@ jobs:
           deployment-name: pr-${{ github.event.pull_request.number }}
           delete-github-env: 'true'
           delete-github-deployments: 'true'
-          delete-container: 'true'
-          containers: |
-            [
-              {"org": "${{ needs.meta.outputs.owner }}", "name": "fbs-berichtenuitvraag", "tag": "${{ needs.meta.outputs.tag }}"}
-            ]
+          delete-container: 'false'
           github-admin-token: ${{ secrets.GH_ADMIN_TOKEN }}
 
   cleanup-preview-externe-stubs:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    needs: meta
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
     steps:
       - name: Cleanup externe-stubs-project
         uses: RijksICTGilde/zad-actions/cleanup@13434cd415db0cd195a2c5f12bf67645acfcb635 # v4
@@ -476,18 +488,11 @@ jobs:
           project-id: ${{ env.PROJECT_EXTERNE_STUBS }}
           deployment-name: pr-${{ github.event.pull_request.number }}
           delete-github-env: 'false'
-          delete-container: 'true'
-          containers: |
-            [
-              {"org": "${{ needs.meta.outputs.owner }}", "name": "fbs-externe-stubs", "tag": "${{ needs.meta.outputs.tag }}"}
-            ]
+          delete-container: 'false'
 
   cleanup-preview-magazijnen:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    needs: meta
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
     steps:
       - name: Cleanup magazijnen-project
         uses: RijksICTGilde/zad-actions/cleanup@13434cd415db0cd195a2c5f12bf67645acfcb635 # v4
@@ -496,11 +501,62 @@ jobs:
           project-id: ${{ env.PROJECT_MAGAZIJNEN }}
           deployment-name: pr-${{ github.event.pull_request.number }}
           delete-github-env: 'false'
-          delete-container: 'true'
-          containers: |
-            [
-              {"org": "${{ needs.meta.outputs.owner }}", "name": "fbs-berichtenmagazijn", "tag": "${{ needs.meta.outputs.tag }}"}
-            ]
+          delete-container: 'false'
+
+  # Ruimt ALLE images van de PR op: één ghcr-versie per commit, niet alleen de laatste. De
+  # tags van deze PR zijn te herkennen aan de prefix `pr-<n>-`; het afsluitende koppelteken
+  # is essentieel, anders zou het sluiten van PR 16 de images van PR 168 meenemen.
+  #
+  # Bewust niet de `delete-container`-stap van zad-actions: die verwijdert één exacte tag, wat
+  # met unieke tags per commit alle tussenversies zou laten staan. Ook bewust géén
+  # package-brede fallback bij "cannot delete the last tagged version" (die de action wél
+  # heeft): dat zou een preview-cleanup het hele package laten verwijderen inclusief de
+  # main-images. De `main-<sha7>`-tags zorgen ervoor dat die situatie zich niet voordoet.
+  cleanup-preview-images:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    needs: meta
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Verwijder de ghcr-versies van deze PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG: ${{ needs.meta.outputs.owner }}
+          PREFIX: pr-${{ github.event.pull_request.number }}-
+        run: |
+          set -euo pipefail
+          fail=0
+
+          for pkg in fbs-berichtenuitvraag fbs-berichtenmagazijn fbs-externe-stubs; do
+            if ! versions=$(gh api --paginate "orgs/$ORG/packages/container/$pkg/versions?per_page=100"); then
+              echo "::warning::Kon de versies van $pkg niet ophalen — images van deze PR blijven mogelijk staan."
+              fail=1
+              continue
+            fi
+
+            # --paginate levert per pagina een eigen array; jq verwerkt ze als losse inputs.
+            ids=$(printf '%s' "$versions" | jq -r --arg p "$PREFIX" \
+              '.[] | select(.metadata.container.tags | any(startswith($p))) | .id')
+
+            if [ -z "$ids" ]; then
+              echo "$pkg: geen versies met tag-prefix $PREFIX."
+              continue
+            fi
+
+            for id in $ids; do
+              if gh api "orgs/$ORG/packages/container/$pkg/versions/$id" -X DELETE; then
+                echo "$pkg: versie $id verwijderd."
+              else
+                echo "::warning::$pkg: versie $id niet verwijderd."
+                fail=1
+              fi
+            done
+          done
+
+          # Achterblijvende images zijn geen reden om de PR-afsluiting te blokkeren, maar het
+          # moet wel als rode job zichtbaar zijn — anders groeit de ghcr-berg ongemerkt door.
+          exit "$fail"
 
   # Push naar main → per project de `test`-deployment (de baseline waarvan previews klonen;
   # env/secrets configureer je daar in Operations Manager). Per project een eigen parallelle job.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,25 +115,40 @@ env:
   PREVIEW_TASK_TIMEOUT: '900'
 
 jobs:
-  # Docs-only PR's (alleen docs/ of *.md) hoeven niet naar ZAD te deployen. Deze job bepaalt dat
-  # één keer; de kwaliteits-`gate` en de deploy-preview-jobs hangen eraan en worden op een
-  # docs-only PR overgeslagen — 'skipped' telt als succes voor de required checks, dus de merge
-  # blijft mogelijk. Op een push naar main draait alles altijd (run=true).
+  # Bepaalt één keer of deze revisie de bouw-en-deployketen in moet. De `gate`, de build-jobs en
+  # de deploy-preview-jobs hangen eraan; 'skipped' telt als succes voor de required checks, dus
+  # de merge blijft mogelijk. Op een push naar main draait alles altijd (run=true).
+  #
+  # Twee gevallen slaan we over:
+  # - Docs-only PR's (alleen docs/ of *.md): er is niets te draaien op ZAD.
+  # - PR's van een bot: `zad-actions` weigert die zelf (`skip-bot-prs`, default true), dus de
+  #   preview komt er toch niet. Zonder deze uitsluiting bouwden en pushten we er wél drie
+  #   images voor die nooit een pod bereiken — en de cleanup slaat bot-PR's óók over, dus die
+  #   bleven permanent in ghcr staan (zichtbaar aan `pr-143` en `pr-167` van gesloten
+  #   Dependabot-PR's).
   changes:
     runs-on: ubuntu-latest
     outputs:
       run: ${{ steps.filter.outputs.run }}
     steps:
-      - name: Detecteer niet-documentatie wijzigingen
+      - name: Bepaal of er gebouwd en gedeployd moet worden
         id: filter
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVENT: ${{ github.event_name }}
           REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
+          # Het type komt van GitHub zelf (enum), niet uit door de indiener bepaalde tekst.
+          PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
         run: |
           if [ "$EVENT" != "pull_request" ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$PR_AUTHOR_TYPE" = "Bot" ]; then
+            echo "PR van een bot — zad-actions deployt die niet, dus bouwen we ook niet."
+            echo "run=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           # Fail-safe: kan de bestandenlijst niet opgehaald worden (API-hik, rate-limit), deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -296,7 +296,8 @@ jobs:
   # triggert alleen op docs/architecture-wijzigingen — op een gewone PR verschijnt er geen
   # check-run ('afwezig'), waardoor de gate anders tot de timeout zou blijven wachten.
   gate:
-    # Niet op PR-close (teardown, geen deploy) en niet op een docs-only PR (niets te deployen).
+    # Niet op PR-close (teardown, geen deploy) en niet wanneer `changes` de keten heeft
+    # uitgesloten (docs-only of bot-PR) — dan valt er niets te bewaken.
     if: github.event_name == 'push' || (github.event.action != 'closed' && needs.changes.outputs.run == 'true')
     needs: changes
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -147,7 +147,9 @@ jobs:
           fi
 
           if [ "$PR_AUTHOR_TYPE" = "Bot" ]; then
-            echo "PR van een bot — zad-actions deployt die niet, dus bouwen we ook niet."
+            # Luid loggen: een overgeslagen deploy laat de required checks 'skipped' (= succes)
+            # rapporteren, dus een onterechte overslag moet in de run-samenvatting zichtbaar zijn.
+            echo "::notice::PR van een bot — zad-actions deployt die niet, dus bouwen we ook niet."
             echo "run=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -552,6 +554,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG: ${{ needs.meta.outputs.owner }}
           PREFIX: pr-${{ github.event.pull_request.number }}-
+          # Overgangsgeval: PR's die al liepen vóór de unieke tags bestonden, hebben nog een
+          # kale `pr-<n>`-versie in ghcr staan. Die valt niet onder de prefix, dus expliciet
+          # meenemen — anders blijft hij achter zodra zo'n PR sluit.
+          LEGACY_TAG: pr-${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
           fail=0
@@ -569,11 +575,11 @@ jobs:
             fi
 
             # --paginate levert per pagina een eigen array; jq verwerkt ze als losse inputs.
-            ids=$(printf '%s' "$versions" | jq -r --arg p "$PREFIX" \
-              '.[] | select(.metadata.container.tags | any(startswith($p))) | .id')
+            ids=$(printf '%s' "$versions" | jq -r --arg p "$PREFIX" --arg legacy "$LEGACY_TAG" \
+              '.[] | select(.metadata.container.tags | any(startswith($p) or . == $legacy)) | .id')
 
             if [ -z "$ids" ]; then
-              echo "$pkg: geen versies met tag-prefix $PREFIX."
+              echo "$pkg: geen versies met tag $LEGACY_TAG of prefix $PREFIX."
               continue
             fi
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -184,7 +184,7 @@ jobs:
   # per commit.
   #
   # Elke build krijgt zo zijn eigen tag; `cleanup-preview-images` ruimt ze bij PR-sluiten
-  # allemaal op (op prefix, niet op één exacte tag).
+  # allemaal op — op prefix, plus de kale `pr-<n>` van vóór deze wijziging.
   meta:
     runs-on: ubuntu-latest
     outputs:
@@ -217,9 +217,10 @@ jobs:
           fi
           echo "owner=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
 
-  # Bouw + push de service-images met jib (geen Dockerfile). Niet op PR-close en niet op een
-  # docs-only PR: die deployt toch niet, dus twee volledige Maven/jib-builds + push zouden
-  # alleen rekentijd, netwerk en een ghcr-versie kosten die nooit een pod bereikt.
+  # Bouw + push de service-images met jib (geen Dockerfile). Niet op PR-close, en niet wanneer
+  # `changes` de keten heeft uitgesloten: zo'n revisie deployt toch niet, dus twee volledige
+  # Maven/jib-builds + push kosten dan alleen rekentijd, netwerk en een ghcr-versie die nooit
+  # een pod bereikt.
   build:
     if: github.event_name == 'push' || (github.event.action != 'closed' && needs.changes.outputs.run == 'true')
     needs: [meta, changes]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -184,16 +184,28 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           if [ "$EVENT" = "pull_request" ]; then
-            echo "tag=pr-${PR}-${HEAD_SHA::7}" >> "$GITHUB_OUTPUT"
+            tag="pr-${PR}-${HEAD_SHA::7}"
+
+            # Een herdraai bouwt uit refs/pull/<n>/merge, dus met de main van dát moment. Is main
+            # inmiddels verder, dan levert dezelfde head-sha andere inhoud op en zou de tag
+            # verschuiven — precies de bevriezing die deze tagvorm moet voorkomen. Vanaf poging 2
+            # dus een eigen tag. Poging 1 (het normale geval) blijft kaal en leesbaar.
+            if [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+              tag="${tag}-r${GITHUB_RUN_ATTEMPT}"
+            fi
+
+            echo "tag=$tag" >> "$GITHUB_OUTPUT"
           else
             echo "tag=main-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
           fi
           echo "owner=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
 
-  # Bouw + push de service-images met jib (geen Dockerfile). Niet op PR-close.
+  # Bouw + push de service-images met jib (geen Dockerfile). Niet op PR-close en niet op een
+  # docs-only PR: die deployt toch niet, dus twee volledige Maven/jib-builds + push zouden
+  # alleen rekentijd, netwerk en een ghcr-versie kosten die nooit een pod bereikt.
   build:
-    if: github.event_name == 'push' || github.event.action != 'closed'
-    needs: meta
+    if: github.event_name == 'push' || (github.event.action != 'closed' && needs.changes.outputs.run == 'true')
+    needs: [meta, changes]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -234,8 +246,8 @@ jobs:
   # Externe-stubs: één WireMock-image met de profiel- én notificatie-mappings erin gebakken
   # (plain docker, geen jib). Wordt als twee losse componenten gedeployd (profiel + notificatie).
   build-externe-stubs:
-    if: github.event_name == 'push' || github.event.action != 'closed'
-    needs: meta
+    if: github.event_name == 'push' || (github.event.action != 'closed' && needs.changes.outputs.run == 'true')
+    needs: [meta, changes]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -528,6 +540,11 @@ jobs:
           set -euo pipefail
           fail=0
 
+          # Expliciete lijst, bewust niet afgeleid uit alle org-packages: de prefix `pr-<n>-`
+          # is niet uniek binnen de organisatie, dus een brede sweep zou images van een
+          # gelijkgenummerde PR in een andere repo kunnen wissen. Houd deze lijst in sync met
+          # de `build`-matrix en `build-externe-stubs`; een vergeten package laat weesversies
+          # achter.
           for pkg in fbs-berichtenuitvraag fbs-berichtenmagazijn fbs-externe-stubs; do
             if ! versions=$(gh api --paginate "orgs/$ORG/packages/container/$pkg/versions?per_page=100"); then
               echo "::warning::Kon de versies van $pkg niet ophalen — images van deze PR blijven mogelijk staan."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,9 +201,14 @@ géén uitgeschakeld component**).
   (bv. een oude `:main`-tag) terwijl de gesyncte manifest allang een geldige tag heeft.
   **Verifieer altijd eerst de tag/`replicas` in het gerenderde `*-deployment.yaml`** vóór
   je de UI-fouttekst gelooft.
-- De workflow pusht tags `main-<sha7>` (push→main) en `pr-<n>` (PR) — **nooit** een kale
-  `:main`. Zie de `meta`-job in `deploy.yml`. Een deployment die `:main` verwacht, is
-  handmatig/verouderd geconfigureerd.
+- De workflow pusht tags `main-<sha7>` (push→main) en `pr-<n>-<sha7>` (PR) — **nooit** een
+  kale `:main` of `:pr-<n>`. Zie de `meta`-job in `deploy.yml`. Een deployment die `:main`
+  verwacht, is handmatig/verouderd geconfigureerd.
+- **Image-tags moeten uniek zijn per commit.** Argo synct op verschil in het gerenderde
+  manifest; een herbruikte tag laat dat manifest ongewijzigd, dus rolt er niets uit en
+  blijft de preview op de eerste build hangen terwijl de deploy-check groen is
+  (`imagePullPolicy: Always` werkt pas bij een herstart). Bij PR-sluiten ruimt
+  `cleanup-preview-images` alle `pr-<n>-*`-versies in ghcr op.
 - De ghcr-images (`ghcr.io/minbzk/fbs-*`) zijn **public**; ZAD trekt ze via de
   pull-through-mirror `rcr.rijksapps.nl/ghcr-rig/minbzk/*`. Een 404 op een bestaande,
   publieke tag wijst op de mirror/registry-config aan ZAD-zijde, niet op onze push.

--- a/docs/plans/2026-08-10-preview-uitrol-per-commit.md
+++ b/docs/plans/2026-08-10-preview-uitrol-per-commit.md
@@ -70,6 +70,15 @@ Bestaat niet. `:refresh` reconcilet zonder revisiewijziging, en een deployment h
 (`DELETE` + `:upsert-deployment`) draait op projecten met de `postgresql-database`-service een
 `database_cleanup` — dat vernietigt data en is geen routine-oplossing.
 
+### Stand aan ZAD-zijde
+
+Het ZAD-team beschouwt het uitblijven van een rollout bij een ongewijzigde image-referentie als
+een fout aan hun kant en werkt aan een oplossing (gemeld 2026-08-10). Dat verandert deze
+wijziging niet en maakt hem ook niet tijdelijk: een unieke tag per commit is het patroon dat
+`zad-actions/deploy` in al zijn eigen voorbeelden hanteert (`:${{ github.sha }}`), het levert
+herleidbaarheid op van draaiende pod naar commit, en het is de voorwaarde waaronder de
+image-cleanup compleet kan zijn. Er valt na hun fix dus niets terug te draaien.
+
 ### Conclusie
 
 Richting 2. Richting 1 lost het bevriezen even goed op, maar laat het opruimprobleem staan en

--- a/docs/plans/2026-08-10-preview-uitrol-per-commit.md
+++ b/docs/plans/2026-08-10-preview-uitrol-per-commit.md
@@ -100,6 +100,13 @@ mee op.
   sha die in de PR-tijdlijn staat, niet de efemere merge-commit uit `GITHUB_SHA`. De
   interpolaties gaan via `env:` (defense-in-depth injectie), zoals de rest van de workflow.
   De `main`-tak blijft `main-<sha7>`.
+- `meta`: bij een herdraai (`GITHUB_RUN_ATTEMPT > 1`) krijgt de tag een `-r<n>`-achtervoegsel.
+  Een herdraai bouwt uit `refs/pull/<n>/merge` met de main van dát moment; is main inmiddels
+  verder, dan levert dezelfde head-sha andere inhoud onder dezelfde tag op — de bevriezing die
+  deze tagvorm juist moet uitsluiten, plus een ongetagde weesversie. Poging 1, het normale
+  geval, houdt de kale leesbare tag.
+- `build` en `build-externe-stubs` slaan een docs-only PR over (`needs: changes`), net als de
+  `gate` en de deploys dat al deden.
 - `cleanup-preview-*`: `delete-container: 'false'`; de `containers`-lijst en de daarvoor
   benodigde `packages: write` + `needs: meta` zijn weg.
 - Nieuw: `cleanup-preview-images` ruimt bij PR-sluiten alle ghcr-versies op waarvan minstens
@@ -114,6 +121,24 @@ niet voordoet.
 
 `CLAUDE.md`: de tag-conventie in "ZAD deploy & GitOps (debug)" bijgewerkt, plus de reden dat
 image-tags uniek per commit moeten zijn.
+
+## Digitale verspilling
+
+Een review met de duurzaamheidsbril (NeRDS 13, green coding) leverde één harde vondst op, met
+bewijs uit deze PR zelf. De `build`-jobs hingen niet aan de `changes`-filter, terwijl de `gate`
+en de deploys dat wel deden. Een docs-only commit bouwde dus twee volledige Maven/jib-images
+plus de WireMock-image en pushte die naar ghcr, waarna er niets mee gebeurde: de commits
+`3e2866c` en `941933a` van deze PR raakten alleen `docs/plans/*.md` en hebben desondanks
+`pr-172-3e2866c` en `pr-172-941933a` in beide service-packages staan.
+
+Dat kostte per docs-commit een volledige buildcyclus (Maven-augmentatie, jib-push, docker
+build/push) zonder enige afnemer. Met de unieke tags weegt het bovendien zwaarder dan voorheen:
+elke overbodige build laat nu een eigen ghcr-versie achter in plaats van een tag te verplaatsen.
+De jobs hangen nu aan dezelfde filter als de rest.
+
+Blijft staan als bewuste afweging: elke commit vernieuwt de tag van alle app-componenten, dus
+rollen ze alle mee. Zie "Openstaand" — zonder reproduceerbare build valt daar niets aan te
+winnen, ook niet met een digest.
 
 ## Randvoorwaarden getoetst
 
@@ -154,12 +179,19 @@ ze niet — het afsluitende koppelteken doet zijn werk.
 ## Openstaand
 
 **Per-component granulariteit.** Elke commit vernieuwt nu de tag van alle app-componenten, dus
-rollen ze alle vijf mee terwijl er vaak één service wijzigde. Het alternatief dat dat wél
-scheidt: de unieke tag blijven pushen (voor toewijsbaarheid en opruimen) maar op digest
-deployen. Een ongewijzigd component houdt dan dezelfde digest — jib bouwt reproduceerbaar — en
-rolt niet mee; ghcr hangt de nieuwe tag simpelweg aan dezelfde versie. Vergt één stap die na de
-push de digest ophaalt, plus de vaststelling dat OM en de pull-through-mirror een
-`@sha256:`-referentie aankunnen. Alleen oppakken als de overbodige rollouts merkbaar hinderen.
+rollen ze alle mee terwijl er vaak één service wijzigde.
+
+Deployen op digest lost dat níét op, ondanks wat je zou verwachten. Gemeten op de vijf builds
+van deze PR: `berichtenuitvraag` werd geen byte gewijzigd en commit `3fb1f96` draaide de
+voorgaande commit exact terug, en tóch heeft elke build een eigen digest (magazijn:
+`341796cb…`, `bbba6900…`, `5fc3d971…`, `93715c51…`, `ed7804c5…`). Onze jib-build is dus niet
+reproduceerbaar: de digest volgt de build, niet de inhoud. Een digest-deploy zou hetzelfde
+rolgedrag geven als de unieke tag, plus een resolve-stap en een onbewezen aanname over OM en de
+pull-through-mirror.
+
+Wie de granulariteit écht wil, moet eerst de build reproduceerbaar maken (build-timestamps
+pinnen, `SOURCE_DATE_EPOCH`). Dat is een eigen traject; pas daarna wordt een digest-deploy
+zinvol.
 
 De ~157 bestaande ongetagde ghcr-versies van `fbs-berichtenmagazijn` (en de overeenkomstige
 van de andere twee packages) blijven staan: ze zijn niet aan een PR toe te wijzen. Ze

--- a/docs/plans/2026-08-10-preview-uitrol-per-commit.md
+++ b/docs/plans/2026-08-10-preview-uitrol-per-commit.md
@@ -110,7 +110,9 @@ mee op.
 - `cleanup-preview-*`: `delete-container: 'false'`; de `containers`-lijst en de daarvoor
   benodigde `packages: write` + `needs: meta` zijn weg.
 - Nieuw: `cleanup-preview-images` ruimt bij PR-sluiten alle ghcr-versies op waarvan minstens
-  één tag begint met `pr-<n>-`. Het afsluitende koppelteken is essentieel: zonder dat zou het
+  één tag begint met `pr-<n>-`, plus de kale `pr-<n>`-tag. Die laatste is het overgangsgeval:
+  PR's die al liepen toen de tag nog vast was (#150, #163, #166, #168, #170 op het moment van
+  schrijven) hebben zo'n versie staan, en die valt niet onder de prefix. Het afsluitende koppelteken is essentieel: zonder dat zou het
   sluiten van PR 16 de images van PR 168 meenemen. De job faalt zichtbaar (rood) als een
   verwijdering mislukt, zodat een groeiende ghcr-berg niet ongemerkt ontstaat.
 

--- a/docs/plans/2026-08-10-preview-uitrol-per-commit.md
+++ b/docs/plans/2026-08-10-preview-uitrol-per-commit.md
@@ -72,12 +72,18 @@ Bestaat niet. `:refresh` reconcilet zonder revisiewijziging, en een deployment h
 
 ### Stand aan ZAD-zijde
 
-Het ZAD-team beschouwt het uitblijven van een rollout bij een ongewijzigde image-referentie als
-een fout aan hun kant en werkt aan een oplossing (gemeld 2026-08-10). Dat verandert deze
-wijziging niet en maakt hem ook niet tijdelijk: een unieke tag per commit is het patroon dat
-`zad-actions/deploy` in al zijn eigen voorbeelden hanteert (`:${{ github.sha }}`), het levert
-herleidbaarheid op van draaiende pod naar commit, en het is de voorwaarde waaronder de
-image-cleanup compleet kan zijn. Er valt na hun fix dus niets terug te draaien.
+Niet uitrollen bij een ongewijzigde image-referentie is aan ZAD-zijde opzet, geen fout
+(bevestigd door het ZAD-team, 2026-08-10): bij een deployment met tien componenten mag één
+gewijzigde image niet alle tien vervangen. De oplossing moet daar dus binnen passen, niet
+omheen — en dat doet een per-commit wijzigende referentie ook: ZAD rolt uit omdat de referentie
+écht anders is.
+
+Wel de keerzijde benoemen: een tag die de commit-sha draagt wijzigt voor álle componenten bij
+elke commit, ook als alleen `berichtenuitvraag` veranderde. Op deze drie projecten (vijf
+app-pods, plus redis/clickhouse die hun eigen vaste pin houden) is dat goedkoop, maar het is
+precies de granulariteit die ZAD bewaakt. Wie die wil behouden, deployt op digest en pusht
+daarnaast de unieke tag voor de opruimkant: een ongewijzigd component levert dan dezelfde
+digest en rolt niet, een gewijzigd component wel. Zie "Openstaand".
 
 ### Conclusie
 
@@ -146,6 +152,14 @@ De opruimkant is drooggetest tegen de echte ghcr-data: het filter van
 ze niet — het afsluitende koppelteken doet zijn werk.
 
 ## Openstaand
+
+**Per-component granulariteit.** Elke commit vernieuwt nu de tag van alle app-componenten, dus
+rollen ze alle vijf mee terwijl er vaak één service wijzigde. Het alternatief dat dat wél
+scheidt: de unieke tag blijven pushen (voor toewijsbaarheid en opruimen) maar op digest
+deployen. Een ongewijzigd component houdt dan dezelfde digest — jib bouwt reproduceerbaar — en
+rolt niet mee; ghcr hangt de nieuwe tag simpelweg aan dezelfde versie. Vergt één stap die na de
+push de digest ophaalt, plus de vaststelling dat OM en de pull-through-mirror een
+`@sha256:`-referentie aankunnen. Alleen oppakken als de overbodige rollouts merkbaar hinderen.
 
 De ~157 bestaande ongetagde ghcr-versies van `fbs-berichtenmagazijn` (en de overeenkomstige
 van de andere twee packages) blijven staan: ze zijn niet aan een PR toe te wijzen. Ze

--- a/docs/plans/2026-08-10-preview-uitrol-per-commit.md
+++ b/docs/plans/2026-08-10-preview-uitrol-per-commit.md
@@ -114,17 +114,27 @@ image-tags uniek per commit moeten zijn.
 
 ## Verificatie
 
-Een groene CI-run is hier geen bewijs — dat was juist het probleem. Aangetoond op de PR van
-deze wijziging zelf:
+Een groene CI-run is hier geen bewijs — dat was juist het probleem. Aangetoond op PR #172 zelf,
+met `magazijna` in project `mpfm-w3h`.
 
-1. Eerste commit → preview uitgerold.
-2. Tweede, triviale commit gepusht.
-3. In `RijksICTGilde/rig-cluster-application-test` heeft
-   `odcn-production/<project-id>/pr-<n>/<component>-deployment.yaml` ná die tweede push een
-   nieuwe commit met een gewijzigde `image:`-regel.
-4. Het draaiende component vertoont het gedrag van de tweede commit.
+De tweede commit zette tijdelijk een `%prod`-only responseheader `X-Preview-Verificatie:
+commit-2` op berichtenmagazijn; die is in de commit erna weer verwijderd. Alleen `%prod`, zodat
+tests en dev-mode er niets van merkten.
 
-Zie de verificatiesectie in de PR-beschrijving voor de uitkomst.
+1. Ná commit 1 (`6e8616f`): manifest
+   `odcn-production/mpfm-w3h/pr-172/magazijna-deployment.yaml` op commit `b016a5a`
+   (08:24:07Z), `image: …/fbs-berichtenmagazijn:pr-172-6e8616f`. Preview bereikbaar, header
+   afwezig.
+2. Ná commit 2 (`95f59fb`): nieuwe manifest-commit `7e69327` (08:37:10Z) met
+   `image: …/fbs-berichtenmagazijn:pr-172-95f59fb` — de regel die bij PR #168 drie dagen
+   onveranderd bleef.
+3. Argo rolde uit: `curl` op de preview gaf `x-preview-verificatie: commit-2`. Het draaiende
+   component vertoonde dus het gedrag van de tweede commit.
+
+De opruimkant is drooggetest tegen de echte ghcr-data: het filter van
+`cleanup-preview-images` (`tags | any(startswith("pr-172-"))`) selecteerde beide versies
+(`pr-172-6e8616f` én `pr-172-95f59fb`), niet alleen de laatste. De prefix `pr-17-` selecteert
+ze niet — het afsluitende koppelteken doet zijn werk.
 
 ## Openstaand
 

--- a/docs/plans/2026-08-10-preview-uitrol-per-commit.md
+++ b/docs/plans/2026-08-10-preview-uitrol-per-commit.md
@@ -1,0 +1,134 @@
+# Preview rolt uit per commit (unieke image-tag)
+
+**Status:** Uitgevoerd
+**Issue:** #171
+
+## Context
+
+Een PR-preview op ZAD bevroor bij de eerste build. Elke volgende commit werd wel gebouwd en
+gepusht en de `deploy-preview-*`-check werd groen, maar er rolde niets uit: de pods bleven op
+de image-laag van de eerste build draaien.
+
+Oorzaak: `deploy.yml` gaf op een PR altijd dezelfde image-tag mee (`pr-<n>`). Die tag komt via
+`zad-actions/deploy` in Operations Manager en belandt in het gerenderde k8s-manifest in
+`rig-cluster-application-test`. Bij een tweede commit is dat manifest byte-identiek — dezelfde
+`image:`-regel stond er al. Argo CD synct op verschil in het manifest, ziet er geen, en doet
+niets. `imagePullPolicy: Always` verandert dat niet: dat werkt alleen bij een herstart van de
+pod, en die komt niet vanzelf. Op `main` speelde het niet, want `main-<sha7>` wijzigt per commit.
+
+Gemeten bewijs (PR #168): `odcn-production/mpfm-w3h/pr-168/magazijna-deployment.yaml` was sinds
+2026-08-07 09:56 onveranderd, terwijl de deploy van 2026-08-10 07:40 groen stond. Die deploy
+raakte in de PR-map alleen `decrypt-sops.yaml`, `kustomization.yaml` en de twee
+`*-user-secret.sops.yaml` — geen enkel `*-deployment.yaml`.
+
+Waarom dit erger is dan een vertraging: een groene deploy-check zegt alleen dat het image
+bouwde en dat OM de aanroep accepteerde. Wie op de preview verifieert kijkt vanaf de tweede
+commit naar oude code, zonder signaal dat dat zo is.
+
+## Afweging
+
+### 1. Deployen op digest (`image: …@sha256:…`)
+
+De digest wijzigt zodra de inhoud wijzigt, dus het manifest ook. De tag `pr-<n>` kan blijven
+bestaan, waarmee de bestaande cleanup ongewijzigd werkt.
+
+Onderzocht in `RijksICTGilde/zad-actions@13434cd` (v4): de `deploy`-action valideert alleen de
+component-*naam* (`^[a-zA-Z0-9._-]+$`) en geeft het image-veld ongewijzigd door aan
+`zad-cli@v0.8.0`. Die valideert in `api/models.py` eveneens alleen `Component.name`; de
+OM-OpenAPI (`api/upstream-openapi.json`) legt geen patroon op `image`/`newImageUrl` op. Een
+digest-referentie wordt dus waarschijnlijk geaccepteerd — maar dat is een afwezigheid van
+validatie, geen bewijs dat OM's manifest-rendering en de pull-through-mirror er goed mee
+omgaan. Dat pad is niet zonder een echte deploy vast te stellen.
+
+Zwaarder weegt de opruimkant. Jib bouwt reproduceerbaar: identieke sources geven een identieke
+digest. Voor de tag betekent dat weinig, maar het maakt de digest ongeschikt als *label* van
+een PR: een ghcr-versie draagt geen PR-nummer, en na het verplaatsen van de tag `pr-<n>` is de
+vorige versie ongetagd. Ongetagde versies zijn niet meer aan een PR toe te wijzen en dus niet
+gericht op te ruimen.
+
+Dat is geen theorie: `fbs-berichtenmagazijn` telde bij het schrijven van dit plan ~237
+ghcr-versies waarvan ~157 ongetagd — precies de tussenbuilds die het verplaatsen van `pr-<n>`
+achterliet. De huidige cleanup ruimt per package één exacte tag op en laat die berg staan.
+
+### 2. Unieke tag per commit (`pr-<n>-<sha7>`) — gekozen
+
+Elke build krijgt een eigen tag, dus elk manifest wijzigt, dus Argo rolt uit. Geen aannames
+over wat OM met een referentievorm doet: de vorm blijft `repo:tag`, precies zoals nu op `main`
+(waar de per-commit-tag al jaren werkt — dat is meteen het bewijs dat dit pad werkt).
+
+De cleanup moet dan wél alle tags van de PR opruimen in plaats van één. Dat kan, en het is
+strikt beter dan vandaag: elke build houdt een tag, dus elke build blijft toewijsbaar aan zijn
+PR en gaat bij het sluiten mee. Het ongetagde-versies-lek stopt daarmee voor nieuwe PR's.
+
+Kosten: bij twee builds van identieke sources rolt Argo een identiek image opnieuw uit (jib
+levert dan dezelfde digest, dus ghcr hangt beide tags aan dezelfde versie). Dat is één
+overbodige herstart in een randgeval, tegenover een preview die anders stil verkeerd staat.
+
+### 3. Iets aan ZAD-zijde dat een rollout forceert
+
+Bestaat niet. `:refresh` reconcilet zonder revisiewijziging, en een deployment herscheppen
+(`DELETE` + `:upsert-deployment`) draait op projecten met de `postgresql-database`-service een
+`database_cleanup` — dat vernietigt data en is geen routine-oplossing.
+
+### Conclusie
+
+Richting 2. Richting 1 lost het bevriezen even goed op, maar laat het opruimprobleem staan en
+vraagt bovendien een niet-verifieerbare aanname over de OM-keten. Richting 2 heeft één nadeel
+(een zeldzame overbodige rollout) en één extra stuk workflow-code, en lost het ghcr-lek meteen
+mee op.
+
+## Wijzigingen
+
+`.github/workflows/deploy.yml`
+
+- `meta`: PR-tag wordt `pr-<n>-<sha7>` op basis van `github.event.pull_request.head.sha` — de
+  sha die in de PR-tijdlijn staat, niet de efemere merge-commit uit `GITHUB_SHA`. De
+  interpolaties gaan via `env:` (defense-in-depth injectie), zoals de rest van de workflow.
+  De `main`-tak blijft `main-<sha7>`.
+- `cleanup-preview-*`: `delete-container: 'false'`; de `containers`-lijst en de daarvoor
+  benodigde `packages: write` + `needs: meta` zijn weg.
+- Nieuw: `cleanup-preview-images` ruimt bij PR-sluiten alle ghcr-versies op waarvan minstens
+  één tag begint met `pr-<n>-`. Het afsluitende koppelteken is essentieel: zonder dat zou het
+  sluiten van PR 16 de images van PR 168 meenemen. De job faalt zichtbaar (rood) als een
+  verwijdering mislukt, zodat een groeiende ghcr-berg niet ongemerkt ontstaat.
+
+Bewust géén package-brede fallback bij "cannot delete the last tagged version" (die de
+`zad-actions`-cleanup wél heeft): dat zou een preview-cleanup het hele package laten
+verwijderen, main-images incluis. De `main-<sha7>`-tags zorgen ervoor dat die situatie zich
+niet voordoet.
+
+`CLAUDE.md`: de tag-conventie in "ZAD deploy & GitOps (debug)" bijgewerkt, plus de reden dat
+image-tags uniek per commit moeten zijn.
+
+## Randvoorwaarden getoetst
+
+- **Alle drie projecten.** De tag komt uit één `meta`-job; de jib-services en de
+  docker-gebouwde externe-stubs gebruiken dezelfde output. Geen van beide bouwpaden kent de
+  tagvorm.
+- **Geen weesversies.** Elke gepushte PR-versie houdt een unieke tag en valt onder de prefix
+  die de cleanup opruimt.
+- **Actions SHA-gepind.** Er komt geen nieuwe action bij; `cleanup-preview-images` draait op
+  `gh`/`jq` van de runner.
+- **`pin-consistency.yml`.** Bewaakt alleen `redis/redis-stack-server` en
+  `clickhouse/clickhouse-server`; die pins zijn niet geraakt.
+
+## Verificatie
+
+Een groene CI-run is hier geen bewijs — dat was juist het probleem. Aangetoond op de PR van
+deze wijziging zelf:
+
+1. Eerste commit → preview uitgerold.
+2. Tweede, triviale commit gepusht.
+3. In `RijksICTGilde/rig-cluster-application-test` heeft
+   `odcn-production/<project-id>/pr-<n>/<component>-deployment.yaml` ná die tweede push een
+   nieuwe commit met een gewijzigde `image:`-regel.
+4. Het draaiende component vertoont het gedrag van de tweede commit.
+
+Zie de verificatiesectie in de PR-beschrijving voor de uitkomst.
+
+## Openstaand
+
+De ~157 bestaande ongetagde ghcr-versies van `fbs-berichtenmagazijn` (en de overeenkomstige
+van de andere twee packages) blijven staan: ze zijn niet aan een PR toe te wijzen. Ze
+opruimen vraagt een eigen afweging (een ongetagde versie kan ook een index-/attestatie-kind
+zijn) en valt buiten deze wijziging.

--- a/docs/plans/2026-08-10-preview-uitrol-per-commit.md
+++ b/docs/plans/2026-08-10-preview-uitrol-per-commit.md
@@ -136,6 +136,15 @@ build/push) zonder enige afnemer. Met de unieke tags weegt het bovendien zwaarde
 elke overbodige build laat nu een eigen ghcr-versie achter in plaats van een tag te verplaatsen.
 De jobs hangen nu aan dezelfde filter als de rest.
 
+Tweede vondst, uit dezelfde review: **we bouwden drie images per bot-PR die nooit gedeployd
+worden.** `zad-actions/deploy` weigert PR's van bots (`skip-bot-prs`, default `true`) — in de
+log van de Dependabot-PR #167 staat letterlijk `Skipping: PR author 'dependabot[bot]' is a bot`.
+Onze build-jobs kenden die regel niet en pushten er wél images voor. De cleanup-action slaat
+bot-PR's óók over, dus die images bleven staan: `pr-143` en `pr-167` staan er vandaag nog,
+terwijl beide PR's op 2026-08-07 gesloten zijn. Per Dependabot-PR kostte dat twee Maven/jib-
+builds plus een docker-build, en een permanente ghcr-versie. De `changes`-job zet `run=false`
+voor bot-PR's, waarmee ook de `gate` (die minutenlang op checks polt) vervalt.
+
 Blijft staan als bewuste afweging: elke commit vernieuwt de tag van alle app-componenten, dus
 rollen ze alle mee. Zie "Openstaand" — zonder reproduceerbare build valt daar niets aan te
 winnen, ook niet met een digest.
@@ -192,6 +201,11 @@ pull-through-mirror.
 Wie de granulariteit écht wil, moet eerst de build reproduceerbaar maken (build-timestamps
 pinnen, `SOURCE_DATE_EPOCH`). Dat is een eigen traject; pas daarna wordt een digest-deploy
 zinvol.
+
+**Achtergebleven bot-PR-images.** De images van eerdere Dependabot-PR's (`pr-143`, `pr-167` en
+soortgenoten) zijn al gepusht en worden door geen enkele cleanup meer opgehaald: die PR's zijn
+gesloten en hun cleanup-run heeft ze overgeslagen. Ze zijn wél getagd en dus herkenbaar; een
+eenmalige opruimactie kan, maar verwijdert onherstelbaar en hoort niet in deze wijziging.
 
 De ~157 bestaande ongetagde ghcr-versies van `fbs-berichtenmagazijn` (en de overeenkomstige
 van de andere twee packages) blijven staan: ze zijn niet aan een PR toe te wijzen. Ze

--- a/docs/plans/2026-08-10-preview-uitrol-per-commit.md
+++ b/docs/plans/2026-08-10-preview-uitrol-per-commit.md
@@ -155,7 +155,11 @@ winnen, ook niet met een digest.
   docker-gebouwde externe-stubs gebruiken dezelfde output. Geen van beide bouwpaden kent de
   tagvorm.
 - **Geen weesversies.** Elke gepushte PR-versie houdt een unieke tag en valt onder de prefix
-  die de cleanup opruimt.
+  die de cleanup opruimt. Dat het verwijderen zelf werkt met de `GITHUB_TOKEN` blijkt uit de
+  huidige toestand van ghcr: van alle gesloten PR's van menselijke indieners ná #104 staat er
+  geen enkele `pr-<n>`-tag meer, terwijl die van openstaande PR's er wel staan. De tags die
+  achterbleven (`pr-143`, `pr-165`, `pr-167`, …) horen zonder uitzondering bij bot-PR's, die de
+  cleanup-action overslaat.
 - **Actions SHA-gepind.** Er komt geen nieuwe action bij; `cleanup-preview-images` draait op
   `gh`/`jq` van de runner.
 - **`pin-consistency.yml`.** Bewaakt alleen `redis/redis-stack-server` en

--- a/services/berichtenmagazijn/src/main/resources/application.properties
+++ b/services/berichtenmagazijn/src/main/resources/application.properties
@@ -32,6 +32,11 @@ quarkus.http.header."Referrer-Policy".value=no-referrer
 # `no-store` aan voor API-endpoints.
 quarkus.http.header."Cache-Control".value=no-store
 
+# TIJDELIJK — bewijst dat een tweede commit op een PR de preview daadwerkelijk bereikt.
+# Alleen %prod (ZAD), zodat tests en dev er niets van merken. Wordt in de volgende commit
+# van deze PR weer verwijderd.
+%prod.quarkus.http.header."X-Preview-Verificatie".value=commit-2
+
 # Max request body: ruim boven Bericht.MAX_INHOUD_BYTES (1 MiB) + één
 # bijlage van Bijlage.MAX_CONTENT_BYTES (25 MiB) + base64-overhead (~33%)
 # + JSON-envelope. 40M dekt een aanlever-request met inhoud en bijlage(n);

--- a/services/berichtenmagazijn/src/main/resources/application.properties
+++ b/services/berichtenmagazijn/src/main/resources/application.properties
@@ -32,11 +32,6 @@ quarkus.http.header."Referrer-Policy".value=no-referrer
 # `no-store` aan voor API-endpoints.
 quarkus.http.header."Cache-Control".value=no-store
 
-# TIJDELIJK — bewijst dat een tweede commit op een PR de preview daadwerkelijk bereikt.
-# Alleen %prod (ZAD), zodat tests en dev er niets van merken. Wordt in de volgende commit
-# van deze PR weer verwijderd.
-%prod.quarkus.http.header."X-Preview-Verificatie".value=commit-2
-
 # Max request body: ruim boven Bericht.MAX_INHOUD_BYTES (1 MiB) + één
 # bijlage van Bijlage.MAX_CONTENT_BYTES (25 MiB) + base64-overhead (~33%)
 # + JSON-envelope. 40M dekt een aanlever-request met inhoud en bijlage(n);


### PR DESCRIPTION
Closes #171

Een PR-preview op ZAD bevroor bij de eerste build. Elke commit daarna werd wel gebouwd en de deploy-check werd groen, maar er rolde niets uit.

## Wat er mis was

`meta` gaf op een PR altijd dezelfde image-tag mee (`pr-<n>`). Die tag belandt via `zad-actions/deploy` → Operations Manager in het gerenderde k8s-manifest in `rig-cluster-application-test`. Bij een tweede commit is dat manifest byte-identiek — dezelfde `image:`-regel stond er al. Argo CD synct op verschil, ziet er geen, en rolt niets uit. De pod blijft op de image-laag van de eerste build. `imagePullPolicy: Always` helpt niet: dat werkt pas bij een herstart, en die komt niet vanzelf.

Wie op de preview verifieerde keek vanaf de tweede commit dus naar oude code, met een groen vinkje ernaast. Op `main` speelde het niet, want `main-<sha7>` wijzigt per commit.

## Wat er verandert

- **`meta`**: de PR-tag wordt `pr-<n>-<sha7>` op basis van de head-sha (niet de efemere merge-commit uit `GITHUB_SHA`). Interpolatie via `env:`.
- **Herdraai krijgt een eigen tag** (`-r<n>` vanaf poging 2). Een herdraai bouwt uit `refs/pull/<n>/merge` met de main van dát moment; is main verder, dan zou dezelfde head-sha andere inhoud onder dezelfde tag pushen — precies de bevriezing die deze tagvorm uitsluit.
- **Nieuwe job `cleanup-preview-images`**: verwijdert bij PR-sluiten álle ghcr-versies met tag-prefix `pr-<n>-`, plus de kale `pr-<n>` van PR's die al liepen vóór deze wijziging. Het afsluitende koppelteken in de prefix is essentieel — anders neemt het sluiten van PR 16 de images van PR 168 mee.
- **`cleanup-preview-*`**: `delete-container: 'false'`. Die stap verwijdert precies één exacte tag en zou met unieke tags alle tussenversies laten staan.
- **Geen bouw- en deploystraat meer voor revisies die toch niet deployen**: docs-only PR's (bestond al voor `gate`/deploy, gold niet voor `build`) en PR's van bots.
- **`CLAUDE.md`**: tag-conventie bijgewerkt, met de reden dat tags uniek moeten zijn per commit.

## Waarom deze richting

Dat ZAD niet uitrolt bij een ongewijzigde image-referentie is **opzet, geen fout** (bevestigd door het ZAD-team): bij een deployment met tien componenten mag één gewijzigde image niet alle tien vervangen. De oplossing moet daar dus binnen passen — en dat doet een per-commit wijzigende referentie: ZAD rolt uit omdat de referentie écht anders is.

Deployen op digest (`@sha256:…`) is overwogen en afgevallen op twee gronden:

1. **Het lost de granulariteit niet op.** Gemeten over de builds van deze PR: `berichtenuitvraag` werd geen byte gewijzigd, en commit `3fb1f96` draaide de voorgaande commit exact terug — toch heeft elke build een eigen digest. Onze jib-build is niet reproduceerbaar, dus een digest volgt de build, niet de inhoud. Een digest-deploy zou hetzelfde rolgedrag geven als de unieke tag.
2. **De opruimkant wordt er slechter van.** Een digest-deploy laat de vorige versie ongetagd achter, en ongetagde versies zijn niet aan een PR toe te wijzen. Dat lek is er al: `fbs-berichtenmagazijn` telt ~237 versies waarvan ~157 ongetagd, precies de tussenbuilds die het verplaatsen van `pr-<n>` achterliet.

Bovendien valideren `zad-actions`, `zad-cli@v0.8.0` en de OM-OpenAPI het image-veld niet — een digest wordt waarschijnlijk geaccepteerd, maar dat is afwezigheid van validatie, geen bewijs. Een unieke tag gebruikt de referentievorm die op `main` al werkt. Volledige afweging: `docs/plans/2026-08-10-preview-uitrol-per-commit.md`.

## Verificatie

Een groene CI-run is hier geen bewijs — dat was juist het probleem. Aangetoond op deze PR zelf, met `magazijna` in `mpfm-w3h`. Commit 2 zette tijdelijk een `%prod`-only header `X-Preview-Verificatie: commit-2`; commit 3 haalde die weer weg.

| stap | manifest-commit in `rig-cluster-application-test` | `image:` in `magazijna-deployment.yaml` | preview |
|---|---|---|---|
| commit 1 `6e8616f` | `b016a5a` — 08:24:07Z | `…/fbs-berichtenmagazijn:pr-172-6e8616f` | bereikbaar, header afwezig |
| commit 2 `95f59fb` | `7e69327` — 08:37:10Z | `…/fbs-berichtenmagazijn:pr-172-95f59fb` | `x-preview-verificatie: commit-2` |
| commit 3 `3fb1f96` | `20f4f11` — 08:47:36Z | `…/fbs-berichtenmagazijn:pr-172-3fb1f96` | header weer weg |

Precies die `image:`-regel bleef bij #168 drie dagen onveranderd terwijl de deploy-check groen was. Nu beweegt hij mee én rolt Argo daadwerkelijk uit: de draaiende pod volgde commit 2 heen én terug. Over de hele PR heeft het manifest inmiddels zeven commits — één per deployende revisie.

**Opruimen**, drooggetest tegen de echte ghcr-data: het filter van `cleanup-preview-images` selecteert op dit moment alle negen builds van deze PR (`pr-172-6e8616f` t/m `pr-172-7af9989`), niet alleen de laatste. De prefix `pr-17-` selecteert ze niet — het afsluitende koppelteken doet zijn werk. De echte opruimactie draait pas bij het sluiten van deze PR.

Dat het verwijderen zélf werkt met de `GITHUB_TOKEN` blijkt uit de huidige toestand van ghcr: van alle gesloten PR's van menselijke indieners ná #104 staat er geen enkele `pr-<n>`-tag meer, terwijl die van openstaande PR's er wel staan. Wat achterbleef (`pr-143`, `pr-165`, `pr-167`, …) hoort zonder uitzondering bij bot-PR's, die de cleanup-action overslaat.

## Reviewronde (duurzaamheid / verspilling / NeRDS)

Na de eerste opzet een review gedraaid met de digital-waste-bril en NeRDS 13 (duurzame technologie, green coding). Drie vondsten met bewijs, alle drie opgelost:

**1. Build draaide op revisies die nooit deployen.** De `build`-jobs hingen niet aan de `changes`-filter, terwijl `gate` en de deploys dat wel deden. Een docs-only commit bouwde dus twee Maven/jib-images plus de WireMock-image en pushte ze naar ghcr, waarna er niets mee gebeurde — bewijs: `pr-172-3e2866c` en `pr-172-941933a` horen bij commits die alleen `docs/plans/*.md` raakten. Met unieke tags weegt dat zwaarder dan voorheen: elke overbodige build laat nu een eigen ghcr-versie achter in plaats van een tag te verplaatsen.

**2. Drie images per bot-PR die nooit gedeployd worden.** `zad-actions/deploy` weigert PR's van bots (`skip-bot-prs`, default `true`); in de log van Dependabot-PR #167 staat letterlijk `Skipping: PR author 'dependabot[bot]' is a bot`. Onze build-jobs kenden die regel niet en pushten er wél images voor, en de cleanup-action slaat bot-PR's óók over — dus die images blijven staan. `pr-143` en `pr-167` staan er vandaag nog, terwijl beide PR's op 2026-08-07 gesloten zijn. Met `run=false` voor bot-PR's vervalt ook de `gate`, die anders minutenlang op checks polt voor een deploy die niet komt.

**3. Herdraai kon de tag alsnog laten verschuiven** — zie "Wat er verandert".

Verder aangescherpt: de bot-overslag logt als `::notice::` zodat een onterechte overslag zichtbaar is in de run-samenvatting (een overgeslagen deploy rapporteert 'skipped', en dat telt als succes), en de expliciete package-lijst in de cleanup heeft een toelichting gekregen: de prefix `pr-<n>-` is niet uniek binnen de organisatie, dus een sweep over alle org-packages zou images van een gelijkgenummerde PR in een andere repo kunnen raken.

`actionlint` (inclusief shellcheck op de `run`-blokken) is schoon.

## Openstaand

- **Per-component granulariteit.** Elke commit vernieuwt de tag van alle app-componenten, dus rollen ze alle mee. Daar valt pas iets aan te winnen als de build reproduceerbaar is (build-timestamps pinnen, `SOURCE_DATE_EPOCH`); dat is een eigen traject.
- **De `gate` polt elke 15 s tot 900 s** — een idlende runner in plaats van event-gedreven wachten. Gemeten: 50 gate-jobs in zeven dagen, samen 384 minuten runnertijd. Bestaand ontwerp, eigen refactor.
- **Achtergebleven bot-PR-images** (`pr-143`, `pr-167` en soortgenoten) worden door geen enkele cleanup meer opgehaald; een eenmalige opruimactie kan, maar verwijdert onherstelbaar en hoort niet hier.
- **~157 ongetagde ghcr-versies** uit het tijdperk van de verplaatste tag blijven staan: niet aan een PR toe te wijzen, en blind ongetagde versies wissen raakt mogelijk index-/attestatie-kinderen.
