### PR TITLE
Logboek van de uitvraag schrijft weer naar een bestaande database

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -160,7 +160,7 @@ services:
       AANMELD_URL: http://toxiproxy:18086/api/v1/aanmeldingen
       NOTIFICATIE_URL: http://toxiproxy:18084/events
       PROFIEL_SERVICE_URL: http://profiel-service:8080
-      LDV_CLICKHOUSE_ENDPOINT: http://clickhouse:8123
+      # Geen LDV-env: het magazijn logt onder %dev in zijn eigen datasource, dus postgres-a.
       # Outbox sneller laten pollen zodat storing→herstel binnen seconden zichtbaar is (default 60s),
       # en meer pogingen zodat een uitgeschakelde downstream niet terminal MISLUKT tijdens de uitleg.
       MAGAZIJN_PUBLICATIE_POLLING_INTERVAL: 5s
@@ -188,7 +188,7 @@ services:
       AANMELD_URL: http://toxiproxy:18086/api/v1/aanmeldingen
       NOTIFICATIE_URL: http://toxiproxy:18084/events
       PROFIEL_SERVICE_URL: http://profiel-service:8080
-      LDV_CLICKHOUSE_ENDPOINT: http://clickhouse:8123
+      # Geen LDV-env: het magazijn logt onder %dev in zijn eigen datasource, dus postgres-b.
       MAGAZIJN_PUBLICATIE_POLLING_INTERVAL: 5s
       MAGAZIJN_PUBLICATIE_DOWNSTREAMS_AANMELD_MAX_POGINGEN: "50"
       MAGAZIJN_PUBLICATIE_DOWNSTREAMS_NOTIFICATIE_MAX_POGINGEN: "50"
@@ -230,6 +230,8 @@ services:
         condition: service_started
       toxiproxy:
         condition: service_started
+      postgres-uitvraag:
+        condition: service_healthy
     environment:
       QUARKUS_PROFILE: dev
       QUARKUS_HTTP_HOST: 0.0.0.0
@@ -238,7 +240,12 @@ services:
       MAGAZIJN_A_URL: http://toxiproxy:18090
       MAGAZIJN_B_URL: http://toxiproxy:18091
       PROFIEL_SERVICE_URL: http://toxiproxy:18089
-      LDV_CLICKHOUSE_ENDPOINT: http://clickhouse:8123
+      # Het logboek moet expliciet: de %dev-default wijst naar localhost:5434, en dat is
+      # binnen een container de container zelf. Credentials staan hier naast de service
+      # die ze definieert, zodat een wijziging daar niet stil uiteenloopt.
+      LDV_POSTGRES_URL: jdbc:postgresql://postgres-uitvraag:5432/ldv_logging
+      LDV_POSTGRES_USERNAME: ldv
+      LDV_POSTGRES_PASSWORD: ldv
       # CORS voor de Berichtenbox-UI (:8095). Runtime-property, dus geen rebuild nodig;
       # origins staan onder %dev in application.properties. Alleen in het demo-profiel.
       QUARKUS_HTTP_CORS_ENABLED: "true"

--- a/docs/demo-runbook.md
+++ b/docs/demo-runbook.md
@@ -61,7 +61,7 @@ Er zijn twee modi met dezelfde compose:
 
 | Commando | Wat draait | Wanneer |
 |---|---|---|
-| `docker compose up -d` | Alleen infra (Redis, Postgres, WireMock-stubs, ClickHouse) | **Ontwikkelen** — draai services zelf met `./mvnw quarkus:dev` (hot reload) |
+| `docker compose up -d` | Alleen infra (Redis, de drie Postgres-instanties, WireMock-stubs) | **Ontwikkelen** — draai services zelf met `./mvnw quarkus:dev` (hot reload) |
 | `docker compose --profile demo up -d` | Alles: infra + de drie services + demo-console + Toxiproxy + stub-magazijnen | **Demo** |
 
 > **Draai altijd eerst §3**, óók als je "veel magazijnen" niet demonstreert. `demo/generated/` is
