### PR TITLE
ci: uitrol wacht zonder draaiende bouwmachine op de kwaliteitscontroles

### DIFF
--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -17,6 +17,7 @@ jobs:
   # overgeslagen job telt daarentegen als 'skipped' = succes voor branch protection.
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       run: ${{ steps.filter.outputs.run }}
     steps:
@@ -41,6 +42,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.run == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,7 +1,11 @@
 name: ClusterFuzzLite PR fuzzing
 on:
-  pull_request:
-    branches: [main]
+  # Uitsluitend als aangeroepen workflow: deze fuzzing draaide al alleen voor PR's naar main, en
+  # dat is precies wanneer deploy.yml draait. Door hem daar aan te roepen kan de deploy er met
+  # `needs:` aan hangen in plaats van op de check-run te pollen — een pollende job houdt een
+  # runner bezet zonder werk te doen. Een gestapelde PR fuzzt dus nog steeds niet; die dekking
+  # komt bij de PR naar main.
+  workflow_call:
 
 permissions: read-all
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,10 +36,12 @@
 # GESTAPELDE PR'S (base != main) deployen niet — zie het `branches`-filter hieronder. Hun
 # wijzigingen belanden alsnog in een preview zodra ze de PR bereiken die wél op main mikt: die
 # krijgt dan een `synchronize` en rolt zijn eigen pr-<n> opnieuw uit. Wat zo'n PR aan controles
-# houdt: test, detekt-gate en infra-image-pins (die workflows filteren niet op de doelbranch).
-# CodeQL en de fuzz-check draaien er NIET — codeql.yml en cflite_pr.yml filteren nog wel op main,
-# dus die dekking komt pas bij de PR naar main. Een gestapelde PR is dus inhoudelijk getoetst,
-# maar niet security-gescand; weeg dat mee bij het reviewen ervan.
+# houdt: test, detekt-gate en infra-image-pins — die workflows draaien zichzelf op elke PR
+# BEHALVE die naar main (`branches-ignore: [main]`), en worden voor een PR naar main juist hier
+# aangeroepen. CodeQL en de fuzz-check draaien er NIET: codeql.yml filtert op main en
+# cflite_pr.yml draait uitsluitend als aangeroepen workflow vanuit deze. Die dekking komt dus pas
+# bij de PR naar main. Een gestapelde PR is inhoudelijk getoetst maar niet security-gescand; weeg
+# dat mee bij het reviewen ervan.
 #
 # BEKENDE BEPERKING: wordt een PR ná een preview-deploy handmatig weggericht van main, dan valt
 # hij buiten dit filter en ruimt het sluiten zijn pr-<n>-deployments en ghcr-tags niet meer op.
@@ -66,8 +68,9 @@ on:
   # automatisch naar main zodra de parent merget, zónder nieuw event — die stale vinkjes zouden
   # dan blijven staan. Zonder run zijn de checks afwezig, wat de merge wél blokkeert.
   #
-  # Let op de bewuste asymmetrie met test.yml/detekt.yml: die hebben juist géén branch-filter,
-  # want een gestapelde PR verdient wél inhoudelijke toetsing. Alleen de deploy valt weg.
+  # Let op de bewuste asymmetrie met test.yml/detekt.yml/pin-consistency.yml: die dragen het
+  # complement (`branches-ignore: [main]`), want een gestapelde PR verdient wél inhoudelijke
+  # toetsing. Alleen de deploy valt weg. Samen dekken de twee filters elke PR precies één keer.
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, closed]
@@ -78,12 +81,16 @@ on:
 # (build → packages, cleanup → deployments/packages/pull-requests) declareren dat zelf.
 permissions: read-all
 
-# Eén deploy-run tegelijk per PR; een nieuwe push wacht op de lopende i.p.v. die af te
-# breken (cancel-in-progress: false) — een halverwege afgebroken ZAD-deploy kan een
-# deployment in een inconsistente staat achterlaten.
-concurrency:
-  group: zad-deploy-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: false
+# GEEN workflow-brede concurrency. De toetsende checks draaien sinds #173 als jobs ín deze
+# workflow; een workflow-brede groep met `cancel-in-progress: false` zou een opvolgende push laten
+# wachten tot de vorige deploy klaar is én de achterhaalde testrun helemaal uit laten draaien —
+# precies de verspilling die we wegnemen. Met `cancel-in-progress: true` zou een lopende ZAD-deploy
+# halverwege afgebroken kunnen worden, wat een deployment in een inconsistente staat achterlaat.
+# Beide eisen tegelijk kan alleen per job:
+#   * build/toetsing → eigen groep met cancel-in-progress: true (achterhaald werk stoppen);
+#   * deploy/cleanup → eigen groep PER PROJECT + doel-deployment met cancel-in-progress: false
+#     (nooit halverwege afbreken; per project apart zodat de drie parallelle jobs elkaar niet
+#     blokkeren, wat met één gedeelde groep wél zou gebeuren).
 
 env:
   REGISTRY: ghcr.io
@@ -176,6 +183,13 @@ jobs:
     if: github.event_name == 'push' || github.event.action != 'closed'
     needs: meta
     runs-on: ubuntu-latest
+    # Een opvolgende push maakt deze build achterhaald: afbreken scheelt runnertijd én voorkomt dat
+    # twee runs van dezelfde PR om beurten dezelfde image-tag overschrijven, waarna de deploy een
+    # oudere image zou kunnen trekken. Per matrix-service een eigen groep, anders blokkeren de twee
+    # parallelle builds van dezelfde run elkaar.
+    concurrency:
+      group: build-${{ matrix.service }}-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     permissions:
       contents: read
       packages: write
@@ -218,6 +232,9 @@ jobs:
     if: github.event_name == 'push' || github.event.action != 'closed'
     needs: meta
     runs-on: ubuntu-latest
+    concurrency:
+      group: build-externe-stubs-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     permissions:
       contents: read
       packages: write
@@ -235,110 +252,114 @@ jobs:
           docker build -t "$IMG" wiremock/externe-stubs
           docker push "$IMG"
 
+  # De vier toetsende workflows draaien als aangeroepen (`workflow_call`) job ín deze workflow,
+  # zodat de deploy er met `needs:` aan kan hangen. Vóór #173 draaiden ze zelfstandig en wachtte
+  # een `gate`-job er in een poll-lus op: ~461 s per run een runner die niets deed dan `sleep 15`.
+  # Hun eigen `pull_request`-trigger staat nu op `branches-ignore: [main]` — het complement van de
+  # `branches: [main]` hierboven — zodat een gestapelde PR ze zelfstandig draait en een PR naar
+  # main ze precies één keer draait, hier.
+  #
+  # LET OP: door de aanroep krijgen de check-runs het caller-job-voorvoegsel: `checks-test / test`
+  # in plaats van `test`. Branch protection op main pint op die namen; wijzig je hier een job-id,
+  # dan moet de required context mee. Een required context die nooit meer verschijnt, blokkeert
+  # elke merge.
+  #
+  # `github.event.action != 'closed'`: de close-trigger is er voor de cleanup-jobs, daar valt
+  # niets te toetsen.
+  checks-test:
+    if: github.event_name == 'push' || github.event.action != 'closed'
+    uses: ./.github/workflows/test.yml
+    # De aangeroepen workflow mag nooit meer rechten hebben dan de caller-job toekent;
+    # pull-requests: write is voor de JaCoCo-coverage-comment.
+    permissions:
+      contents: read
+      pull-requests: write
+
+  checks-detekt:
+    if: github.event_name == 'push' || github.event.action != 'closed'
+    uses: ./.github/workflows/detekt.yml
+    permissions:
+      contents: read
+      pull-requests: read
+      security-events: write
+
+  checks-pins:
+    if: github.event_name == 'push' || github.event.action != 'closed'
+    uses: ./.github/workflows/pin-consistency.yml
+    permissions:
+      contents: read
+
+  # ClusterFuzzLite fuzzt alleen PR's: op een push naar main is er geen basis om code-change-fuzzing
+  # tegen af te zetten. Deze job wordt daar dus overgeslagen, en de gate telt dat als OK.
+  checks-fuzz:
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    uses: ./.github/workflows/cflite_pr.yml
+    permissions: read-all
+
   # Kwaliteitspoort vóór élke ZAD-deploy: geen cluster-capaciteit (en geen review-ruis van een
