### PR TITLE
docs(c4): gelijke magazijnlijnen in landschap en contextviews

### DIFF
--- a/docs/architecture/workspace.dsl
+++ b/docs/architecture/workspace.dsl
@@ -176,6 +176,14 @@ workspace "MOZa PoC Federatief Berichtenstelsel" "Doel-architectuur van het Fede
         interactielaag -> digiD "Authenticatie burgers" "SAML 2.0"
         interactielaag -> eHerkenning "Authenticatie zakelijke gebruikers" "SAML 2.0"
 
+        // Drie componentrelaties (ophalen, sessiecache-aggregatie, beheer) lopen naar hetzelfde magazijn.
+        // Structurizr leidt daaruit per elementenpaar hooguit één systeemlijn af, die dan willekeurig de
+        // beschrijving van de eerst geparste relatie erft — het beheerverkeer verdwijnt zo uit beeld. Door
+        // de systeemlijn hier expliciet en vóór die componentrelaties te declareren, staat de samengevoegde
+        // beschrijving vast en blijft het bij één lijn per richting.
+        berichtenUitvraagSysteem -> bboMagazijn "Haalt berichtenlijst, berichtinhoud en bijlagen op en beheert berichtstatus per gebruiker" "Digikoppeling REST API via FSC"
+        berichtenUitvraagSysteem -> eigenMagazijn "Haalt berichtenlijst, berichtinhoud en bijlagen op en beheert berichtstatus per gebruiker" "Digikoppeling REST API via FSC"
+
         uitvraagOphaalService -> magazijnOphaalBeheerApi "Haalt berichtenlijst, incl. berichtinhoud en attributen, of bijlagen op" "Digikoppeling REST API via FSC"
         uitvraagBeheerService -> magazijnOphaalBeheerApi "Beheert berichtstatus" "Digikoppeling REST API via FSC"
 
@@ -215,8 +223,6 @@ workspace "MOZa PoC Federatief Berichtenstelsel" "Doel-architectuur van het Fede
 
         systemLandscape "SystemLandscape" "Het Federatief Berichtenstelsel - een stelsel van federatief gekoppelde diensten" {
             include *
-            exclude "bboMagazijn -> berichtenUitvraagSysteem"
-            exclude "eigenMagazijn -> berichtenUitvraagSysteem"
             autoLayout
         }
 


### PR DESCRIPTION
Closes #716

## Aanleiding

In het System Landscape stond één lijn tussen de magazijnen en het Berichten Uitvraag Systeem, terwijl beide system context views er twee toonden.

Oorzaak: de landschapsview sloot de richting magazijn → uitvraag expliciet uit. Daarmee was het aanmelden van nieuwe berichten in het landschap onzichtbaar, maar in de contextviews wel zichtbaar. De twee lijnen in de contextviews zijn dus twee richtingen, geen dubbele ophaal-lijn.

Daarnaast bleek het beheren van berichtstatus in geen enkele view op systeemniveau terug te komen: er lopen drie componentrelaties naar hetzelfde magazijn (ophalen, sessiecache-aggregatie, beheren) en Structurizr leidt daaruit hooguit één systeemlijn af, die de beschrijving van de eerst geparste relatie erft.

## Wijziging

`docs/architecture/workspace.dsl`:

- De twee `exclude`-regels uit de `systemLandscape`-view verwijderd.
- De systeemlijn uitvraag → magazijn expliciet gedeclareerd met een samengevoegde beschrijving: *"Haalt berichtenlijst, berichtinhoud en bijlagen op en beheert berichtstatus per gebruiker"*.

De declaratie staat bewust **vóór** de componentrelaties. Structurizr leidt alleen een systeemlijn af als er nog geen relatie tussen dat elementenpaar bestaat; staat de expliciete regel erachter, dan komt er een tweede lijn naast (dat is bij het bouwen van deze PR ook eerst zo misgegaan).

## Resultaat

Landschap en beide contextviews tonen nu dezelfde twee lijnen per magazijn:

| Richting | Beschrijving |
|---|---|
| uitvraag → magazijn | Haalt berichtenlijst, berichtinhoud en bijlagen op en beheert berichtstatus per gebruiker |
| magazijn → uitvraag | Meldt nieuw bericht aan |

## Verificatie

Site lokaal gegenereerd met dezelfde image als CI (`ghcr.io/avisi-cloud/structurizr-site-generatr:1.5.2`) en de gegenereerde PlantUML nagelopen:

- `SystemLandscape`: 2 lijnen per magazijn, beide richtingen, samengevoegde beschrijving — geen dubbele lijn meer.
- `Berichtenmagazijn` en `BerichtenUitvraagSysteem` (context): identiek aan het landschap.
- Containerviews: ongewijzigd, detail per container blijft staan.

Zie ook de architecture preview die de CI op deze PR plaatst.

## Bekende beperking (buiten scope)

Op containerniveau geldt dezelfde afleidingsregel: `uitvraagOphaalService` en `uitvraagBeheerService` zitten in dezelfde container, dus de containerview toont ook daar één lijn met alleen de ophaal-beschrijving. Dat gedrag is ongewijzigd door deze PR; als dit stoort, is een apart issue de plek.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
