### PR TITLE
fix(ci): geef deploy-test-*-jobs een expliciete statusfunctie

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -668,7 +668,20 @@ jobs:
   # Push naar main → per project de `test`-deployment (de baseline waarvan previews klonen;
   # env/secrets configureer je daar in Operations Manager). Per project een eigen parallelle job.
   deploy-test-uitvraag:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Expliciete statusfunctie i.p.v. de impliciete success(): die kijkt niet alleen naar de vier
+    # directe needs hieronder, maar transitief door naar hún needs — en `checks-fuzz` (PR-only) is
+    # bij een push naar main altijd 'skipped', wat de impliciete success() over de hele keten laat
+    # falen. `gate` ontsnapt daar zelf al aan met `!cancelled()`, maar dat beschermt alleen `gate`
+    # zelf, niet de jobs die van `gate` afhangen. Vandaar hier dezelfde `!cancelled()`-vorm, plus
+    # expliciete per-need result-checks zodat een échte build-/gate-fout deze job wél overslaat.
+    if: >-
+      !cancelled()
+      && needs.meta.result == 'success'
+      && needs.build.result == 'success'
+      && needs.build-externe-stubs.result == 'success'
+      && needs.gate.result == 'success'
+      && github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
     needs: [meta, build, build-externe-stubs, gate]
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -695,7 +708,16 @@ jobs:
             ]
 
   deploy-test-externe-stubs:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Zelfde reden als deploy-test-uitvraag hierboven: impliciete success() over de needs-keten
+    # wordt vergiftigd door het op push altijd-geskipte `checks-fuzz`, ook al is `gate` zelf groen.
+    if: >-
+      !cancelled()
+      && needs.meta.result == 'success'
+      && needs.build.result == 'success'
+      && needs.build-externe-stubs.result == 'success'
+      && needs.gate.result == 'success'
+      && github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
     needs: [meta, build, build-externe-stubs, gate]
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -718,7 +740,16 @@ jobs:
             ]
 
   deploy-test-magazijnen:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Zelfde reden als deploy-test-uitvraag hierboven: impliciete success() over de needs-keten
+    # wordt vergiftigd door het op push altijd-geskipte `checks-fuzz`, ook al is `gate` zelf groen.
+    if: >-
+      !cancelled()
+      && needs.meta.result == 'success'
+      && needs.build.result == 'success'
+      && needs.build-externe-stubs.result == 'success'
+      && needs.gate.result == 'success'
+      && github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
     needs: [meta, build, build-externe-stubs, gate]
     runs-on: ubuntu-latest
     timeout-minutes: 20


### PR DESCRIPTION
## Samenvatting

Sinds #174 worden `deploy-test-uitvraag`, `deploy-test-externe-stubs` en
`deploy-test-magazijnen` bij **elke push naar main stilzwijgend overgeslagen**
— geverifieerd via de daadwerkelijke CI-runs (`gh api .../jobs`): in elke run
sinds `36c246f` (#174) hebben `meta`, `build`, `build-externe-stubs` én `gate`
conclusion `success`, maar de drie deploy-jobs zelf `skipped`.

Oorzaak: hun `if:` bevat geen statusfunctie, dus GitHub Actions past de
impliciete `success()` toe over de héle transitieve needs-keten — niet alleen
over de vier directe `needs` van deze jobs. `checks-fuzz` (PR-only) is bij een
push naar main altijd `skipped`, wat die impliciete `success()` laat falen.
`gate`'s eigen `!cancelled()`-fix (ook uit #174) beschermt alléén `gate` zelf
tegen dat skip-effect, niet de jobs die van `gate` afhangen.

- Elke `if:` krijgt nu dezelfde `!cancelled()`-vorm als `gate`, plus expliciete
  per-need `result == 'success'`-checks — zodat een échte build-/gate-fout de
  job nog steeds terecht overslaat.
- Toegepast op alle drie de `deploy-test-*`-jobs; ze delen precies dezelfde
  `needs`-lijst en dus hetzelfde lek.

## Gevolg voor `test`

De `test`-deployments van uitvraag/magazijnen/externe-stubs hebben al drie
merges lang geen nieuwe image gekregen. Dat wordt los van deze PR handmatig
gedeblokkeerd (OM-API image-update naar de laatst geslaagde build). Deze PR
voorkomt dat het opnieuw gebeurt bij de eerstvolgende merge.

## Test plan

- [x] YAML gevalideerd (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Na merge: volgende push naar main → `deploy-test-uitvraag`,
      `deploy-test-externe-stubs` en `deploy-test-magazijnen` draaien
      daadwerkelijk (niet meer `skipped`) wanneer `gate` groen is