-  # "geslaagde" preview) verspillen aan een revisie die de tests/kwaliteitsgates niet haalt. De
-  # functionele checks draaien in aparte workflows (Test, detekt, Pin consistency, ClusterFuzzLite),
-  # dus we kunnen er niet via `needs` aan hangen — vandaar dat we hun check-runs op dezelfde
-  # head-SHA pollen.
-  # De fuzz-check ('PR', cflite_pr.yml) hoort erbij: een nog lopende fuzzer of een gevonden crash
-  # mag niet ingehaald worden door een preview-deploy. Die check bestaat echter ALLEEN op
-  # pull_request-events; op push-naar-main draait cflite_pr niet, dus daar zou 'PR' eeuwig
-  # 'afwezig' zijn en de gate tot de timeout laten falen. Daarom staat 'PR' alleen in de set bij
-  # een pull_request (conditionele REQUIRED hieronder).
+  # "geslaagde" preview) verspillen aan een revisie die de tests/kwaliteitsgates niet haalt.
+  #
+  # De poort zelf toetst niets — dat doen de checks-jobs hierboven. Hij aggregeert alleen hun
+  # resultaat op één plek, zodat de "overgeslagen telt als OK"-regel één keer bestaat in plaats van
+  # als `always() && ...`-formule op elk van de zes deploy-jobs, met zes kansen op drift.
+  #
   # CodeQL en architecture bewust NIET in de set: CodeQL mag traag of tijdelijk rood zijn (bv.
   # extractor-lag op een nieuwe Kotlin-versie) zonder de preview te blokkeren, en architecture
-  # triggert alleen op docs/architecture-wijzigingen — op een gewone PR verschijnt er geen
-  # check-run ('afwezig'), waardoor de gate anders tot de timeout zou blijven wachten.
+  # triggert alleen op docs/architecture-wijzigingen.
   gate:
+    # `!cancelled()` i.p.v. de impliciete success(): een overgeslagen `checks-fuzz` (push naar main)
+    # zou deze job anders meeslepen in 'skipped' en de deploy stilzwijgend blokkeren. Bij een
+    # geannuleerde run hoeft de poort juist niet meer te oordelen.
     # Niet op PR-close (teardown, geen deploy) en niet op een docs-only PR (niets te deployen).
-    if: github.event_name == 'push' || (github.event.action != 'closed' && needs.changes.outputs.run == 'true')
-    needs: changes
+    if: >-
+      !cancelled()
+      && (github.event_name == 'push'
+          || (github.event.action != 'closed' && needs.changes.outputs.run == 'true'))
+    needs: [changes, checks-test, checks-detekt, checks-pins, checks-fuzz]
     runs-on: ubuntu-latest
-    permissions:
-      checks: read
     steps:
-      - name: Wacht tot de verplichte checks slagen
+      - name: Beoordeel de verplichte checks
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          # PR: de branch-head (waar de sibling-workflows hun checks aan hangen). Push naar
-          # main: de push-SHA. Bij push is de pull_request-context leeg → valt terug op github.sha.
-          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          # Exacte check-namen: Test-workflow → 'test', detekt.yml → 'detekt-gate',
-          # pin-consistency.yml → 'infra-image-pins', cflite_pr.yml → 'PR' (fuzz, alleen op PR).
-          REQUIRED: ${{ (github.event_name == 'pull_request' && 'test detekt-gate infra-image-pins PR') || 'test detekt-gate infra-image-pins' }}
-          # ~2× de typische `test`-duur (~7 min incl. Testcontainers) als marge voor een trage
-          # runner; fail-closed, dus liever iets ruimer dan een op-zich-groene build blokkeren.
-          TIMEOUT_SECONDS: '900'
-          POLL_SECONDS: '15'
+          # Naam=resultaat per verplichte check. De namen zijn die van de check-runs zoals ze in
+          # de PR verschijnen, niet de job-id's — dit is wat een lezer van het logboek zoekt.
+          # De fuzz-check hoort er alleen bij op een pull_request; op een push naar main is hij
+          # per definitie afwezig en zou hij elke run een 'overgeslagen'-waarschuwing opleveren.
+          RESULTATEN: |
+            test=${{ needs.checks-test.result }}
+            detekt-gate=${{ needs.checks-detekt.result }}
+            infra-image-pins=${{ needs.checks-pins.result }}
+            ${{ github.event_name == 'pull_request' && format('PR={0}', needs.checks-fuzz.result) || '' }}
         run: |
           set -euo pipefail
-          # REQUIRED komt uit de job-`env` hierboven; shellcheck ziet die bron niet en denkt
-          # dat het een misspelling van de lokale `required`-array is (SC2153).
-          # shellcheck disable=SC2153
-          read -ra required <<< "$REQUIRED"
-          deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+          geblokkeerd=0
 
-          while :; do
-            pending=()
+          while IFS='=' read -r naam resultaat; do
+            [ -n "$naam" ] || continue
 
-            for name in "${required[@]}"; do
-              # Server-side op naam filteren én alle pagina's mergen: op een drukke PR staan er
-              # (met reruns) makkelijk >100 check-runs op de SHA. Eén ongepagineerde pagina zou
-              # de nieuwste run kunnen missen en stil een oudere conclusie kiezen. Nieuwste =
-              # hoogste `id` (monotoon; `started_at` is null zolang een rerun nog queued is en
-              # zou dan verkeerd vooraan sorteren).
-              if ! entry=$(gh api --paginate \
-                    "repos/$REPO/commits/$SHA/check-runs?check_name=$name&per_page=100" \
-                    --jq '.check_runs[]' | jq -sc 'sort_by(.id) | last // empty'); then
-                echo "::warning::Ophalen van check-runs voor '$name' faalde — retry over ${POLL_SECONDS}s."
-                entry=""
-              fi
+            case "$resultaat" in
+              success)
+                echo "Verplichte check '$naam' geslaagd."
+                ;;
+              skipped)
+                # Legitiem wanneer de check zichzelf heeft overgeslagen via zijn eigen
+                # relevantie-filter: de fuzz-`PR` bij een niet-fuzz-relevante wijziging of op een
+                # push naar main, of een docs-only wijziging. (Een docs-only PR bereikt deze poort
+                # niet eens — dan is de deploy zelf al overgeslagen.) Luid loggen zodat een
+                # onbedoelde overslag auditbaar is i.p.v. stil als 'groen' doortelt.
+                echo "::warning::Verplichte check '$naam' is overgeslagen — als OK geteld (check overgeslagen via eigen relevantie-filter)."
+                ;;
+              *)
+                echo "::error::Verplichte check '$naam' eindigde als '$resultaat' — deploy geblokkeerd."
+                geblokkeerd=1
+                ;;
+            esac
+          done <<< "$RESULTATEN"
 
-              if [ -z "$entry" ]; then
-                pending+=("$name(afwezig)")
-                continue
-              fi
+          if [ "$geblokkeerd" -ne 0 ]; then
+            exit 1
+          fi
 
-              status=$(jq -r '.status' <<< "$entry")
-
-              if [ "$status" != "completed" ]; then
-                pending+=("$name($status)")
-                continue
-              fi
-
-              conclusion=$(jq -r '.conclusion // ""' <<< "$entry")
-
-              case "$conclusion" in
-                success) ;;
-                skipped|neutral)
-                  # Alleen legitiem als de check bewust is overgeslagen door zijn eigen
-                  # relevantie-filter: de fuzz-`PR` bij een niet-fuzz-relevante wijziging, of een
-                  # paths-gated check zonder rakende bestanden. (Een docs-only PR bereikt deze gate
-                  # niet — dan is de deploy zelf al overgeslagen.) Luid loggen zodat een onbedoelde
-                  # overslag auditbaar is i.p.v. stil als 'groen' doortelt.
-                  echo "::warning::Verplichte check '$name' concludeerde '$conclusion' — als OK geteld (check overgeslagen via eigen relevantie-filter)."
-                  ;;
-                *)
-                  echo "::error::Verplichte check '$name' concludeerde '$conclusion' — deploy geblokkeerd."
-                  exit 1
-                  ;;
-              esac
-            done
-
-            if [ "${#pending[@]}" -eq 0 ]; then
-              echo "Alle verplichte checks groen ($REQUIRED) op $SHA — deploy vrijgegeven."
-              exit 0
-            fi
-
-            if [ "$(date +%s)" -ge "$deadline" ]; then
-              echo "::error::Timeout na ${TIMEOUT_SECONDS}s — nog niet afgerond: ${pending[*]}"
-              exit 1
-            fi
-
-            echo "Wachten op: ${pending[*]} — opnieuw over ${POLL_SECONDS}s"
-            sleep "$POLL_SECONDS"
-          done
+          echo "Alle verplichte checks groen — deploy vrijgegeven."
 
   # PR-preview: één job PER project zodat ze PARALLEL draaien — bij een fout falen alle drie
   # projecten tegelijk (geen fail-fast tussen losse jobs), dus alle fouten in één run