@@ -91,8 +91,8 @@ Afsluiten: `docker compose --profile demo down` (voeg `-v` toe om de Postgres-vo
 | profiel-service | 8089 | Profiel-stub (welke magazijnen per persona) |
 | redis | 6379 | Sessiecache + ontdubbel-markers |
 | aanmeld-stub / notificatie-stub | 8083 / 8084 | Downstreams van de publicatiestroom |
-| postgres-a / -b | 5432 / 5433 | Databases van de echte magazijnen |
-| clickhouse | 8123 | Logboek Dataverwerkingen (LDV) |
+| postgres-a / -b | 5432 / 5433 | Databases van de echte magazijnen, inclusief hun eigen logboek |
+| postgres-uitvraag | 5434 | Logboek Dataverwerkingen (LDV) van de uitvraag |
 
 De uitvraag loopt in de demo door Toxiproxy voor redis, profiel en de twee echte magazijnen; de
 magazijn-downstreams (aanmeld, notificatie) lopen óók door Toxiproxy zodat ze per knop uit kunnen.


### PR DESCRIPTION
## Aanleiding

De demo-stack schrijft het Logboek Dataverwerkingen van de berichtenuitvraag nergens naartoe. De drie demo-services wijzen naar een ClickHouse die niet meer in `compose.yaml` staat, en de uitvraag krijgt geen enkele instelling mee voor de PostgreSQL die er wél staat.

Omdat het logboek op `write-failure-policy=fail-closed` staat, is dit niet alleen een gat in de vastlegging: elke verwerking die moet loggen, faalt.

## Hoe het is ontstaan

Twee PR's die los van elkaar klopten, in deze volgorde:

1. **#168** verving de `clickhouse`-service door `postgres-uitvraag`. Op dat moment stonden de demo-services nog niet in `compose.yaml`, dus daar viel niets te herzien.
2. **#150** (demo-platform) landde daarna en bracht de demo-services mee, geschreven tegen de compose van vóór #168 — inclusief `LDV_CLICKHOUSE_ENDPOINT: http://clickhouse:8123`.

## Wat er verandert

**Berichtenuitvraag** — krijgt zijn logboek-instellingen expliciet, plus een `depends_on` op de database:

```yaml
      LDV_POSTGRES_URL: jdbc:postgresql://postgres-uitvraag:5432/ldv_logging
      LDV_POSTGRES_USERNAME: ldv
      LDV_POSTGRES_PASSWORD: ldv
```

De `%dev`-default was `jdbc:postgresql://localhost:5434/ldv_logging`. Prima op een werkplek, maar binnen een container is `localhost` de container zelf en luistert daar niets.

**Beide magazijnen** — de dode `LDV_CLICKHOUSE_ENDPOINT`-regel eruit. Zij hebben geen vervanging nodig: onder `%dev` staat hun logboek-URL al op `${quarkus.datasource.jdbc.url}`, dus ze schrijven in hun eigen `postgres-a` respectievelijk `postgres-b`. Dat is precies de bedoelde inrichting — elke organisatie voert een eigen verwerkingenlogboek. Er staat nu een regel bij die dat vastlegt, zodat de afwezigheid van LDV-env niet als omissie leest.

**Runbook** — de poortentabel noemde `clickhouse | 8123`; dat is nu `postgres-uitvraag | 5434`. De regel over "alleen infra" noemde ClickHouse in plaats van de drie Postgres-instanties.

## Verificatie

- `docker compose --profile demo config` rendert schoon; in de gerenderde configuratie staat geen enkele ClickHouse-verwijzing meer.
- De uitvraag wacht nu op `postgres-uitvraag` met `condition: service_healthy` — die service heeft al een `pg_isready`-healthcheck.
- De logboek-instellingen resolven naar `postgres-uitvraag:5432`, de host die `compose.yaml` in hetzelfde bestand definieert.

**Niet gedaan:** de demo-stack daadwerkelijk opgestart en een logregel in `postgres-uitvraag` teruggelezen. Dat vraagt een jib-build van de drie images. Het faalgedrag hierboven is afgeleid uit de configuratie (`fail-closed` plus een onbereikbare host), niet gereproduceerd. Wie de demo toch draait: één `Ophalen` in de Berichtenbox en daarna `SELECT count(*) FROM logboek_dataverwerkingen` op poort 5434 bevestigt het in één keer.

## Raakvlak

Losgetrokken uit #163, waar dit als bewust geparkeerd punt genoteerd stond. De reden om het daar te laten liggen — "hoort in de base-PR thuis" — verviel toen demo-platform naar `main` ging.