@@ -352,6 +373,13 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action != 'closed' && needs.changes.outputs.run == 'true'
     needs: [meta, build, build-externe-stubs, gate, changes]
     runs-on: ubuntu-latest
+    # Eén ZAD-taak tegelijk op deze deployment; een nieuwe push wacht op de lopende i.p.v. die af
+    # te breken — een halverwege afgebroken ZAD-deploy laat de deployment in een inconsistente
+    # staat achter. De cleanup-job voor hetzelfde project + dezelfde PR deelt deze groep, zodat een
+    # PR-close een lopende deploy niet onder handen wegtrekt.
+    concurrency:
+      group: zad-uitvraag-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
     permissions:
       contents: read
       pull-requests: write
@@ -383,6 +411,9 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action != 'closed' && needs.changes.outputs.run == 'true'
     needs: [meta, build, build-externe-stubs, gate, changes]
     runs-on: ubuntu-latest
+    concurrency:
+      group: zad-externe-stubs-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
     permissions:
       contents: read
     steps:
@@ -406,6 +437,9 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action != 'closed' && needs.changes.outputs.run == 'true'
     needs: [meta, build, build-externe-stubs, gate, changes]
     runs-on: ubuntu-latest
+    concurrency:
+      group: zad-magazijnen-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
     permissions:
       contents: read
     steps:
@@ -432,6 +466,11 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     needs: meta
     runs-on: ubuntu-latest
+    # Zelfde groep als de deploy-job van dit project + deze PR: opruimen mag een lopende deploy
+    # niet onder handen wegtrekken.
+    concurrency:
+      group: zad-uitvraag-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
     permissions:
       deployments: write
       packages: write
@@ -466,6 +505,9 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     needs: meta
     runs-on: ubuntu-latest
+    concurrency:
+      group: zad-externe-stubs-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
     permissions:
       packages: write
     steps:
@@ -486,6 +528,9 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     needs: meta
     runs-on: ubuntu-latest
+    concurrency:
+      group: zad-magazijnen-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
     permissions:
       packages: write
     steps:
@@ -508,6 +553,11 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [meta, build, build-externe-stubs, gate]
     runs-on: ubuntu-latest
+    # Eén ZAD-taak tegelijk op de `test`-deployment van dit project; twee snel opeenvolgende merges
+    # naar main mogen elkaars deploy niet halverwege afbreken.
+    concurrency:
+      group: zad-uitvraag-test
+      cancel-in-progress: false
     permissions:
       contents: read
     environment:
@@ -530,6 +580,9 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [meta, build, build-externe-stubs, gate]
     runs-on: ubuntu-latest
+    concurrency:
+      group: zad-externe-stubs-test
+      cancel-in-progress: false
     permissions:
       contents: read
     steps:
@@ -549,6 +602,10 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [meta, build, build-externe-stubs, gate]
     runs-on: ubuntu-latest
+    # Dekt ook de tweede stap (deployment `fsc-magazijna`) — die hoort bij hetzelfde project.
+    concurrency:
+      group: zad-magazijnen-test
+      cancel-in-progress: false
     permissions:
       contents: read
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,12 @@
 # GitHub's automatische retarget náár main bij het mergen van de parent — is veilig: de checks
 # zijn dan afwezig i.p.v. groen, en `strict: true` op main dwingt sowieso een verse run af.
 #
+# TIMEOUT-MINUTES OP ELKE JOB: GitHub's default is 360 minuten. Een job die hangt (netwerkstall,
+# vastgelopen Testcontainer, een herintroduceerde wachtlus) houdt dan zes uur een runner bezet
+# voordat iemand het merkt. De waarden hieronder staan op ~3× de waargenomen maximumduur, dus ruim
+# genoeg voor een trage runner maar kort genoeg om verspilling te begrenzen. Jobs die een andere
+# workflow aanroepen kunnen de sleutel niet dragen; die staat daar in de aangeroepen workflow.
+#
 # Repo-secrets (Settings → Secrets and variables → Actions):
 #   ZAD_API_KEY_UITVRAAG    — API-key project mpfb-8wh
 #   ZAD_API_KEY_PROFIEL     — API-key project mpfpsm-lcl (externe-stubs)
@@ -128,6 +134,7 @@ jobs:
   # blijft mogelijk. Op een push naar main draait alles altijd (run=true).
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       run: ${{ steps.filter.outputs.run }}
     steps:
@@ -165,6 +172,7 @@ jobs:
   # Afgeleide waarden op één plek: image-tag + lowercase GHCR-owner (GHCR eist lowercase).
   meta:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       tag: ${{ steps.m.outputs.tag }}
       owner: ${{ steps.m.outputs.owner }}
@@ -183,6 +191,7 @@ jobs:
     if: github.event_name == 'push' || github.event.action != 'closed'
     needs: meta
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     # Een opvolgende push maakt deze build achterhaald: afbreken scheelt runnertijd én voorkomt dat
     # twee runs van dezelfde PR om beurten dezelfde image-tag overschrijven, waarna de deploy een
     # oudere image zou kunnen trekken. Per matrix-service een eigen groep, anders blokkeren de twee
@@ -232,6 +241,7 @@ jobs:
     if: github.event_name == 'push' || github.event.action != 'closed'
     needs: meta
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     concurrency:
       group: build-externe-stubs-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
@@ -317,6 +327,7 @@ jobs:
           || (github.event.action != 'closed' && needs.changes.outputs.run == 'true'))
     needs: [changes, checks-test, checks-detekt, checks-pins, checks-fuzz]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Beoordeel de verplichte checks
         env:
@@ -373,6 +384,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action != 'closed' && needs.changes.outputs.run == 'true'
     needs: [meta, build, build-externe-stubs, gate, changes]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     # Eén ZAD-taak tegelijk op deze deployment; een nieuwe push wacht op de lopende i.p.v. die af
     # te breken — een halverwege afgebroken ZAD-deploy laat de deployment in een inconsistente
     # staat achter. De cleanup-job voor hetzelfde project + dezelfde PR deelt deze groep, zodat een
@@ -411,6 +423,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action != 'closed' && needs.changes.outputs.run == 'true'
     needs: [meta, build, build-externe-stubs, gate, changes]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     concurrency:
       group: zad-externe-stubs-pr-${{ github.event.pull_request.number }}
       cancel-in-progress: false
@@ -437,6 +450,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action != 'closed' && needs.changes.outputs.run == 'true'
     needs: [meta, build, build-externe-stubs, gate, changes]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     concurrency:
       group: zad-magazijnen-pr-${{ github.event.pull_request.number }}
       cancel-in-progress: false
@@ -466,6 +480,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     needs: meta
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Zelfde groep als de deploy-job van dit project + deze PR: opruimen mag een lopende deploy
     # niet onder handen wegtrekken.
     concurrency:
@@ -505,6 +520,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     needs: meta
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     concurrency:
       group: zad-externe-stubs-pr-${{ github.event.pull_request.number }}
       cancel-in-progress: false
@@ -528,6 +544,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     needs: meta
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     concurrency:
       group: zad-magazijnen-pr-${{ github.event.pull_request.number }}
       cancel-in-progress: false
@@ -553,6 +570,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [meta, build, build-externe-stubs, gate]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     # Eén ZAD-taak tegelijk op de `test`-deployment van dit project; twee snel opeenvolgende merges
     # naar main mogen elkaars deploy niet halverwege afbreken.
     concurrency:
@@ -580,6 +598,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [meta, build, build-externe-stubs, gate]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     concurrency:
       group: zad-externe-stubs-test
       cancel-in-progress: false
@@ -602,6 +621,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [meta, build, build-externe-stubs, gate]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     # Dekt ook de tweede stap (deployment `fsc-magazijna`) — die hoort bij hetzelfde project.
     concurrency:
       group: zad-magazijnen-test

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -27,12 +27,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Bepaalt of er iets buiten documentatie (docs/, *.md) is gewijzigd. De detekt-gate is
-  # hieraan gegate, maar de workflow blijft triggeren zodat de required status check
-  # `detekt-gate` ook bij een docs-only PR gerapporteerd wordt: een via `if` overgeslagen
-  # job telt als 'skipped' = succes voor branch protection.
+  # Bepaalt of er iets buiten documentatie (docs/, *.md) is gewijzigd. De detekt-gate is hieraan
+  # gegate, maar de workflow zelf draait wél door — zo wordt de required status check ook bij een
+  # docs-only PR gerapporteerd: een via `if` overgeslagen job telt als 'skipped' = succes voor
+  # branch protection.
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       run: ${{ steps.filter.outputs.run }}
     steps:
@@ -73,6 +74,7 @@ jobs:
     # GitHub Advanced Security post (SARIF tool.name "detekt"). Required status check.
     name: detekt-gate
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -1,17 +1,26 @@
 name: detekt
 
 on:
-  push:
-    branches: [main]
-  # Géén branch-filter op pull_request: die filtert op de DOELbranch, waardoor een gestapelde
-  # PR (base = een feature-branch i.p.v. main) helemaal geen detekt-analyse zou draaien. Zo'n PR
-  # wordt op eigen merites gereviewd en gemerged; zonder analyse komen bevindingen pas aan het
-  # licht op de PR naar main, vermengd met de rest van de stapel. deploy.yml filtert juist wél op
-  # de doelbranch — die deployt niet vanaf een feature-branch. Die asymmetrie is opzet.
+  # deploy.yml roept deze workflow aan voor PR's naar main en voor pushes naar main. Daar hangt
+  # de deploy er met `needs:` aan, in plaats van in een eigen job op de check-run te pollen —
+  # een pollende job houdt een runner bezet zonder werk te doen.
+  workflow_call:
+  # Het complement van deploy.yml's `branches: [main]`, dat op de DOELbranch filtert. Een
+  # gestapelde PR (base = een feature-branch) draait deploy.yml niet en heeft deze workflow dus
+  # zelfstandig nodig: zonder analyse komen bevindingen pas aan het licht op de PR naar main,
+  # vermengd met de rest van de stapel. Voor een PR naar main roept deploy.yml deze workflow aan;
+  # zonder dit filter zou detekt dan twee keer draaien. De asymmetrie — wel toetsen, niet
+  # deployen — is opzet.
   pull_request:
+    branches-ignore: [main]
   workflow_dispatch:
 
-permissions: read-all
+# Geen `read-all`: als aangeroepen workflow mag dit nooit meer zijn dan de caller-job toekent, en
+# die kent alleen toe wat hier daadwerkelijk nodig is. De `changes`-job leest de bestandenlijst van
+# de PR; de `detekt`-job verhoogt zelf naar security-events: write voor de SARIF-upload.
+permissions:
+  contents: read
+  pull-requests: read
 
 concurrency:
   group: detekt-${{ github.ref }}

--- a/.github/workflows/pin-consistency.yml
+++ b/.github/workflows/pin-consistency.yml
@@ -10,10 +10,16 @@
 name: Pin consistency
 
 on:
+  # deploy.yml roept deze workflow aan voor PR's naar main en voor pushes naar main. Daar hangt
+  # de deploy er met `needs:` aan, in plaats van in een eigen job op de check-run te pollen —
+  # een pollende job houdt een runner bezet zonder werk te doen.
+  workflow_call:
+  # Complement van deploy.yml's `branches: [main]`: een gestapelde PR draait deploy.yml niet en
+  # heeft deze guard dus zelfstandig nodig. Zonder dit filter zou hij op een PR naar main twee
+  # keer draaien.
   pull_request:
+    branches-ignore: [main]
     types: [opened, synchronize, reopened]
-  push:
-    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/pin-consistency.yml
+++ b/.github/workflows/pin-consistency.yml
@@ -27,6 +27,7 @@ permissions:
 jobs:
   infra-image-pins:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: infra-image-pins moeten overal identiek zijn

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,26 @@
 name: Test
 
 on:
-  push:
-    branches: [main]
-  # Géén branch-filter op pull_request: die filtert op de DOELbranch, waardoor een gestapelde
-  # PR (base = een feature-branch i.p.v. main) helemaal geen tests zou draaien. Zo'n PR wordt op
-  # eigen merites gereviewd en gemerged; zonder tests komt breuk pas aan het licht op de PR naar
-  # main, vermengd met de wijzigingen van de rest van de stapel. deploy.yml filtert juist wél op
-  # de doelbranch — die deployt niet vanaf een feature-branch. Die asymmetrie is opzet.
+  # deploy.yml roept deze workflow aan voor PR's naar main en voor pushes naar main. Daar hangt
+  # de deploy er met `needs:` aan, in plaats van in een eigen job op de check-run te pollen —
+  # een pollende job houdt een runner bezet zonder werk te doen.
+  workflow_call:
+  # Het complement van deploy.yml's `branches: [main]`, dat op de DOELbranch filtert. Een
+  # gestapelde PR (base = een feature-branch) draait deploy.yml niet en heeft deze workflow dus
+  # zelfstandig nodig: zo'n PR wordt op eigen merites gereviewd en gemerged, en zonder tests komt
+  # breuk pas aan het licht op de PR naar main, vermengd met de rest van de stapel. Voor een PR
+  # naar main roept deploy.yml deze workflow aan; zonder dit filter zouden de tests dan twee keer
+  # draaien. De asymmetrie — wel toetsen, niet deployen — is opzet.
   pull_request:
+    branches-ignore: [main]
   workflow_dispatch:
 
-permissions: read-all
+# Geen `read-all`: als aangeroepen workflow mag dit nooit meer zijn dan de caller-job toekent, en
+# die kent alleen toe wat hier daadwerkelijk nodig is. De `changes`-job leest de bestandenlijst van
+# de PR; de `test`-job verhoogt zelf naar pull-requests: write voor de coverage-comment.
+permissions:
+  contents: read
+  pull-requests: read
 
 concurrency:
   group: test-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,12 +28,13 @@ concurrency:
 
 jobs:
   # Bepaalt of er iets buiten documentatie (docs/, *.md) is gewijzigd. De zware test-job is
-  # hieraan gegate, maar de workflow blijft triggeren zodat de required status check `test`
-  # ook bij een docs-only PR gerapporteerd wordt: een via `if` overgeslagen job telt als
-  # 'skipped' = succes voor branch protection. Een workflow-niveau paths-filter zou de check
-  # juist nooit rapporteren en de PR eeuwig blokkeren.
+  # hieraan gegate, maar de workflow zelf draait wél door — zo wordt de required status check ook
+  # bij een docs-only PR gerapporteerd: een via `if` overgeslagen job telt als 'skipped' = succes
+  # voor branch protection. Een workflow-niveau paths-filter zou de check juist nooit rapporteren
+  # en de PR eeuwig blokkeren.
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       run: ${{ steps.filter.outputs.run }}
     steps:
@@ -71,6 +72,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.run == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # pull-requests: write voor de coverage-PR-comment (madrapps/jacoco-report).
     permissions:
       contents: read

--- a/docs/plans/2026-08-10-deploy-gate-zonder-wachtende-runner.md
+++ b/docs/plans/2026-08-10-deploy-gate-zonder-wachtende-runner.md
@@ -155,6 +155,13 @@ Ongewijzigd: `Analyze (kotlin)`, `deploy-preview-uitvraag`, `deploy-preview-exte
 Volgorde: eerst de PR groen laten worden (de nieuwe contexts verschijnen dan op de head-SHA),
 dán branch protection omzetten, dán mergen. Andersom blokkeert de oude contextnaam de merge.
 
+De nieuwe namen bestaan alléén op branches die deze wijziging bevatten; open PR's die nog op de
+workflows van `main` draaien produceren de oude. Er is dus geen moment waarop beide sets bestaan —
+wie de knop omzet, blokkeert tijdelijk de andere groep. Omdat `strict: true` die PR's na de merge
+sowieso tot rebasen dwingt, is het extra ongemak vooral timing: houd het venster tussen omzetten
+en mergen kort en meld het. De volledige afweging met de drie routes staat in de beschrijving van
+#174.
+
 ## Verificatie
 
 Uitgevoerd op PR #174 en de wegwerp-PR #175 (10 augustus 2026).

--- a/docs/plans/2026-08-10-deploy-gate-zonder-wachtende-runner.md
+++ b/docs/plans/2026-08-10-deploy-gate-zonder-wachtende-runner.md
@@ -99,24 +99,44 @@ relevant geweest als 1 én 2 waren afgevallen.
   halverwege afgebroken ZAD-deploy), terwijl de toetsende jobs hun eigen
   `cancel-in-progress: true` uit de aangeroepen workflow houden.
 
+- `timeout-minutes` op elke job. GitHub's default is 360 minuten; een hangende job houdt zo lang
+  een runner bezet voordat iemand ingrijpt — dezelfde soort verspilling als de wachtlus, alleen
+  zeldzamer. De waarden staan op ~3× de waargenomen maximumduur. Jobs die een andere workflow
+  aanroepen kunnen de sleutel niet dragen; die staat daar in de aangeroepen workflow.
+
 ### `test.yml`, `detekt.yml`, `pin-consistency.yml`, `cflite_pr.yml`
 
 - `workflow_call:` toegevoegd.
 - `pull_request` beperkt tot `branches-ignore: [main]` (test, detekt, pins). `cflite_pr.yml`
   verliest zijn `pull_request`-trigger volledig: fuzzing draaide al alleen voor PR's naar main.
 - `push: branches: [main]` verwijderd waar `deploy.yml` die dekking nu levert.
+- De workflow-brede `permissions: read-all` van `test.yml` en `detekt.yml` teruggebracht tot
+  `contents: read` + `pull-requests: read`. Een aangeroepen workflow mag niet méér rechten hebben
+  dan de caller-job toekent, en die kent alleen toe wat de jobs echt nodig hebben.
+- `timeout-minutes` per job.
 
 ## Bewust niet gedaan
 
 - **De vier `changes`-jobs samenvoegen.** `deploy.yml`, `test.yml`, `detekt.yml` en `cflite_pr.yml`
   detecteren elk zelf of er iets buiten documentatie is gewijzigd: ~211 jobs per week van ~4 s
   (~14 min) plus evenzoveel API-calls. Dedupliceren vergt een optionele `workflow_call`-input plus
-  `always()`-conditie in elke aangeroepen workflow, omdat ze óók standalone moeten draaien voor
-  gestapelde PR's. Die conditielogica is precies waar CI stil kapot gaat. De verhouding
-  (14 min tegenover de 392 min die deze PR wegneemt) rechtvaardigt dat risico niet.
-- **`build` achter de gate zetten.** Zou ~170 s runnertijd besparen bij een falende testrun, maar
-  kost 83 s extra wachttijd op élke geslaagde run. Tests falen zelden genoeg om die ruil te maken.
+  extra conditielogica in elke aangeroepen workflow, omdat ze óók standalone moeten draaien voor
+  gestapelde PR's. Bij het uitwerken kwam een concreet gat boven: laat je `checks-test` van
+  `changes` afhangen, dan wordt bij een falende `changes`-job de hele testjob overgeslagen — en
+  `skipped` telt door als succes voor branch protection, dus ongeteste code zou merge-baar worden.
+  Sluitbaar met een `!cancelled()`-guard plus "sla alleen over bij een expliciete `false`", maar
+  dat zijn drie samenwerkende condities over drie bestanden voor 14 minuten per week. Niet waard
+  tegenover de 388 minuten die deze PR wegneemt.
+- **`build` achter de gate zetten.** Zou ~190 s runnertijd besparen op de 12% runs waarin een
+  check faalt (6 van 51 in de meetweek), maar kost 83 s extra wachttijd op élke geslaagde run.
+  Netto slechter.
+- **`build` laten afhangen van `changes`.** Op een docs-only PR bouwt en pusht de keten nu drie
+  images die nooit uitgerold worden. Fix lijkt triviaal, maar de cleanup bij PR-close probeert dan
+  een tag te verwijderen die niet bestaat, en of `zad-actions/cleanup` daarop faalt is niet
+  geverifieerd. In de meetweek kwam het geval niet voor (0 docs-only PR's). Doorgeschoven.
 - **De per-commit image-tag (#171/#172)** is niet aangeraakt.
+
+Deze posten staan met meetgegevens en de gevonden valkuilen in #176.
 
 ## Handmatige stap bij de merge
 
@@ -137,8 +157,30 @@ dán branch protection omzetten, dán mergen. Andersom blokkeert de oude context
 
 ## Verificatie
 
-1. **Besparing gemeten** — dezelfde meting vóór en ná over een vergelijkbaar aantal runs.
-2. **De poort werkt nog** — een revisie met een falende verplichte check deployt niet.
-3. **De merge-route werkt nog** — alle required contexts verschijnen op de head-SHA; een docs-only
-   PR haalt een merge-bare staat.
-4. **Geen dubbele runs** — de tests draaien één keer per revisie.
+Uitgevoerd op PR #174 en de wegwerp-PR #175 (10 augustus 2026).
+
+1. **Besparing gemeten.** `gate` duurde 4 s in beide runs op #174 (31387630765, 31388950061),
+   tegenover 461 s gemiddeld over 51 runs ervoor: **99,1% minder runnertijd**, geprojecteerd
+   ~388 min per week. Het aantal API-verzoeken van de gate gaat van ~120 per run naar 0.
+   Doorlooptijd van run-start tot de eerste preview-deploy: 475 s en 655 s ná, tegenover
+   gemiddeld 735 s (spreiding 434–936 s, n=38) ervóór — binnen de bestaande spreiding, dus geen
+   verlenging. Die doorlooptijd wordt bepaald door de traagste check (`test` 420 s, fuzz 526 s),
+   niet door de poort.
+2. **De poort werkt nog.** Wegwerp-PR #175 forceerde detekt-bevindingen. Run 31387899696:
+   `checks-detekt / detekt-gate` faalde, `gate` faalde na 3 s met
+   `Verplichte check 'detekt-gate' eindigde als 'failure' — deploy geblokkeerd`, en alle zes
+   deploy-jobs bleven `skipped`. Er is niets uitgerold.
+3. **De merge-route werkt nog.** Run 31388950061 laat alle vier de nieuwe contexts op de head-SHA
+   verschijnen (`checks-test / test`, `checks-detekt / detekt-gate`,
+   `checks-pins / infra-image-pins`, `checks-fuzz / PR`), naast de ongewijzigde
+   `deploy-preview-*` en `Analyze (kotlin)`. Voor de docs-only route is op #175 een run gedraaid
+   waarin elke `changes`-job `run=false` rapporteerde (31388993368): alle vier de contexts
+   verschenen als `skipped`, de deploy-jobs sloegen over en de run eindigde groen — merge-bare
+   staat.
+4. **Geen dubbele runs.** Op de branch van #174 draaiden alleen `Deploy ZAD` en `CodeQL`. `Test`,
+   `detekt`, `Pin consistency` en `ClusterFuzzLite PR fuzzing` startten niet zelfstandig.
+
+Bij de eerste run op #174 faalde `deploy-preview-magazijnen` op
+`timed out waiting for application to be created`. Dat is de bekende Argo-Application-wait aan
+ZAD-zijde die in de kop van `deploy.yml` staat beschreven; de tweede run deployde hetzelfde
+project zonder wijziging succesvol.

--- a/docs/plans/2026-08-10-deploy-gate-zonder-wachtende-runner.md
+++ b/docs/plans/2026-08-10-deploy-gate-zonder-wachtende-runner.md
@@ -159,9 +159,11 @@ dán branch protection omzetten, dán mergen. Andersom blokkeert de oude context
 
 Uitgevoerd op PR #174 en de wegwerp-PR #175 (10 augustus 2026).
 
-1. **Besparing gemeten.** `gate` duurde 4 s in beide runs op #174 (31387630765, 31388950061),
-   tegenover 461 s gemiddeld over 51 runs ervoor: **99,1% minder runnertijd**, geprojecteerd
-   ~388 min per week. Het aantal API-verzoeken van de gate gaat van ~120 per run naar 0.
+1. **Besparing gemeten.** Over de vijf runs met de nieuwe workflow (vier op #174, één op #175)
+   duurde `gate` 2–4 s, gemiddeld 3,4 s — tegenover 461 s gemiddeld over 51 runs ervoor:
+   **99,3% minder runnertijd**, geprojecteerd ~389 min per week. Het aantal API-verzoeken van de
+   gate gaat van ~120 per run naar 0. Ter controle draaide in hetzelfde tijdvak een run van een
+   andere branch (31389684161) nog op de oude, gepollde gate uit main: 526 s.
    Doorlooptijd van run-start tot de eerste preview-deploy: 475 s en 655 s ná, tegenover
    gemiddeld 735 s (spreiding 434–936 s, n=38) ervóór — binnen de bestaande spreiding, dus geen
    verlenging. Die doorlooptijd wordt bepaald door de traagste check (`test` 420 s, fuzz 526 s),

--- a/docs/plans/2026-08-10-deploy-gate-zonder-wachtende-runner.md
+++ b/docs/plans/2026-08-10-deploy-gate-zonder-wachtende-runner.md
@@ -179,6 +179,14 @@ Uitgevoerd op PR #174 en de wegwerp-PR #175 (10 augustus 2026).
    staat.
 4. **Geen dubbele runs.** Op de branch van #174 draaiden alleen `Deploy ZAD` en `CodeQL`. `Test`,
    `detekt`, `Pin consistency` en `ClusterFuzzLite PR fuzzing` startten niet zelfstandig.
+5. **Gestapelde PR's blijven getoetst zonder te deployen.** Wegwerp-PR #177 (base = de
+   feature-branch) draaide `Test` (job `test`, 444 s, geslaagd), `detekt` en `Pin consistency`
+   zelfstandig; `Deploy ZAD` en `ClusterFuzzLite PR fuzzing` startten niet.
+6. **PR-close doet geen toetswerk meer dan nodig.** De close van #175 (run 31390338566) sloeg alle
+   vier de `checks-*`-jobs en de `gate` over en draaide alleen de drie cleanup-jobs.
+7. **De rechten kloppen door de aanroep heen.** De JaCoCo-coverage-comment (`pull-requests: write`
+   via de caller-job), de ZAD-preview-comment en de detekt-SARIF-upload (`security-events: write`)
+   werkten alle drie op #174.
 
 Bij de eerste run op #174 faalde `deploy-preview-magazijnen` op
 `timed out waiting for application to be created`. Dat is de bekende Argo-Application-wait aan

--- a/docs/plans/2026-08-10-deploy-gate-zonder-wachtende-runner.md
+++ b/docs/plans/2026-08-10-deploy-gate-zonder-wachtende-runner.md
@@ -1,0 +1,144 @@
+# Deploy-gate zonder wachtende runner
+
+**Status:** Uitgevoerd
+**Issue:** #173
+
+## Context
+
+`deploy.yml` heeft een `gate`-job die de deploy tegenhoudt tot de verplichte checks uit *andere*
+workflows groen zijn. Die checks draaien in aparte workflows, dus er kan geen `needs:` aan gehangen
+worden; de gate pollt hun check-runs op dezelfde head-SHA met `sleep 15`. Functioneel klopt dat,
+maar het kost een volledige runner-VM die vrijwel alleen slaapt.
+
+Gemeten over 3–10 augustus 2026 (`gh api repos/{repo}/actions/runs/{id}/jobs`, script in de
+PR-beschrijving):
+
+| job | workflow | n | totaal | gemiddeld | max |
+|-----|----------|---|--------|-----------|-----|
+| `gate` | deploy.yml | 51 | 23.522 s (392 min) | 461 s | 910 s |
+| `test` | test.yml | 50 | 21.001 s | 420 s | 504 s |
+| `PR` (fuzz) | cflite_pr.yml | 17 | 8.942 s | 526 s | 663 s |
+| `detekt-gate` | detekt.yml | 53 | 2.840 s | 54 s | 79 s |
+| `infra-image-pins` | pin-consistency.yml | 55 | 304 s | 6 s | 31 s |
+| `build` (matrix ×2) | deploy.yml | 104 | 8.572 s | 83 s | 271 s |
+
+Twee dingen vallen op die het richtingskeuze-plaatje bepalen:
+
+- **De fuzz-check is de langste pool (526 s), niet `test` (420 s).** Elke oplossing die alleen
+  `test` versnelt of ontwijkt, lost niets op.
+- **`build` duurt maar 83 s.** De gate wacht dus ~380 s ná de build. Dat maakt richting 3
+  ("gate pas na de build starten") bij voorbaat marginaal.
+
+Daarnaast: de gate-timeout staat op 900 s terwijl de fuzz al 663 s piekte — krapper dan bedoeld.
+
+## Afweging van de richtingen
+
+### 1. `workflow_run`-trigger — afgevallen
+
+Een `workflow_run`-run hangt aan de default branch: `GITHUB_SHA` is de main-head, en de check-runs
+van die run verschijnen dus op main, niet op de head-SHA van de PR. De required contexts
+`deploy-preview-uitvraag`/`-externe-stubs`/`-magazijnen` zouden nooit meer op een PR verschijnen en
+elke merge permanent blokkeren. Dat is te omzeilen door met `POST /repos/{o}/{r}/statuses/{sha}`
+zelf commit-statussen op de PR-head te zetten, maar dan:
+
+- draait de deploy in een context mét schrijfrechten en projectsecrets, getriggerd door een run van
+  onvertrouwde PR-code (het patroon dat Scorecard's Dangerous-Workflow-check adresseert);
+- is de merge-route afhankelijk van zelfgeschreven statussen in plaats van de check-runs die
+  branch protection nu op `app_id 15368` (GitHub Actions) vastpint;
+- en — doorslaggevend — **is het niet te verifiëren vóór de merge**: een `workflow_run`-workflow
+  triggert alleen als het bestand op de default branch staat. Precies de wijziging met het hoogste
+  "blokkeert alle merges"-risico is dan de enige die je niet op een PR kunt uitproberen.
+
+### 2. Consolideren via `workflow_call` — gekozen
+
+`test.yml`, `detekt.yml`, `pin-consistency.yml` en `cflite_pr.yml` krijgen een `workflow_call`-
+trigger en worden vanuit `deploy.yml` als job aangeroepen. De deploy hangt er met `needs:` aan; de
+`gate` blijft bestaan maar wordt een **aggregator zonder wachtlus**: hij leest `needs.*.result` en
+is in seconden klaar.
+
+Waarom de gate niet helemaal verdwijnt: de "skipped/neutral telt als OK"-regel (docs-only PR's,
+niet-fuzz-relevante PR's, push-naar-main zonder fuzz) moet ergens staan. Als `if:`-expressie op
+elk van de zes deploy-jobs is dat zes keer dezelfde `always() && ...`-formule met zes kansen op
+drift. In één aggregator staat de regel één keer, mét de bestaande audit-logging bij een
+overgeslagen check.
+
+Dubbele runs worden voorkomen door de PR-trigger van de aangeroepen workflows te beperken tot
+`branches-ignore: [main]` — precies het complement van `deploy.yml`'s `branches: [main]`. Voor een
+PR naar main draait alleen `deploy.yml` (en roept de checks aan); voor een gestapelde PR draaien
+alleen de losse workflows. De `push: branches: [main]`-triggers vervallen: `deploy.yml` draait daar
+al en roept dezelfde jobs aan.
+
+Kosten: de check-namen krijgen het caller-job-voorvoegsel (`test` → `test / test`), dus branch
+protection moet mee. Dat is een handmatige stap buiten de repo, maar — anders dan bij richting 1 —
+**verschijnen de nieuwe contexts op de PR zelf**, dus je ziet vóór het omzetten dat ze bestaan en
+groen zijn.
+
+### 3. Gate goedkoper maken — afgevallen als hoofdrichting
+
+`gate` pas na `build` starten scheelt de build-duur: 83 s van 461 s (18%). Poll-interval omhoog
+scheelt API-verkeer maar geen runnertijd. Beide laten de kern intact: een VM die slaapt. Alleen
+relevant geweest als 1 én 2 waren afgevallen.
+
+## Wijzigingen
+
+### `deploy.yml`
+
+- `gate` verliest de poll-lus en wordt aggregator: `needs: [changes, checks-test, checks-detekt,
+  checks-pins, checks-fuzz]`, `if: always() && ...`, faalt zodra een van de results niet
+  `success`/`skipped` is. `TIMEOUT_SECONDS`/`POLL_SECONDS` en de `checks: read`-permissie
+  vervallen.
+- Vier caller-jobs erbij: `checks-test`, `checks-detekt`, `checks-pins`, `checks-fuzz`. Elk met
+  `if: github.event.action != 'closed'` (de `closed`-trigger is voor de cleanup, niet voor
+  toetsing) en de permissies die de aangeroepen workflow nodig heeft. `checks-fuzz` draait alleen
+  op `pull_request` — cflite bestaat niet op push.
+- De workflow-brede `concurrency` verhuist naar job-niveau. Reden: met de tests binnen deze
+  workflow zou `cancel-in-progress: false` op workflow-niveau een opvolgende push laten wachten
+  tot de vorige deploy klaar is, én de achterhaalde testrun helemaal uit laten draaien. Dat is
+  precies de verspilling die we wegnemen. De deploy- en cleanup-jobs krijgen nu elk een eigen
+  groep per project met `cancel-in-progress: false` (dezelfde bescherming als voorheen: geen
+  halverwege afgebroken ZAD-deploy), terwijl de toetsende jobs hun eigen
+  `cancel-in-progress: true` uit de aangeroepen workflow houden.
+
+### `test.yml`, `detekt.yml`, `pin-consistency.yml`, `cflite_pr.yml`
+
+- `workflow_call:` toegevoegd.
+- `pull_request` beperkt tot `branches-ignore: [main]` (test, detekt, pins). `cflite_pr.yml`
+  verliest zijn `pull_request`-trigger volledig: fuzzing draaide al alleen voor PR's naar main.
+- `push: branches: [main]` verwijderd waar `deploy.yml` die dekking nu levert.
+
+## Bewust niet gedaan
+
+- **De vier `changes`-jobs samenvoegen.** `deploy.yml`, `test.yml`, `detekt.yml` en `cflite_pr.yml`
+  detecteren elk zelf of er iets buiten documentatie is gewijzigd: ~211 jobs per week van ~4 s
+  (~14 min) plus evenzoveel API-calls. Dedupliceren vergt een optionele `workflow_call`-input plus
+  `always()`-conditie in elke aangeroepen workflow, omdat ze óók standalone moeten draaien voor
+  gestapelde PR's. Die conditielogica is precies waar CI stil kapot gaat. De verhouding
+  (14 min tegenover de 392 min die deze PR wegneemt) rechtvaardigt dat risico niet.
+- **`build` achter de gate zetten.** Zou ~170 s runnertijd besparen bij een falende testrun, maar
+  kost 83 s extra wachttijd op élke geslaagde run. Tests falen zelden genoeg om die ruil te maken.
+- **De per-commit image-tag (#171/#172)** is niet aangeraakt.
+
+## Handmatige stap bij de merge
+
+Branch protection op `main` moet in dezelfde beweging mee. Oud → nieuw:
+
+| oud | nieuw |
+|-----|-------|
+| `test` | `checks-test / test` |
+| `detekt-gate` | `checks-detekt / detekt-gate` |
+| `infra-image-pins` | `checks-pins / infra-image-pins` |
+| `PR` | `checks-fuzz / PR` |
+
+Ongewijzigd: `Analyze (kotlin)`, `deploy-preview-uitvraag`, `deploy-preview-externe-stubs`,
+`deploy-preview-magazijnen`, `strict: true`.
+
+Volgorde: eerst de PR groen laten worden (de nieuwe contexts verschijnen dan op de head-SHA),
+dán branch protection omzetten, dán mergen. Andersom blokkeert de oude contextnaam de merge.
+
+## Verificatie
+
+1. **Besparing gemeten** — dezelfde meting vóór en ná over een vergelijkbaar aantal runs.
+2. **De poort werkt nog** — een revisie met een falende verplichte check deployt niet.
+3. **De merge-route werkt nog** — alle required contexts verschijnen op de head-SHA; een docs-only
+   PR haalt een merge-bare staat.
+4. **Geen dubbele runs** — de tests draaien één keer per revisie.


### PR DESCRIPTION
> [!IMPORTANT]
> Deze PR hernoemt vier required status checks. Branch protection op `main` moet in dezelfde
> beweging mee, en de **volgorde** waarin dat gebeurt bepaalt of de zeven andere open PR's
> tussentijds vastlopen. Lees [Handmatige stap vóór de merge](#-handmatige-stap-vóór-de-merge)
> vóórdat je mergt. Er is bewust niets aan branch protection gewijzigd.

De uitrol naar de testomgeving wachtte op een eigen bouwmachine tot de kwaliteitscontroles groen
waren: gemiddeld 7 minuten en 41 seconden per wijziging, waarin die machine niets deed dan elke
15 seconden vragen of de controles al klaar waren. Deze PR laat de uitrol daar met een gewone
afhankelijkheid aan hangen, zodat er niets meer staat te wachten. **De poort duurt nu 4 seconden
in plaats van 461** — en blokkeert nog steeds, aantoonbaar, een revisie die een verplichte
controle niet haalt.

Closes MinBZK/moza-poc-fbs-berichtenbox#173

## Wat er verandert

`test.yml`, `detekt.yml`, `pin-consistency.yml` en `cflite_pr.yml` krijgen een
`workflow_call`-trigger en worden vanuit `deploy.yml` als job aangeroepen. Daardoor kan de deploy
er met `needs:` aan hangen. De `gate`-job blijft bestaan, maar verliest zijn poll-lus en wordt een
aggregator van `needs.*.result` — daar staat de "overgeslagen telt als OK"-regel één keer, in
plaats van als `always() && …`-formule op elk van de zes deploy-jobs.

Dubbele runs worden voorkomen door de PR-trigger van de aangeroepen workflows te beperken tot
`branches-ignore: [main]`, precies het complement van `deploy.yml`'s `branches: [main]`. Een
gestapelde PR (base ≠ main) draait ze zelfstandig; een PR naar main draait ze hier. `cflite_pr.yml`
draait voortaan uitsluitend als aangeroepen workflow — fuzzing gold al alleen voor PR's naar main.

De workflow-brede `concurrency` verhuist naar job-niveau. Met de tests binnen deze workflow zou
`cancel-in-progress: false` op workflow-niveau een opvolgende push laten wachten tot de vorige
deploy klaar is én de achterhaalde testrun helemaal uit laten draaien — precies de verspilling die
we wegnemen — terwijl `true` een lopende ZAD-deploy halverwege zou kunnen afbreken. Per job kan het
allebei: build- en toetsjobs breken achterhaald werk af, deploy- en cleanup-jobs krijgen een eigen
groep per project + doel-deployment die nooit afbreekt.

Twee kleinere posten uit dezelfde analyse zijn meegenomen: `timeout-minutes` op elke job (GitHub's
default is 360 minuten, dus een hangende job kost zes uur runner voordat iemand ingrijpt), en de
`permissions: read-all` van `test.yml`/`detekt.yml` teruggebracht tot wat de jobs echt nodig
hebben — een aangeroepen workflow mag toch niet meer rechten hebben dan de caller-job toekent.

De afweging van de drie richtingen — inclusief waarom `workflow_run` afvalt — staat in
`docs/plans/2026-08-10-deploy-gate-zonder-wachtende-runner.md`. Kort: bij `workflow_run` hangen de
check-runs aan de default branch in plaats van aan de head-SHA van de PR, en zo'n workflow triggert
pas als hij op de default branch staat. De wijziging met het grootste "blokkeert alle merges"-risico
zou dan de enige zijn die je niet vooraf op een PR kunt uitproberen.

## ⚠️ Handmatige stap vóór de merge

Branch protection op `main` pint required contexts op check-run-namen. Door de aanroep krijgen die
het caller-job-voorvoegsel. Zet ze om **nadat** deze PR groen is en **vóór** de merge:

| oud | nieuw |
|-----|-------|
| `test` | `checks-test / test` |
| `detekt-gate` | `checks-detekt / detekt-gate` |
| `infra-image-pins` | `checks-pins / infra-image-pins` |
| `PR` | `checks-fuzz / PR` |

Ongewijzigd: `Analyze (kotlin)`, `deploy-preview-uitvraag`, `deploy-preview-externe-stubs`,
`deploy-preview-magazijnen`, `strict: true`.

Tot die omzetting is deze PR niet merge-baar: de oude contexts verschijnen niet meer. Dat de
nieuwe contexts wél al op deze PR staan, is precies het voordeel van deze richting boven
`workflow_run`.

### De volgorde is de hele afweging

De nieuwe namen bestaan alléén op branches die deze wijziging al bevatten. De zeven andere open
PR's (#172, MinBZK/moza-poc-fbs-berichtenbox#170, MinBZK/moza-poc-fbs-berichtenbox#168, MinBZK/moza-poc-fbs-berichtenbox#166, MinBZK/moza-poc-fbs-berichtenbox#163, MinBZK/moza-poc-fbs-berichtenbox#150, MinBZK/moza-poc-fbs-berichtenbox#147) draaien nog de workflows van `main` en produceren
dus nog de oude namen. Er is geen moment waarop beide sets tegelijk bestaan, dus wie de knop ook
omzet: één van de twee groepen is even geblokkeerd. Drie routes, met hun prijs:

| route | gevolg |
|-------|--------|
| **Contexts omzetten vóór de merge** (aanbevolen) | Deze PR wordt merge-baar. De zeven andere PR's leveren dan de oude namen die niet meer verplicht zijn, en de nieuwe namen die ze niet kunnen leveren — dus geblokkeerd tot ze rebasen op de gemergede `main`. Houd het venster kort: zet om, merge direct, meld het in het kanaal. |
| **Mergen met admin-override, daarna omzetten** | Kortste blokkade voor de andere PR's, maar deze PR gaat in zonder dat de required checks formeel groen stonden — precies de bewaking die we hier repareren, één keer overgeslagen. Alleen doen als de andere PR's echt niet kunnen wachten. |
| **Niets doen** | Deze PR blijft hangen. Geen optie op termijn: de wijziging veroudert en de 392 min/week blijft lopen. |

`strict: true` staat aan, dus de andere PR's moeten na de merge sowieso rebasen. Het extra
ongemak van route 1 is dus vooral *timing*, niet extra werk: de rebase moest toch gebeuren.

Er is bewust niets aan branch protection gewijzigd vanuit deze PR — het is een handmatige stap
buiten de repo, en wie hem zet moet weten wat er in het venster ertussen gebeurt.

## Meting

Reproduceerbaar met:

```bash
# alle deploy-runs sinds <datum>
gh run list --repo MinBZK/moza-poc-fbs-berichtenbox --workflow deploy.yml --limit 200 \
  --json databaseId,createdAt --jq '[.[] | select(.createdAt > "<datum>")] | .[].databaseId'

# per run de looptijd per job
gh api "repos/MinBZK/moza-poc-fbs-berichtenbox/actions/runs/<id>/jobs" \
  --jq '.jobs[] | select(.name=="gate") | "\(.conclusion) \(.started_at) -> \(.completed_at)"'
```

### Vóór (3–10 augustus 2026)

| job | workflow | n | totaal | gemiddeld | max |
|-----|----------|---|--------|-----------|-----|
| `gate` | deploy.yml | 51 | **23.522 s (392 min)** | **461 s** | 910 s |
| `test` | test.yml | 50 | 21.001 s | 420 s | 504 s |
| `PR` (fuzz) | cflite_pr.yml | 17 | 8.942 s | 526 s | 663 s |
| `detekt-gate` | detekt.yml | 53 | 2.840 s | 54 s | 79 s |
| `infra-image-pins` | pin-consistency.yml | 55 | 304 s | 6 s | 31 s |
| `build` (matrix ×2) | deploy.yml | 104 | 8.572 s | 83 s | 271 s |

Twee dingen die de richtingskeuze bepaalden: de **fuzz-check is de langste pool** (526 s), niet
`test`; en `build` duurt maar 83 s, dus "gate pas na de build starten" (richting 3) zou hooguit
18% schelen.

### Ná (deze PR)

| | vóór | ná |
|---|---|---|
| `gate` runnertijd | 461 s gemiddeld (n=51) | **3,4 s** gemiddeld, spreiding 2–4 s (n=5) |
| API-verzoeken door de gate | ~120 per run, ~6.000 per week | **0** |
| Geprojecteerd per week | 392 min wachtende runner | **~3 min** |

Ter controle draaide in hetzelfde tijdvak een run van een andere branch
([31389684161](https://github.com/MinBZK/moza-poc-fbs-berichtenbox/actions/runs/31389684161)) nog
op de oude, gepollde gate uit `main`: 526 s. Zelfde infrastructuur, zelfde moment.

**Doorlooptijd niet verslechterd.** Van run-start tot de eerste preview-deploy: 475 s en 655 s ná,
tegenover gemiddeld 735 s (spreiding 434–936 s, n=38) ervóór. Die doorlooptijd wordt bepaald door
de traagste check (fuzz 526 s, test 420 s), niet door de poort — de poort zat er alleen naast te
wachten. Met n=2 is dit "binnen de bestaande spreiding", geen aantoonbare versnelling.

## Verificatie

**1. De poort werkt nog** — wegwerp-PR MinBZK/moza-poc-fbs-berichtenbox#175 forceerde detekt-bevindingen. Run
[31387899696](https://github.com/MinBZK/moza-poc-fbs-berichtenbox/actions/runs/31387899696):

```
checks-detekt / detekt-gate   failure
gate                          failure (3 s)
  Verplichte check 'test' geslaagd.
  ##[error]Verplichte check 'detekt-gate' eindigde als 'failure' — deploy geblokkeerd.
  Verplichte check 'infra-image-pins' geslaagd.
deploy-preview-uitvraag       skipped
deploy-preview-externe-stubs  skipped
deploy-preview-magazijnen     skipped
```

**2. De merge-route werkt nog** — alle vier nieuwe contexts verschijnen op de head-SHA van deze PR,
naast de ongewijzigde `deploy-preview-*` en `Analyze (kotlin)`. Voor de docs-only route draaide op
MinBZK/moza-poc-fbs-berichtenbox#175 een run waarin elke `changes`-job `run=false` rapporteerde
([31388993368](https://github.com/MinBZK/moza-poc-fbs-berichtenbox/actions/runs/31388993368)): alle
vier de contexts verschenen als `skipped`, alle deploy-jobs sloegen over, run groen — merge-bare
staat.

**3. Geen dubbele runs** — op de branch van deze PR draaiden alleen `Deploy ZAD` en `CodeQL`:

```
$ gh run list --branch feature/deploy-gate-zonder-wachtende-runner --json workflowName,event
CodeQL      pull_request  completed/success
Deploy ZAD  pull_request  completed/success
```

`Test`, `detekt`, `Pin consistency` en `ClusterFuzzLite PR fuzzing` startten niet zelfstandig.

**4. Gestapelde PR's blijven getoetst zonder te deployen** — wegwerp-PR MinBZK/moza-poc-fbs-berichtenbox#177 met base = deze
feature-branch draaide `Test` (job `test`, 444 s, geslaagd), `detekt` en `Pin consistency`
zelfstandig, met de onveranderde check-namen. `Deploy ZAD` en `ClusterFuzzLite PR fuzzing`
startten niet. Het complement-filter dekt dus precies één keer, aan beide kanten.

**5. PR-close doet geen toetswerk meer** — de close van MinBZK/moza-poc-fbs-berichtenbox#175
([31390338566](https://github.com/MinBZK/moza-poc-fbs-berichtenbox/actions/runs/31390338566)) sloeg
alle vier de `checks-*`-jobs en de `gate` over en draaide alleen de drie cleanup-jobs.

**6. De rechten kloppen door de aanroep heen** — de JaCoCo-coverage-comment
(`pull-requests: write` via de caller-job), de ZAD-preview-comment en de detekt-SARIF-upload
(`security-events: write`) werkten alle drie op deze PR.

**Kanttekening:** bij de eerste run faalde `deploy-preview-magazijnen` op `timed out waiting for
application to be created`. Dat is de bekende Argo-Application-wait aan ZAD-zijde die in de kop van
`deploy.yml` staat beschreven; de tweede run deployde hetzelfde project zonder wijziging succesvol.

## Samenloop met MinBZK/moza-poc-fbs-berichtenbox#172

MinBZK/moza-poc-fbs-berichtenbox#172 landde op main terwijl deze PR openstond en raakt dezelfde jobs. Bij het samenvoegen (merge
`03f5043`) drie conflicten in `deploy.yml`, alle drie opgelost richting "beide behouden":

- `gate` houdt zijn `needs`-lijst en `!cancelled()` uit deze PR, met de nauwkeurigere
  comment-tekst van MinBZK/moza-poc-fbs-berichtenbox#172 (docs-only **of bot-PR**).
- `build`/`build-externe-stubs` houden de `changes`-afhankelijkheid van MinBZK/moza-poc-fbs-berichtenbox#172 én de
  job-concurrency hiervandaan. Het oorspronkelijke argument voor die concurrency — voorkomen dat
  twee runs dezelfde tag overschrijven — is met de per-commit-tag vervallen; wat blijft is dat een
  achterhaalde build geen runnertijd hoeft te kosten. Comment daarop aangepast.
- De `cleanup-preview-*`-jobs nemen de versmalling van MinBZK/moza-poc-fbs-berichtenbox#172 over (`packages: write` en
  `needs: meta` weg), met de job-concurrency en `timeout-minutes` hiervandaan erbovenop. De nieuwe
  job `cleanup-preview-images` heeft `timeout-minutes` gekregen.

De per-commit-tag werkt na de merge: run
[31473630425](https://github.com/MinBZK/moza-poc-fbs-berichtenbox/actions/runs/31473630425) pushte
`fbs-berichtenuitvraag:pr-174-03f5043`, gelijk aan de head-sha. `gate` deed er 3 s over; alle drie
de previews rolden uit.

**Eén nieuw randgeval**, eerlijk gemeld: een close-run wacht niet meer op een nog lopende build
van een eerdere push (venster ≈ 85 s), dus `cleanup-preview-images` kan die net mislopen en één
ghcr-versie laten staan. Geen kapotte deploy; herdraaien ruimt hem op. Staat als bekende beperking
in `deploy.yml` en met denkrichting in MinBZK/MijnOverheidZakelijk#934.

Eén post uit MinBZK/MijnOverheidZakelijk#934 is door MinBZK/moza-poc-fbs-berichtenbox#172 al opgelost: `build` hangt daar nu zelf aan `changes`.

## Wat blijft staan

Vier kleinere posten uit dezelfde analyse staan met meetgegevens in MinBZK/MijnOverheidZakelijk#934 — waaronder de vier
`changes`-jobs die dezelfde vraag stellen, en de preview-uitrol voor PR's die de applicatie niet
raken (de enige post met echt clusterverbruik). Elk is bewust doorgeschoven; de afwegingen staan
in het plan.
