### PR TITLE
fix(sessiecache): dicht de robuustheids-restpunten rond het berichten-ophalen

### DIFF
--- a/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtensessiecacheService.kt
+++ b/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtensessiecacheService.kt
@@ -558,9 +558,15 @@ internal class BerichtensessiecacheService(
                 "Magazijn %s (%s) overschreed berichten-cap: %d > %d",
                 magazijnId, naam, response.berichten.size, maxBerichtenPerMagazijn,
             )
-            val foutMessage = "Magazijn leverde meer berichten dan toegestaan (${response.berichten.size} > $maxBerichtenPerMagazijn)"
-
-            return MagazijnResult.Failure(magazijnId, naam, MagazijnResponseOverflow(foutMessage), MagazijnFault.OVERFLOW)
+            // Geen aantallen in de exception-tekst: die belandt niet in de respons, maar de
+            // grens en de werkelijke omvang zijn interne gegevens die niet naar buiten horen
+            // te lekken langs welk pad dan ook. De counts staan hierboven al in de log.
+            return MagazijnResult.Failure(
+                magazijnId,
+                naam,
+                MagazijnResponseOverflow("Magazijn leverde meer berichten dan toegestaan"),
+                MagazijnFault.OVERFLOW,
+            )
         }
 
         // Magazijn levert MagazijnBericht-DTO's; vlak af naar het cache-domein
@@ -727,12 +733,24 @@ internal class BerichtensessiecacheService(
     ): Uni<MagazijnEvent> {
         val errorId = UUID.randomUUID()
         val ref = errorId.toString()
+        val afgebroken = isAfbreking(error)
 
-        log.errorf(
-            error,
-            "(errorId=%s) Fout bij opslaan in cache na aggregatie (key=%s, berichten=%d, geslaagd=%d, mislukt=%d)",
-            errorId, cacheKey, alleBerichten.size, geslaagd.get(), mislukt.get(),
-        )
+        // Een afbreking is geen storing: de gebruiker sloot de pagina, of de pod gaat uit.
+        // Op errorf-niveau loggen zou beheer wakker maken voor normaal gedrag en echte
+        // fouten laten ondersneeuwen.
+        if (afgebroken) {
+            log.infof(
+                "(errorId=%s) Opslaan na aggregatie afgebroken (key=%s, berichten=%d); geen storing",
+                errorId, cacheKey, alleBerichten.size,
+            )
+        } else {
+            log.errorf(
+                error,
+                "(errorId=%s) Fout bij opslaan in cache na aggregatie (key=%s, berichten=%d, geslaagd=%d, mislukt=%d)",
+                errorId, cacheKey, alleBerichten.size, geslaagd.get(), mislukt.get(),
+            )
+        }
+
         val foutStatus = AggregationStatus(
             status = OphalenStatus.FOUT,
             totaalMagazijnen = totaalMagazijnen,
@@ -744,12 +762,21 @@ internal class BerichtensessiecacheService(
             // FATAL + ALERT-marker: dubbele Redis-fout = cache effectief onbruikbaar
             // voor deze sessie. Lock blijft tot Redis-TTL hangen. Het prefix wordt
             // door log-aggregator (Loki/CloudWatch) gefilterd richting alert-routing.
+            // Een afbreking krijgt die marker niet: beheer oppiepen voor een gesloten
+            // pagina of een herstart laat echte storingen ondersneeuwen.
             .onFailure().invoke { e ->
-                log.fatalf(
-                    e,
-                    "[ALERT cache_doublefail] (errorId=%s) Cache-write FAIL/FAIL (key=%s, berichten=%d, geslaagd=%d, mislukt=%d): Redis onbruikbaar voor sessie, lock leunt op TTL",
-                    errorId, cacheKey, alleBerichten.size, geslaagd.get(), mislukt.get(),
-                )
+                if (afgebroken || isAfbreking(e)) {
+                    log.infof(
+                        "(errorId=%s) Ook de fout-status kon niet worden weggeschreven na een afbreking (key=%s); lock leunt op TTL",
+                        errorId, cacheKey,
+                    )
+                } else {
+                    log.fatalf(
+                        e,
+                        "[ALERT cache_doublefail] (errorId=%s) Cache-write FAIL/FAIL (key=%s, berichten=%d, geslaagd=%d, mislukt=%d): Redis onbruikbaar voor sessie, lock leunt op TTL",
+                        errorId, cacheKey, alleBerichten.size, geslaagd.get(), mislukt.get(),
+                    )
+                }
             }
             .onFailure().recoverWithNull()
             // Meld expliciet dat de eerder per-magazijn getoonde resultaten niet
@@ -862,6 +889,20 @@ internal class BerichtensessiecacheService(
         }
     }
 
+    /**
+     * Onderscheidt "het ophalen is afgebroken" van "er ging iets stuk". Een gebruiker die de
+     * pagina sluit en een pod die herstart leveren beide een annulering of een interrupt op;
+     * dat is normaal gedrag en hoort geen storingsmelding op te leveren. [classifyMagazijnFault]
+     * maakt hetzelfde onderscheid voor de per-magazijn-calls.
+     */
+    internal fun isAfbreking(error: Throwable): Boolean {
+        val chain = error.causeChain()
+
+        return chain.hasCauseOf(java.util.concurrent.CancellationException::class.java) ||
+            chain.hasCauseOf(InterruptedException::class.java) ||
+            Thread.currentThread().isInterrupted
+    }
+
     // Internal voor directe unit-test van de classificatie-tabel (zie service-test).
     internal fun classifyMagazijnFault(error: Throwable): MagazijnFault {
         // Cause-walking eenmalig via causeChain(); meerdere instanceof-checks tegen
@@ -880,6 +921,12 @@ internal class BerichtensessiecacheService(
                 when {
                     status in 500..599 -> MagazijnFault.HTTP_5XX
                     status >= 400 -> MagazijnFault.HTTP_4XX
+                    // Een 3xx die als fout terugkomt betekent dat de client de redirect niet
+                    // volgde: het magazijn staat op een ander adres dan wij kennen. Dat is een
+                    // configuratie-kwestie aan de andere kant, geen bug in onze code — vandaar
+                    // dezelfde behandeling als een 4xx (errorf + "contact beheerder"), niet de
+                    // INTERNAL_BUG-tak die als eigen storing zou alerten.
+                    status in 300..399 -> MagazijnFault.HTTP_4XX
                     // WAE zonder status = raw WAE("oeps") zonder Response → eigen-bug.
                     else -> MagazijnFault.INTERNAL_BUG
                 }

--- a/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtensessiecacheService.kt
+++ b/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtensessiecacheService.kt
@@ -117,7 +117,10 @@ internal class BerichtensessiecacheService(
         // De per-magazijn query-timeout (ifNoItem) MOET vóór de socket-read-timeout aanslaan,
         // anders krijgt de client een ruwe client-fout i.p.v. een net TIMEOUT-event; de
         // read-timeout blijft het vangnet als de query-timeout om welke reden dan ook niet vuurt.
-        require(magazijnReadTimeoutMs > magazijnQueryTimeoutSeconds * 1000) {
+        // In seconden vergelijken i.p.v. de query-timeout naar milliseconden te tillen: dat
+        // laatste loopt bij een absurde waarde over naar negatief en laat de check dan juist
+        // passeren — precies het stil uitzetten van een bescherming dat hier voorkomen wordt.
+        require(magazijnReadTimeoutMs / 1000 > magazijnQueryTimeoutSeconds) {
             "magazijn-client.read-timeout-ms ($magazijnReadTimeoutMs) moet groter zijn dan " +
                 "berichtensessiecache.magazijn-query-timeout-seconds × 1000 (${magazijnQueryTimeoutSeconds * 1000})"
         }
@@ -283,10 +286,13 @@ internal class BerichtensessiecacheService(
 
         return when (classifyLockAcquireError(ex)) {
             LockAcquireError.INTERRUPTED -> {
-                // Herstel interrupt-flag voor graceful pod-shutdown; 503 (transient), geen eigen-bug.
-                Thread.currentThread().interrupt()
+                // Flag wissen vóór de cleanup en daarna herstellen; zie de toelichting op het
+                // resolver-pad. Blijft hij staan, dan breekt de await in de cleanup meteen af en
+                // meldt het log ten onrechte dat de lock op zijn TTL leunt.
+                Thread.interrupted()
                 log.warnf(ex, "(errorId=%s) Lock-acquire onderbroken voor key=%s", errorId, cacheKey)
                 cleanupLockMetFoutStatus(cacheKey, "lock-acquire interrupted", errorId, afbreking = true)
+                Thread.currentThread().interrupt()
                 WebApplicationException("Service shutdown tijdens ophaalstart", 503)
             }
             LockAcquireError.JSON_SERIALIZATION -> {
@@ -357,22 +363,26 @@ internal class BerichtensessiecacheService(
     private fun gooiResolverFout(ex: Exception, cacheKey: String): Nothing {
         // Cause-walking via causeChain() (eenmaal materialiseren) — Mutiny wrapt
         // InterruptedException/TimeoutException, directe instanceof matched niet.
-        // isInterrupted (non-destructive) — Thread.interrupted() zou de flag wissen
-        // ook in niet-interrupt-branches.
         val chain = ex.causeChain()
-        val wasInterrupted = Thread.currentThread().isInterrupted ||
-            chain.hasCauseOf(InterruptedException::class.java)
+        // Uitsluitend de fout zelf, om dezelfde reden als in isAfbreking: de interrupt-flag is
+        // thread-sticky en zou een storing op een hergebruikte worker-thread als onderbreking
+        // laten gelden — en dat oordeel stuurt hieronder de alert-onderdrukking aan.
+        val wasInterrupted = chain.hasCauseOf(InterruptedException::class.java)
         val isOuterTimeout = chain.hasCauseOf(io.smallrye.mutiny.TimeoutException::class.java) ||
             chain.hasCauseOf(java.util.concurrent.TimeoutException::class.java)
 
         when {
             wasInterrupted -> {
-                // Interrupt-flag (her)bevestigen voor graceful pod-shutdown; 503 (transient).
-                Thread.currentThread().interrupt()
+                // Flag wissen vóór de cleanup en daarna herstellen: staat hij nog, dan gooit de
+                // await in de cleanup onmiddellijk en wordt de lock niet vrijgegeven terwijl het
+                // log meldt dat hij op de TTL leunt. Mutiny heeft de flag al gezet toen de await
+                // afbrak, dus dit herstelt hem, het zet hem niet voor het eerst.
+                Thread.interrupted()
                 val errorId = UUID.randomUUID()
 
                 log.warnf(ex, "(errorId=%s) Resolver-await onderbroken voor key=%s", errorId, cacheKey)
                 cleanupLockMetFoutStatus(cacheKey, "resolver-await interrupted", errorId, afbreking = true)
+                Thread.currentThread().interrupt()
                 throw WebApplicationException("Service shutdown tijdens ophalen", 503)
             }
             isOuterTimeout -> {
@@ -573,7 +583,7 @@ internal class BerichtensessiecacheService(
             return MagazijnResult.Failure(
                 magazijnId,
                 naam,
-                MagazijnResponseOverflow(response.berichten.size, maxBerichtenPerMagazijn),
+                MagazijnResponseOverflow(),
                 MagazijnFault.OVERFLOW,
             )
         }
@@ -668,7 +678,7 @@ internal class BerichtensessiecacheService(
         -> MagazijnFoutStatus.FOUT
     }
 
-    private fun foutmeldingVoor(fault: MagazijnFault): String = when (fault) {
+    internal fun foutmeldingVoor(fault: MagazijnFault): String = when (fault) {
         MagazijnFault.TIMEOUT -> "Magazijn reageerde niet binnen de timeout"
         MagazijnFault.MALFORMED -> "Magazijn leverde onleesbare respons (mogelijk schema-drift, contact beheerder)"
         MagazijnFault.OVERFLOW -> "Magazijn leverde te veel berichten (responsgrootte overschreden, contact beheerder)"

--- a/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtensessiecacheService.kt
+++ b/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtensessiecacheService.kt
@@ -558,13 +558,10 @@ internal class BerichtensessiecacheService(
                 "Magazijn %s (%s) overschreed berichten-cap: %d > %d",
                 magazijnId, naam, response.berichten.size, maxBerichtenPerMagazijn,
             )
-            // Geen aantallen in de exception-tekst: die belandt niet in de respons, maar de
-            // grens en de werkelijke omvang zijn interne gegevens die niet naar buiten horen
-            // te lekken langs welk pad dan ook. De counts staan hierboven al in de log.
             return MagazijnResult.Failure(
                 magazijnId,
                 naam,
-                MagazijnResponseOverflow("Magazijn leverde meer berichten dan toegestaan"),
+                MagazijnResponseOverflow(response.berichten.size, maxBerichtenPerMagazijn),
                 MagazijnFault.OVERFLOW,
             )
         }
@@ -654,8 +651,8 @@ internal class BerichtensessiecacheService(
     private fun magazijnFoutStatusVoor(fault: MagazijnFault): MagazijnFoutStatus = when (fault) {
         MagazijnFault.TIMEOUT -> MagazijnFoutStatus.TIMEOUT
         MagazijnFault.MALFORMED, MagazijnFault.OVERFLOW, MagazijnFault.HTTP_5XX,
-        MagazijnFault.HTTP_4XX, MagazijnFault.NETWORK, MagazijnFault.INTERNAL_BUG,
-        MagazijnFault.CIRCUIT_OPEN, MagazijnFault.OVERBELAST,
+        MagazijnFault.HTTP_4XX, MagazijnFault.HTTP_3XX, MagazijnFault.NETWORK,
+        MagazijnFault.INTERNAL_BUG, MagazijnFault.CIRCUIT_OPEN, MagazijnFault.OVERBELAST,
         -> MagazijnFoutStatus.FOUT
     }
 
@@ -665,6 +662,7 @@ internal class BerichtensessiecacheService(
         MagazijnFault.OVERFLOW -> "Magazijn leverde te veel berichten (responsgrootte overschreden, contact beheerder)"
         MagazijnFault.HTTP_5XX -> "Magazijn tijdelijk niet bereikbaar"
         MagazijnFault.HTTP_4XX -> "Magazijn heeft de aanvraag geweigerd (configuratiefout, contact beheerder)"
+        MagazijnFault.HTTP_3XX -> "Magazijn verwijst door naar een ander adres (configuratiefout, contact beheerder)"
         MagazijnFault.CIRCUIT_OPEN -> "Magazijn tijdelijk niet beschikbaar (herhaalde storingen)"
         MagazijnFault.OVERBELAST -> "Magazijn tijdelijk niet beschikbaar (systeem druk, probeer het later opnieuw)"
         // BIO 14.1.3: generiek bericht aan eindgebruiker; technisch onderscheid alleen in log.
@@ -735,9 +733,9 @@ internal class BerichtensessiecacheService(
         val ref = errorId.toString()
         val afgebroken = isAfbreking(error)
 
-        // Een afbreking is geen storing: de gebruiker sloot de pagina, of de pod gaat uit.
-        // Op errorf-niveau loggen zou beheer wakker maken voor normaal gedrag en echte
-        // fouten laten ondersneeuwen.
+        // Een afbreking is geen storing. De aggregatie loopt bewust door na een client-disconnect,
+        // dus de reële trigger hier is een pod die uitgaat. Op errorf-niveau loggen zou beheer
+        // wakker maken voor normaal gedrag en echte fouten laten ondersneeuwen.
         if (afgebroken) {
             log.infof(
                 "(errorId=%s) Opslaan na aggregatie afgebroken (key=%s, berichten=%d); geen storing",
@@ -764,8 +762,11 @@ internal class BerichtensessiecacheService(
             // door log-aggregator (Loki/CloudWatch) gefilterd richting alert-routing.
             // Een afbreking krijgt die marker niet: beheer oppiepen voor een gesloten
             // pagina of een herstart laat echte storingen ondersneeuwen.
+            // Bewust alleen `e`: is de eerste fout een afbreking maar de tweede een echte
+            // Redis-uitval, dan is de cache voor deze sessie wél onbruikbaar en blijft de lock
+            // op de TTL hangen — precies de conditie waarvoor de marker bestaat.
             .onFailure().invoke { e ->
-                if (afgebroken || isAfbreking(e)) {
+                if (isAfbreking(e)) {
                     log.infof(
                         "(errorId=%s) Ook de fout-status kon niet worden weggeschreven na een afbreking (key=%s); lock leunt op TTL",
                         errorId, cacheKey,
@@ -890,17 +891,21 @@ internal class BerichtensessiecacheService(
     }
 
     /**
-     * Onderscheidt "het ophalen is afgebroken" van "er ging iets stuk". Een gebruiker die de
-     * pagina sluit en een pod die herstart leveren beide een annulering of een interrupt op;
-     * dat is normaal gedrag en hoort geen storingsmelding op te leveren. [classifyMagazijnFault]
-     * maakt hetzelfde onderscheid voor de per-magazijn-calls.
+     * Onderscheidt "het ophalen is afgebroken" van "er ging iets stuk". Bij een pod-herstart
+     * midden in de aggregatie levert dat een annulering of een interrupt op; dat is normaal
+     * gedrag en hoort geen storingsmelding op te leveren. [classifyMagazijnFault] maakt
+     * hetzelfde onderscheid voor de per-magazijn-calls.
+     *
+     * Uitsluitend de meegegeven fout telt, niet de interrupt-flag van de huidige thread. Die
+     * flag is thread-sticky en wordt elders in deze klasse bewust gezet zonder hem ooit te
+     * wissen; komt zo'n worker-thread terug in de pool, dan zou een échte Redis-uitval daarna
+     * als afbreking gelden en zou de alert stilvallen.
      */
     internal fun isAfbreking(error: Throwable): Boolean {
         val chain = error.causeChain()
 
         return chain.hasCauseOf(java.util.concurrent.CancellationException::class.java) ||
-            chain.hasCauseOf(InterruptedException::class.java) ||
-            Thread.currentThread().isInterrupted
+            chain.hasCauseOf(InterruptedException::class.java)
     }
 
     // Internal voor directe unit-test van de classificatie-tabel (zie service-test).
@@ -921,12 +926,12 @@ internal class BerichtensessiecacheService(
                 when {
                     status in 500..599 -> MagazijnFault.HTTP_5XX
                     status >= 400 -> MagazijnFault.HTTP_4XX
-                    // Een 3xx die als fout terugkomt betekent dat de client de redirect niet
-                    // volgde: het magazijn staat op een ander adres dan wij kennen. Dat is een
-                    // configuratie-kwestie aan de andere kant, geen bug in onze code — vandaar
-                    // dezelfde behandeling als een 4xx (errorf + "contact beheerder"), niet de
-                    // INTERNAL_BUG-tak die als eigen storing zou alerten.
-                    status in 300..399 -> MagazijnFault.HTTP_4XX
+                    // Een 3xx die als fout terugkomt betekent dat de client de doorverwijzing
+                    // niet volgde: het magazijn staat op een ander adres dan wij kennen. Een
+                    // eigen fault i.p.v. HTTP_4XX, zodat het log de werkelijke oorzaak noemt —
+                    // een beheerder die dit ziet moet naar de magazijn-URL kijken, niet naar
+                    // een 4xx die er niet is.
+                    status in 300..399 -> MagazijnFault.HTTP_3XX
                     // WAE zonder status = raw WAE("oeps") zonder Response → eigen-bug.
                     else -> MagazijnFault.INTERNAL_BUG
                 }
@@ -956,6 +961,10 @@ internal class BerichtensessiecacheService(
                 log.warnf(error, "Magazijn %s (%s) 5xx", magazijnId, naam)
             MagazijnFault.HTTP_4XX ->
                 log.errorf(error, "Magazijn %s (%s) 4xx — configuratie/auth-fout", magazijnId, naam)
+            // Eigen tak, niet samengevoegd met 4xx: wie dit ziet moet de magazijn-URL in het
+            // register nakijken, niet naar rechten of een verkeerd pad zoeken.
+            MagazijnFault.HTTP_3XX ->
+                log.errorf(error, "Magazijn %s (%s) verwijst door — geconfigureerde URL wijst niet naar het magazijn", magazijnId, naam)
             MagazijnFault.NETWORK ->
                 log.warnf(error, "Magazijn %s (%s) niet bereikbaar (network/processing)", magazijnId, naam)
             // Bewust overgeslagen door de circuit breaker — geen echte call-fout. Het CIRCUIT_OPEN-

--- a/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtensessiecacheService.kt
+++ b/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtensessiecacheService.kt
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.core.JsonProcessingException
 import io.smallrye.mutiny.Multi
 import io.smallrye.mutiny.TimeoutException
 import io.smallrye.mutiny.Uni
+import io.quarkus.runtime.StartupEvent
 import io.smallrye.mutiny.infrastructure.Infrastructure
 import jakarta.annotation.PostConstruct
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
 import jakarta.ws.rs.ProcessingException
 import jakarta.ws.rs.WebApplicationException
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.CircuitActie
@@ -90,6 +92,16 @@ internal class BerichtensessiecacheService(
     private val circuitBreaker: MagazijnCircuitBreaker,
 ) {
     private val log = Logger.getLogger(BerichtensessiecacheService::class.java)
+
+    /**
+     * Dwingt bean-instantiatie — en daarmee [valideerTimeouts] — af bij het opstarten. Zonder deze
+     * observer maakt ArC deze bean pas aan bij het eerste request (het enige pad ernaartoe loopt
+     * via de facade), en dan komt een ongeldige timeout-combinatie pas aan het licht wanneer een
+     * gebruiker een ophaalronde start: pod gestart, readiness groen, rollout geslaagd, en daarna
+     * faalt élke ophaalronde. De ondergrenzen in `MagazijnClientFactory` vangen dat niet — die
+     * kent de query-timeout niet, en juist de verhouding read > query is hier de invariant.
+     */
+    fun onStartup(@Observes event: StartupEvent) = Unit
 
     @PostConstruct
     fun valideerTimeouts() {
@@ -274,7 +286,7 @@ internal class BerichtensessiecacheService(
                 // Herstel interrupt-flag voor graceful pod-shutdown; 503 (transient), geen eigen-bug.
                 Thread.currentThread().interrupt()
                 log.warnf(ex, "(errorId=%s) Lock-acquire onderbroken voor key=%s", errorId, cacheKey)
-                cleanupLockMetFoutStatus(cacheKey, "lock-acquire interrupted", errorId)
+                cleanupLockMetFoutStatus(cacheKey, "lock-acquire interrupted", errorId, afbreking = true)
                 WebApplicationException("Service shutdown tijdens ophaalstart", 503)
             }
             LockAcquireError.JSON_SERIALIZATION -> {
@@ -360,7 +372,7 @@ internal class BerichtensessiecacheService(
                 val errorId = UUID.randomUUID()
 
                 log.warnf(ex, "(errorId=%s) Resolver-await onderbroken voor key=%s", errorId, cacheKey)
-                cleanupLockMetFoutStatus(cacheKey, "resolver-await interrupted", errorId)
+                cleanupLockMetFoutStatus(cacheKey, "resolver-await interrupted", errorId, afbreking = true)
                 throw WebApplicationException("Service shutdown tijdens ophalen", 503)
             }
             isOuterTimeout -> {
@@ -807,6 +819,11 @@ internal class BerichtensessiecacheService(
         cacheKey: String,
         oorzaak: String,
         errorId: UUID = UUID.randomUUID(),
+        // De aanroeper weet of dit een afbrekingspad is; hier afleiden uit de opgevangen fout kan
+        // niet. Een gezette interrupt-flag laat de await hierónder onmiddellijk falen met een
+        // InterruptedException, óók wanneer de werkelijke oorzaak een echte storing was — dan zou
+        // de alert-marker juist bij een storing wegvallen.
+        afbreking: Boolean = false,
     ) {
         try {
             berichtenCache.storeAggregationStatus(
@@ -816,11 +833,10 @@ internal class BerichtensessiecacheService(
 
             log.warnf("Lock vrijgegeven na fout (errorId=%s) voor key=%s: %s", errorId, cacheKey, oorzaak)
         } catch (cleanupEx: Exception) {
-            // Een afbreking is ook hier geen storing. Dit pad wordt juist vanuit de
-            // interrupt-takken aangeroepen, en de await hieronder draait dan op een thread met
-            // gezette flag — een rolling restart tijdens een lopende ophaalstart zou anders
-            // gegarandeerd een FATAL met alert-marker per onderbroken sessie opleveren.
-            if (isAfbreking(cleanupEx)) {
+            // Een afbreking is ook hier geen storing: een rolling restart tijdens een lopende
+            // ophaalstart zou anders gegarandeerd een FATAL met alert-marker per onderbroken
+            // sessie opleveren.
+            if (afbreking) {
                 log.infof(
                     "Lock-cleanup afgebroken (errorId=%s) voor key=%s: %s — lock leunt op TTL",
                     errorId,
@@ -953,7 +969,7 @@ internal class BerichtensessiecacheService(
                     // status 400, dus via het echte magazijn-pad komt een 301 hier niet aan — die
                     // strandt eerder op het parsen van de redirect-body en wordt MALFORMED. Deze
                     // tak is de vangnet-kant van de classificatie; hem sluitend maken vraagt een
-                    // eigen ResponseExceptionMapper op MagazijnClient. TODO(#870)
+                    // eigen ResponseExceptionMapper op MagazijnClient. TODO(MinBZK/MijnOverheidZakelijk#870)
                     status in 300..399 -> MagazijnFault.HTTP_3XX
                     // WAE zonder status = raw WAE("oeps") zonder Response → eigen-bug.
                     else -> MagazijnFault.INTERNAL_BUG

--- a/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtensessiecacheService.kt
+++ b/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtensessiecacheService.kt
@@ -816,6 +816,21 @@ internal class BerichtensessiecacheService(
 
             log.warnf("Lock vrijgegeven na fout (errorId=%s) voor key=%s: %s", errorId, cacheKey, oorzaak)
         } catch (cleanupEx: Exception) {
+            // Een afbreking is ook hier geen storing. Dit pad wordt juist vanuit de
+            // interrupt-takken aangeroepen, en de await hieronder draait dan op een thread met
+            // gezette flag — een rolling restart tijdens een lopende ophaalstart zou anders
+            // gegarandeerd een FATAL met alert-marker per onderbroken sessie opleveren.
+            if (isAfbreking(cleanupEx)) {
+                log.infof(
+                    "Lock-cleanup afgebroken (errorId=%s) voor key=%s: %s — lock leunt op TTL",
+                    errorId,
+                    cacheKey,
+                    oorzaak,
+                )
+
+                return
+            }
+
             // FATAL + ALERT-marker: oorspronkelijke fout PLUS cleanup-fail = lock blijft
             // tot Redis-TTL hangen, ontvanger 60s onbedienbaar. Zelfde marker als het
             // aggregatie-pad (`[ALERT cache_doublefail]`) voor uniforme alert-routing
@@ -893,8 +908,10 @@ internal class BerichtensessiecacheService(
     /**
      * Onderscheidt "het ophalen is afgebroken" van "er ging iets stuk". Bij een pod-herstart
      * midden in de aggregatie levert dat een annulering of een interrupt op; dat is normaal
-     * gedrag en hoort geen storingsmelding op te leveren. [classifyMagazijnFault] maakt
-     * hetzelfde onderscheid voor de per-magazijn-calls.
+     * gedrag en hoort geen storingsmelding op te leveren. [classifyMagazijnFault] herkent
+     * annulering ook, maar mapt hem op `NETWORK` — dat telt daar wél als storing voor de circuit
+     * breaker. Die keuze staat los van deze: hier gaat het om het log-niveau, daar om de vraag of
+     * een magazijn tijdelijk overgeslagen moet worden.
      *
      * Uitsluitend de meegegeven fout telt, niet de interrupt-flag van de huidige thread. Die
      * flag is thread-sticky en wordt elders in deze klasse bewust gezet zonder hem ooit te
@@ -931,6 +948,12 @@ internal class BerichtensessiecacheService(
                     // eigen fault i.p.v. HTTP_4XX, zodat het log de werkelijke oorzaak noemt —
                     // een beheerder die dit ziet moet naar de magazijn-URL kijken, niet naar
                     // een 4xx die er niet is.
+                    //
+                    // LET OP: de REST-client maakt vandaag pas een WebApplicationException vanaf
+                    // status 400, dus via het echte magazijn-pad komt een 301 hier niet aan — die
+                    // strandt eerder op het parsen van de redirect-body en wordt MALFORMED. Deze
+                    // tak is de vangnet-kant van de classificatie; hem sluitend maken vraagt een
+                    // eigen ResponseExceptionMapper op MagazijnClient. TODO(#870)
                     status in 300..399 -> MagazijnFault.HTTP_3XX
                     // WAE zonder status = raw WAE("oeps") zonder Response → eigen-bug.
                     else -> MagazijnFault.INTERNAL_BUG

--- a/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnClientFactory.kt
+++ b/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnClientFactory.kt
@@ -31,6 +31,8 @@ internal class MagazijnClientFactory(
 
     @PostConstruct
     fun init() {
+        valideerTimeouts()
+
         // Het register valideert zelf fail-fast bij boot (OIN-keys, URL-geldigheid, TLS,
         // leeg register); hier resteert het bouwen van een REST-client per inschrijving.
         // magazijnId == oin.waarde — de identiteitsconventie uit het register.
@@ -40,6 +42,25 @@ internal class MagazijnClientFactory(
         cachedNamen = inschrijvingen.associate { it.oin.waarde to it.naam }
 
         log.infof("Geconfigureerde magazijnen: %s", cachedClients.keys)
+    }
+
+    /**
+     * Een timeout van 0 of lager schakelt de bescherming stil uit in plaats van hem korter te
+     * zetten: de REST-client leest 0 als "onbegrensd wachten". Een hangend magazijn houdt dan
+     * een socket en een worker-thread vast tot de andere kant iets doet. De read-timeout wordt
+     * daarnaast in [nl.rijksoverheid.moz.fbs.berichtensessiecache.berichten.BerichtensessiecacheService]
+     * tegen de query-timeout gekruisvalideerd; die check dekt de ondergrens niet.
+     */
+    internal fun valideerTimeouts() {
+        require(connectTimeoutMs > 0) {
+            "magazijn-client.connect-timeout-ms ($connectTimeoutMs) moet groter zijn dan 0; " +
+                "0 of lager betekent onbegrensd wachten op een verbinding"
+        }
+
+        require(readTimeoutMs > 0) {
+            "$READ_TIMEOUT_MS_PROPERTY ($readTimeoutMs) moet groter zijn dan 0; " +
+                "0 of lager betekent onbegrensd wachten op een respons"
+        }
     }
 
     fun getAllClients(): Map<String, MagazijnClient> = cachedClients

--- a/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnClientFactory.kt
+++ b/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnClientFactory.kt
@@ -1,8 +1,10 @@
 package nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn
 
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder
+import io.quarkus.runtime.StartupEvent
 import jakarta.annotation.PostConstruct
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
 import nl.rijksoverheid.moz.fbs.common.fsc.FscOutwayHeadersFilter
 import nl.rijksoverheid.moz.fbs.common.identificatie.Oin
 import nl.rijksoverheid.moz.fbs.magazijnregister.Magazijninschrijving
@@ -28,6 +30,15 @@ internal class MagazijnClientFactory(
     private val log = Logger.getLogger(MagazijnClientFactory::class.java)
     private lateinit var cachedClients: Map<String, MagazijnClient>
     private lateinit var cachedNamen: Map<String, String?>
+
+    /**
+     * Dwingt bean-instantiatie — en daarmee [init] met zijn validatie — af bij het opstarten.
+     * Zonder deze observer maakt ArC de bean pas aan bij het eerste gebruik, en dan komt een
+     * ongeldige timeout pas bij de eerste ophaalronde aan het licht: de pod start, readiness
+     * wordt groen, de rollout slaagt, en daarna faalt élke ophaal-request. Zelfde patroon als
+     * `ConfigMagazijnregister`.
+     */
+    fun onStartup(@Observes event: StartupEvent) = Unit
 
     @PostConstruct
     fun init() {

--- a/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnResult.kt
+++ b/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnResult.kt
@@ -16,17 +16,25 @@ internal sealed class MagazijnResult {
         }
     }
 
-    data class Failure(
+    /**
+     * Bewust géén `data class`: de classificatie wordt eenmaal in de service-laag bepaald en
+     * ligt daarna vast, zodat downstream-mapping niet opnieuw classificeert en de fout onderweg
+     * niet van betekenis verandert. Een gegenereerde `copy` zou precies dat toestaan —
+     * `copy(fault = …)` maakt van een timeout stilzwijgend een eigen bug, met bijbehorende
+     * alert-ruis. Gelijkheid is hier niet nodig: instanties worden per bevraging gemaakt en
+     * direct in een `when` verwerkt.
+     */
+    class Failure(
         override val magazijnId: String,
         override val naam: String?,
         val error: Throwable,
-        // Classificatie eenmaal bepaald in service-laag en hier vastgezet zodat
-        // downstream-mapping niet opnieuw classificeert (voorkomt drift).
         val fault: MagazijnFault,
     ) : MagazijnResult() {
         init {
             require(magazijnId.isNotBlank()) { "magazijnId mag niet leeg zijn" }
         }
+
+        override fun toString() = "Failure(magazijnId=$magazijnId, naam=$naam, fault=$fault, error=${error.javaClass.simpleName})"
     }
 }
 

--- a/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnResult.kt
+++ b/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnResult.kt
@@ -47,13 +47,18 @@ internal sealed class MagazijnResult {
  * de call is bewust overgeslagen (snelle fail i.p.v. wachten op een timeout). Geen
  * resultaat van een echte call, dus nooit door `classifyMagazijnFault` geproduceerd.
  *
+ * [HTTP_3XX]: het magazijn antwoordde met een doorverwijzing die de client niet volgde — het
+ * staat op een ander adres dan geconfigureerd. Eigen constante naast [HTTP_4XX] zodat het log de
+ * werkelijke oorzaak noemt; het circuit-breaker-gedrag is identiek (het magazijn ís bereikt, en
+ * een configuratiefout telt niet als availability-storing).
+ *
  * [OVERBELAST]: het concurrency-bulkhead ([MagazijnAggregatieBulkhead]) zat vol — er was geen
  * vrije permit, dus het magazijn is niet eens bevraagd. Geen uitspraak over de beschikbaarheid
  * van dít magazijn (de saturatie komt typisch door een ánder, traag magazijn), dus telt niet als
  * storing én niet als succes.
  */
 internal enum class MagazijnFault {
-    TIMEOUT, MALFORMED, OVERFLOW, HTTP_5XX, HTTP_4XX, NETWORK, INTERNAL_BUG, CIRCUIT_OPEN, OVERBELAST
+    TIMEOUT, MALFORMED, OVERFLOW, HTTP_5XX, HTTP_4XX, HTTP_3XX, NETWORK, INTERNAL_BUG, CIRCUIT_OPEN, OVERBELAST
 }
 
 /**
@@ -68,7 +73,8 @@ internal val MagazijnFault.teltAlsStoring: Boolean
     get() = when (this) {
         MagazijnFault.TIMEOUT, MagazijnFault.HTTP_5XX, MagazijnFault.NETWORK -> true
         MagazijnFault.MALFORMED, MagazijnFault.OVERFLOW, MagazijnFault.HTTP_4XX,
-        MagazijnFault.INTERNAL_BUG, MagazijnFault.CIRCUIT_OPEN, MagazijnFault.OVERBELAST,
+        MagazijnFault.HTTP_3XX, MagazijnFault.INTERNAL_BUG, MagazijnFault.CIRCUIT_OPEN,
+        MagazijnFault.OVERBELAST,
         -> false
     }
 
@@ -82,8 +88,8 @@ internal val MagazijnFault.magazijnBereikt: Boolean
     get() = when (this) {
         MagazijnFault.OVERBELAST, MagazijnFault.CIRCUIT_OPEN -> false
         MagazijnFault.TIMEOUT, MagazijnFault.MALFORMED, MagazijnFault.OVERFLOW,
-        MagazijnFault.HTTP_5XX, MagazijnFault.HTTP_4XX, MagazijnFault.NETWORK,
-        MagazijnFault.INTERNAL_BUG,
+        MagazijnFault.HTTP_5XX, MagazijnFault.HTTP_4XX, MagazijnFault.HTTP_3XX,
+        MagazijnFault.NETWORK, MagazijnFault.INTERNAL_BUG,
         -> true
     }
 
@@ -115,7 +121,13 @@ internal fun circuitActieVoor(result: MagazijnResult): CircuitActie = when (resu
  * `WebApplicationException`/`ProcessingException` — dit is een interne signalering,
  * geen upstream-fault, en wordt door de service in een aparte foutmelding gemapt.
  */
-internal class MagazijnResponseOverflow(message: String) : RuntimeException(message)
+internal class MagazijnResponseOverflow(val aantal: Int, val cap: Int) :
+    RuntimeException("Magazijn leverde meer berichten dan toegestaan") {
+    // Aantallen als velden, niet in de message: die tekst hoort langs geen enkel pad naar
+    // buiten te lekken, terwijl de omvang wél nodig is als een overflow onverwacht via een
+    // ander pad wordt afgehandeld dan het mappen (waar de counts al gelogd worden).
+    override fun toString() = "MagazijnResponseOverflow(aantal=$aantal, cap=$cap)"
+}
 
 /**
  * Marker-exception voor een door de circuit breaker overgeslagen magazijn-call. Draagt de

--- a/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnResult.kt
+++ b/libraries/fbs-berichtensessiecache/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnResult.kt
@@ -121,13 +121,7 @@ internal fun circuitActieVoor(result: MagazijnResult): CircuitActie = when (resu
  * `WebApplicationException`/`ProcessingException` — dit is een interne signalering,
  * geen upstream-fault, en wordt door de service in een aparte foutmelding gemapt.
  */
-internal class MagazijnResponseOverflow(val aantal: Int, val cap: Int) :
-    RuntimeException("Magazijn leverde meer berichten dan toegestaan") {
-    // Aantallen als velden, niet in de message: die tekst hoort langs geen enkel pad naar
-    // buiten te lekken, terwijl de omvang wél nodig is als een overflow onverwacht via een
-    // ander pad wordt afgehandeld dan het mappen (waar de counts al gelogd worden).
-    override fun toString() = "MagazijnResponseOverflow(aantal=$aantal, cap=$cap)"
-}
+internal class MagazijnResponseOverflow : RuntimeException("Magazijn leverde meer berichten dan toegestaan")
 
 /**
  * Marker-exception voor een door de circuit breaker overgeslagen magazijn-call. Draagt de

--- a/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtensessiecacheServiceTest.kt
+++ b/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/BerichtensessiecacheServiceTest.kt
@@ -1065,4 +1065,21 @@ class BerichtensessiecacheServiceTest {
         inhoud = "Inhoud van het bericht",
         publicatietijdstip = Instant.parse("2026-03-10T10:00:00Z"),
     )
+
+    /**
+     * Het acceptatiecriterium dat foutmeldingen geen interne tellingen of grenswaarden bevatten,
+     * is anders alleen door een refactor geborgd: zet iemand de aantallen terug in de melding,
+     * dan blijft een test die op `contains("te veel berichten")` assert gewoon groen.
+     */
+    @Test
+    fun `geen enkele eindgebruiker-melding draagt een getal`() {
+        val meldingen = MagazijnFault.entries.map { service.foutmeldingVoor(it) }
+
+        meldingen.forEach { melding ->
+            assertTrue(
+                melding.none { teken -> teken.isDigit() },
+                "melding bevat een getal en daarmee mogelijk een interne grenswaarde: $melding",
+            )
+        }
+    }
 }

--- a/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/ClassifyMagazijnFaultTest.kt
+++ b/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/ClassifyMagazijnFaultTest.kt
@@ -15,6 +15,7 @@ import nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.MagazijnFault
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.MagazijnResolver
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.MagazijnResponseOverflow
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -181,5 +182,25 @@ class ClassifyMagazijnFaultTest {
     fun `een gewone fout is geen afbreking`() {
         assertFalse(service.isAfbreking(IllegalStateException("redis stuk")))
         assertFalse(service.isAfbreking(java.net.ConnectException("refused")))
+    }
+
+    // --- de bedrading van de opstartcontrole ---
+
+    /**
+     * Zonder observer maakt ArC deze bean pas bij het eerste request aan, en dan komt een
+     * ongeldige timeout-combinatie pas aan het licht als een gebruiker een ophaalronde start.
+     * De validatie zelf is hierboven gedekt; deze test bewaakt dat hij ook echt bij het opstarten
+     * hangt — precies het gat dat een eerdere ronde in deze PR blootlegde.
+     */
+    @Test
+    fun `de timeout-controle hangt aan het opstarten`() {
+        val observer = BerichtensessiecacheService::class.java.methods.singleOrNull { methode ->
+            methode.parameterTypes.contentEquals(arrayOf(io.quarkus.runtime.StartupEvent::class.java)) &&
+                methode.parameterAnnotations.any { annotaties ->
+                    annotaties.any { it.annotationClass == jakarta.enterprise.event.Observes::class }
+                }
+        }
+
+        assertNotNull(observer, "geen @Observes StartupEvent-methode: de validatie draait dan pas bij het eerste request")
     }
 }

--- a/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/ClassifyMagazijnFaultTest.kt
+++ b/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/ClassifyMagazijnFaultTest.kt
@@ -53,7 +53,7 @@ class ClassifyMagazijnFaultTest {
 
     @Test
     fun `MagazijnResponseOverflow direct = OVERFLOW`() {
-        assertEquals(MagazijnFault.OVERFLOW, service.classifyMagazijnFault(MagazijnResponseOverflow(aantal = 300, cap = 200)))
+        assertEquals(MagazijnFault.OVERFLOW, service.classifyMagazijnFault(MagazijnResponseOverflow()))
     }
 
     @Test
@@ -189,8 +189,8 @@ class ClassifyMagazijnFaultTest {
     /**
      * Zonder observer maakt ArC deze bean pas bij het eerste request aan, en dan komt een
      * ongeldige timeout-combinatie pas aan het licht als een gebruiker een ophaalronde start.
-     * De validatie zelf is hierboven gedekt; deze test bewaakt dat hij ook echt bij het opstarten
-     * hangt — precies het gat dat een eerdere ronde in deze PR blootlegde.
+     * De validatie zelf is elders gedekt; deze test bewaakt dat hij ook echt aan het opstarten
+     * hangt en niet pas bij het eerste request draait.
      */
     @Test
     fun `de timeout-controle hangt aan het opstarten`() {

--- a/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/ClassifyMagazijnFaultTest.kt
+++ b/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/ClassifyMagazijnFaultTest.kt
@@ -15,12 +15,16 @@ import nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.MagazijnFault
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.MagazijnResolver
 import nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn.MagazijnResponseOverflow
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 /**
- * Direct-tests op `classifyMagazijnFault` — buiten de end-to-end SSE-pipeline om.
- * Pinned alle enum-takken inclusief edge-cases (WAE met null Response, status=0,
- * status=399) en cause-walking via geneste exceptions.
+ * Direct-tests op `classifyMagazijnFault` en `isAfbreking` — buiten de end-to-end
+ * SSE-pipeline om. Pinnen alle enum-takken inclusief edge-cases (WAE met null Response,
+ * status onder 300, 3xx) en cause-walking via geneste exceptions.
  */
 @QuarkusTest
 @TestProfile(MockedDependenciesProfile::class)
@@ -114,12 +118,27 @@ class ClassifyMagazijnFaultTest {
         assertEquals(MagazijnFault.INTERNAL_BUG, service.classifyMagazijnFault(wae))
     }
 
+    /**
+     * Een 3xx die als fout terugkomt betekent dat de client de doorverwijzing niet volgde: het
+     * magazijn staat op een ander adres dan geconfigureerd. Dat is een configuratiekwestie aan
+     * de andere kant, geen bug bij ons, dus dezelfde behandeling als een 4xx — niet de
+     * INTERNAL_BUG-tak, die als eigen storing zou alerten.
+     */
+    @ParameterizedTest
+    @ValueSource(ints = [300, 301, 302, 307, 308, 399])
+    fun `WebApplicationException met 3xx = HTTP_4XX (upstream-configuratie, geen eigen bug)`(status: Int) {
+        assertEquals(
+            MagazijnFault.HTTP_4XX,
+            service.classifyMagazijnFault(WebApplicationException(Response.status(status).build())),
+        )
+    }
+
     @Test
-    fun `WebApplicationException status 399 (geen 4xx, geen 5xx) = INTERNAL_BUG`() {
-        // Edge: 399 valt buiten beide HTTP-bereiken → eigen-bug.
+    fun `WebApplicationException met status onder 300 = INTERNAL_BUG`() {
+        // Een 2xx die als fout terugkomt kan geen upstream-signaal zijn; dan zit de fout bij ons.
         assertEquals(
             MagazijnFault.INTERNAL_BUG,
-            service.classifyMagazijnFault(WebApplicationException(Response.status(399).build())),
+            service.classifyMagazijnFault(WebApplicationException(Response.status(299).build())),
         )
     }
 
@@ -138,5 +157,30 @@ class ClassifyMagazijnFaultTest {
         val wae = WebApplicationException(Response.status(500).build())
         val diep = RuntimeException("outer", wae)
         assertEquals(MagazijnFault.HTTP_5XX, service.classifyMagazijnFault(diep))
+    }
+
+    // --- isAfbreking: normaal gedrag mag geen storingsmelding opleveren ---
+
+    @Test
+    fun `CancellationException is een afbreking`() {
+        assertTrue(service.isAfbreking(java.util.concurrent.CancellationException("client weg")))
+    }
+
+    @Test
+    fun `InterruptedException is een afbreking`() {
+        assertTrue(service.isAfbreking(InterruptedException("pod gaat uit")))
+    }
+
+    @Test
+    fun `een diep gewrapte annulering is een afbreking`() {
+        val diep = RuntimeException("outer", RuntimeException("middle", java.util.concurrent.CancellationException("weg")))
+
+        assertTrue(service.isAfbreking(diep))
+    }
+
+    @Test
+    fun `een gewone fout is geen afbreking`() {
+        assertFalse(service.isAfbreking(IllegalStateException("redis stuk")))
+        assertFalse(service.isAfbreking(java.net.ConnectException("refused")))
     }
 }

--- a/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/ClassifyMagazijnFaultTest.kt
+++ b/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/berichten/ClassifyMagazijnFaultTest.kt
@@ -52,7 +52,7 @@ class ClassifyMagazijnFaultTest {
 
     @Test
     fun `MagazijnResponseOverflow direct = OVERFLOW`() {
-        assertEquals(MagazijnFault.OVERFLOW, service.classifyMagazijnFault(MagazijnResponseOverflow("te veel")))
+        assertEquals(MagazijnFault.OVERFLOW, service.classifyMagazijnFault(MagazijnResponseOverflow(aantal = 300, cap = 200)))
     }
 
     @Test
@@ -120,15 +120,14 @@ class ClassifyMagazijnFaultTest {
 
     /**
      * Een 3xx die als fout terugkomt betekent dat de client de doorverwijzing niet volgde: het
-     * magazijn staat op een ander adres dan geconfigureerd. Dat is een configuratiekwestie aan
-     * de andere kant, geen bug bij ons, dus dezelfde behandeling als een 4xx — niet de
-     * INTERNAL_BUG-tak, die als eigen storing zou alerten.
+     * magazijn staat op een ander adres dan geconfigureerd. Een eigen fault, zodat het log de
+     * werkelijke oorzaak noemt in plaats van een 4xx die er niet is.
      */
     @ParameterizedTest
     @ValueSource(ints = [300, 301, 302, 307, 308, 399])
-    fun `WebApplicationException met 3xx = HTTP_4XX (upstream-configuratie, geen eigen bug)`(status: Int) {
+    fun `WebApplicationException met 3xx = HTTP_3XX (magazijn staat elders, geen eigen bug)`(status: Int) {
         assertEquals(
-            MagazijnFault.HTTP_4XX,
+            MagazijnFault.HTTP_3XX,
             service.classifyMagazijnFault(WebApplicationException(Response.status(status).build())),
         )
     }

--- a/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnCircuitBreakerTest.kt
+++ b/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnCircuitBreakerTest.kt
@@ -172,11 +172,10 @@ class MagazijnCircuitBreakerTest {
     }
 
     /**
-     * Uitputtend over de enum in plaats van een handmatige lijst: de vorige versie somde negen
-     * van de tien constanten op, dus een nieuwe fault kon er stilzwijgend bij komen met de
-     * verkeerde circuit-actie. Zou HTTP_3XX ooit als storing gaan tellen, dan opent een
-     * redirect-misconfiguratie circuits — dat hoort een bewuste wijziging te zijn, geen
-     * neveneffect.
+     * Uitputtend over de enum in plaats van een handmatige lijst: een handmatige lijst laat een
+     * nieuwe fault stilzwijgend met de verkeerde circuit-actie meeliften. Zou HTTP_3XX ooit als
+     * storing gaan tellen, dan opent een redirect-misconfiguratie circuits — dat hoort een
+     * bewuste wijziging te zijn, geen neveneffect.
      */
     @ParameterizedTest
     @EnumSource(MagazijnFault::class)

--- a/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnCircuitBreakerTest.kt
+++ b/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnCircuitBreakerTest.kt
@@ -3,6 +3,8 @@ package nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.junit.jupiter.api.Test
 
 /**
@@ -167,5 +169,30 @@ class MagazijnCircuitBreakerTest {
         org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
             MagazijnCircuitBreaker(drempel = 3, openSeconds = 0L).valideerConfig()
         }
+    }
+
+    /**
+     * Uitputtend over de enum in plaats van een handmatige lijst: de vorige versie somde negen
+     * van de tien constanten op, dus een nieuwe fault kon er stilzwijgend bij komen met de
+     * verkeerde circuit-actie. Zou HTTP_3XX ooit als storing gaan tellen, dan opent een
+     * redirect-misconfiguratie circuits — dat hoort een bewuste wijziging te zijn, geen
+     * neveneffect.
+     */
+    @ParameterizedTest
+    @EnumSource(MagazijnFault::class)
+    internal fun `elke fault heeft een expliciete circuit-actie`(fault: MagazijnFault) {
+        val verwacht = when (fault) {
+            MagazijnFault.TIMEOUT, MagazijnFault.HTTP_5XX, MagazijnFault.NETWORK -> CircuitActie.MELD_FOUT
+            MagazijnFault.CIRCUIT_OPEN, MagazijnFault.OVERBELAST -> CircuitActie.MELD_ONBESLIST
+            MagazijnFault.MALFORMED, MagazijnFault.OVERFLOW, MagazijnFault.HTTP_4XX,
+            MagazijnFault.HTTP_3XX, MagazijnFault.INTERNAL_BUG,
+            -> CircuitActie.MELD_SUCCES
+        }
+
+        assertEquals(
+            verwacht,
+            circuitActieVoor(MagazijnResult.Failure("magazijn-a", "A", RuntimeException("x"), fault)),
+            "circuit-actie voor $fault",
+        )
     }
 }

--- a/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnClientFactoryTimeoutTest.kt
+++ b/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnClientFactoryTimeoutTest.kt
@@ -1,0 +1,50 @@
+package nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn
+
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import nl.rijksoverheid.moz.fbs.magazijnregister.Magazijnregister
+
+/**
+ * Een timeout van 0 of lager zet de bescherming stil uit in plaats van hem korter te zetten:
+ * de REST-client leest 0 als "onbegrensd wachten", waarna een hangend magazijn een socket en
+ * een worker-thread vasthoudt tot de andere kant iets doet. Zo'n instelling hoort de dienst
+ * tegen te houden bij het opstarten, niet stilzwijgend een gat te maken.
+ */
+class MagazijnClientFactoryTimeoutTest {
+
+    private fun factory(connectTimeoutMs: Long = 2000, readTimeoutMs: Long = 12000) =
+        MagazijnClientFactory(mockk<Magazijnregister>(relaxed = true), connectTimeoutMs, readTimeoutMs)
+
+    @ParameterizedTest
+    @ValueSource(longs = [0, -1, -2000, Long.MIN_VALUE])
+    fun `een connect-timeout van nul of lager wordt geweigerd`(waarde: Long) {
+        val ex = assertThrows<IllegalArgumentException> { factory(connectTimeoutMs = waarde).valideerTimeouts() }
+
+        assertTrue(
+            ex.message!!.contains("connect-timeout-ms"),
+            "melding moet de property noemen die aangepast moet worden: ${ex.message}",
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = [0, -1, -12000, Long.MIN_VALUE])
+    fun `een read-timeout van nul of lager wordt geweigerd`(waarde: Long) {
+        val ex = assertThrows<IllegalArgumentException> { factory(readTimeoutMs = waarde).valideerTimeouts() }
+
+        assertTrue(
+            ex.message!!.contains("read-timeout-ms"),
+            "melding moet de property noemen die aangepast moet worden: ${ex.message}",
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = [1, 2000, Long.MAX_VALUE])
+    fun `een positieve timeout komt door`(waarde: Long) {
+        assertDoesNotThrow { factory(connectTimeoutMs = waarde, readTimeoutMs = waarde).valideerTimeouts() }
+    }
+}

--- a/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnClientFactoryTimeoutTest.kt
+++ b/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnClientFactoryTimeoutTest.kt
@@ -47,4 +47,16 @@ class MagazijnClientFactoryTimeoutTest {
     fun `een positieve timeout komt door`(waarde: Long) {
         assertDoesNotThrow { factory(connectTimeoutMs = waarde, readTimeoutMs = waarde).valideerTimeouts() }
     }
+
+    /**
+     * De tabel hierboven zegt niets over de vraag of de controle ook echt bij het opstarten
+     * draait. Zonder deze test blijft alles groen als de aanroep uit `init()` verdwijnt, en dan
+     * start de dienst alsnog met een uitgeschakelde bescherming.
+     */
+    @Test
+    fun `de controle hangt aan het opstarten van de factory`() {
+        val ex = assertThrows<IllegalArgumentException> { factory(connectTimeoutMs = 0).init() }
+
+        assertTrue(ex.message!!.contains("connect-timeout-ms"), "melding: ${ex.message}")
+    }
 }

--- a/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnClientFactoryTimeoutTest.kt
+++ b/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnClientFactoryTimeoutTest.kt
@@ -1,13 +1,13 @@
 package nl.rijksoverheid.moz.fbs.berichtensessiecache.magazijn
 
 import io.mockk.mockk
+import nl.rijksoverheid.moz.fbs.magazijnregister.Magazijnregister
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import nl.rijksoverheid.moz.fbs.magazijnregister.Magazijnregister
 
 /**
  * Een timeout van 0 of lager zet de bescherming stil uit in plaats van hem korter te zetten:

--- a/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnResultTest.kt
+++ b/libraries/fbs-berichtensessiecache/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtensessiecache/magazijn/MagazijnResultTest.kt
@@ -49,7 +49,7 @@ class MagazijnResultTest {
     }
 
     @Test
-    fun `data class equals en hashCode werken`() {
+    fun `Success vergelijkt op waarde`() {
         val a1 = MagazijnResult.Success("id", "n", listOf(bericht))
         val a2 = MagazijnResult.Success("id", "n", listOf(bericht))
         val b = MagazijnResult.Success("id", "andere", listOf(bericht))

--- a/services/berichtenuitvraag/src/main/resources/application.properties
+++ b/services/berichtenuitvraag/src/main/resources/application.properties
@@ -139,15 +139,9 @@ berichtensessiecache.magazijn-query-timeout-seconds=10
 # tunen. Alle drie moeten > 0 (MagazijnClientFactory.valideerTimeouts), en read > query
 # (BerichtensessiecacheService.valideerTimeouts). De cache-await-timeouts hierboven blijven
 # prod-only: die zijn niet omgevingsafhankelijk gebleken.
-%prod.magazijn-client.connect-timeout-ms=${MAGAZIJN_CONNECT_TIMEOUT_MS:2000}
-%prod.magazijn-client.read-timeout-ms=${MAGAZIJN_READ_TIMEOUT_MS:12000}
-%prod.berichtensessiecache.magazijn-query-timeout-seconds=${MAGAZIJN_QUERY_TIMEOUT_SECONDS:10}
-%staging.magazijn-client.connect-timeout-ms=${MAGAZIJN_CONNECT_TIMEOUT_MS:2000}
-%staging.magazijn-client.read-timeout-ms=${MAGAZIJN_READ_TIMEOUT_MS:12000}
-%staging.berichtensessiecache.magazijn-query-timeout-seconds=${MAGAZIJN_QUERY_TIMEOUT_SECONDS:10}
-%acceptatie.magazijn-client.connect-timeout-ms=${MAGAZIJN_CONNECT_TIMEOUT_MS:2000}
-%acceptatie.magazijn-client.read-timeout-ms=${MAGAZIJN_READ_TIMEOUT_MS:12000}
-%acceptatie.berichtensessiecache.magazijn-query-timeout-seconds=${MAGAZIJN_QUERY_TIMEOUT_SECONDS:10}
+%prod,staging,acceptatie.magazijn-client.connect-timeout-ms=${MAGAZIJN_CONNECT_TIMEOUT_MS:2000}
+%prod,staging,acceptatie.magazijn-client.read-timeout-ms=${MAGAZIJN_READ_TIMEOUT_MS:12000}
+%prod,staging,acceptatie.berichtensessiecache.magazijn-query-timeout-seconds=${MAGAZIJN_QUERY_TIMEOUT_SECONDS:10}
 
 # Veerkracht (#557): een concurrency-bulkhead begrenst hoeveel magazijn-aggregatie-calls TEGELIJK
 # de gedeelde default-worker-pool gebruiken, zodat een trage leverancier niet alle threads
@@ -212,8 +206,11 @@ nl.rijksoverheid.moz.fbs.common.profiel.ProfielServiceClient/getPartij/Retry/jit
 # afkappen i.p.v. de upstream-traagheid.
 profiel.resolver.inner-timeout-seconds=18
 profiel.resolver.outer-await-seconds=25
-%prod.profiel.resolver.inner-timeout-seconds=${PROFIEL_INNER_TIMEOUT:18}
-%prod.profiel.resolver.outer-await-seconds=${PROFIEL_OUTER_AWAIT:25}
+# Ook op staging en acceptatie: het zijn even goed ophaal-timeouts, en de kruisvalidatie
+# (outer > inner) draait daar net zo goed — alleen met een nieuwe build te tunen zou hetzelfde
+# probleem opleveren als bij de magazijn-timeouts hierboven.
+%prod,staging,acceptatie.profiel.resolver.inner-timeout-seconds=${PROFIEL_INNER_TIMEOUT:18}
+%prod,staging,acceptatie.profiel.resolver.outer-await-seconds=${PROFIEL_OUTER_AWAIT:25}
 
 # In-JVM Caffeine-cache (zie ProfielMagazijnResolver.magazijnSetCache). Absorbeert
 # burst-load richting Profiel-service voor dezelfde ontvanger binnen het TTL-window.

--- a/services/berichtenuitvraag/src/main/resources/application.properties
+++ b/services/berichtenuitvraag/src/main/resources/application.properties
@@ -134,8 +134,9 @@ magazijnen."00000001823288444000".naam=Magazijn B
 magazijn-client.connect-timeout-ms=2000
 magazijn-client.read-timeout-ms=12000
 berichtensessiecache.magazijn-query-timeout-seconds=10
-# Per omgeving bij te stellen, op dezelfde wijze als de profiel-timeouts hierboven — inclusief
-# staging en acceptatie, want dat zijn echte deployment-targets:
+# Per omgeving bij te stellen, inclusief staging en acceptatie: dat zijn echte
+# deployment-targets. De cache-timeouts hierboven staan bewust nog prod-only; die zijn niet
+# omgevingsafhankelijk gebleken en krijgen hun overrides wanneer daar aanleiding voor is.
 # zonder deze overrides is een magazijn-timeout alleen met een nieuwe build te tunen. Alle drie
 # moeten > 0 (MagazijnClientFactory.valideerTimeouts en BerichtensessiecacheService.valideerTimeouts).
 %prod.magazijn-client.connect-timeout-ms=${MAGAZIJN_CONNECT_TIMEOUT_MS:2000}

--- a/services/berichtenuitvraag/src/main/resources/application.properties
+++ b/services/berichtenuitvraag/src/main/resources/application.properties
@@ -135,10 +135,10 @@ magazijn-client.connect-timeout-ms=2000
 magazijn-client.read-timeout-ms=12000
 berichtensessiecache.magazijn-query-timeout-seconds=10
 # Per omgeving bij te stellen, inclusief staging en acceptatie: dat zijn echte
-# deployment-targets. De cache-timeouts hierboven staan bewust nog prod-only; die zijn niet
-# omgevingsafhankelijk gebleken en krijgen hun overrides wanneer daar aanleiding voor is.
-# zonder deze overrides is een magazijn-timeout alleen met een nieuwe build te tunen. Alle drie
-# moeten > 0 (MagazijnClientFactory.valideerTimeouts en BerichtensessiecacheService.valideerTimeouts).
+# deployment-targets, en zonder overrides is een magazijn-timeout alleen met een nieuwe build te
+# tunen. Alle drie moeten > 0 (MagazijnClientFactory.valideerTimeouts), en read > query
+# (BerichtensessiecacheService.valideerTimeouts). De cache-await-timeouts hierboven blijven
+# prod-only: die zijn niet omgevingsafhankelijk gebleken.
 %prod.magazijn-client.connect-timeout-ms=${MAGAZIJN_CONNECT_TIMEOUT_MS:2000}
 %prod.magazijn-client.read-timeout-ms=${MAGAZIJN_READ_TIMEOUT_MS:12000}
 %prod.berichtensessiecache.magazijn-query-timeout-seconds=${MAGAZIJN_QUERY_TIMEOUT_SECONDS:10}

--- a/services/berichtenuitvraag/src/main/resources/application.properties
+++ b/services/berichtenuitvraag/src/main/resources/application.properties
@@ -134,6 +134,12 @@ magazijnen."00000001823288444000".naam=Magazijn B
 magazijn-client.connect-timeout-ms=2000
 magazijn-client.read-timeout-ms=12000
 berichtensessiecache.magazijn-query-timeout-seconds=10
+# Per omgeving bij te stellen, op dezelfde wijze als de cache- en profiel-timeouts hierboven:
+# zonder deze overrides is een magazijn-timeout alleen met een nieuwe build te tunen. Alle drie
+# moeten > 0 (MagazijnClientFactory.valideerTimeouts en BerichtensessiecacheService.valideerTimeouts).
+%prod.magazijn-client.connect-timeout-ms=${MAGAZIJN_CONNECT_TIMEOUT_MS:2000}
+%prod.magazijn-client.read-timeout-ms=${MAGAZIJN_READ_TIMEOUT_MS:12000}
+%prod.berichtensessiecache.magazijn-query-timeout-seconds=${MAGAZIJN_QUERY_TIMEOUT_SECONDS:10}
 
 # Veerkracht (#557): een concurrency-bulkhead begrenst hoeveel magazijn-aggregatie-calls TEGELIJK
 # de gedeelde default-worker-pool gebruiken, zodat een trage leverancier niet alle threads

--- a/services/berichtenuitvraag/src/main/resources/application.properties
+++ b/services/berichtenuitvraag/src/main/resources/application.properties
@@ -134,12 +134,19 @@ magazijnen."00000001823288444000".naam=Magazijn B
 magazijn-client.connect-timeout-ms=2000
 magazijn-client.read-timeout-ms=12000
 berichtensessiecache.magazijn-query-timeout-seconds=10
-# Per omgeving bij te stellen, op dezelfde wijze als de cache- en profiel-timeouts hierboven:
+# Per omgeving bij te stellen, op dezelfde wijze als de profiel-timeouts hierboven — inclusief
+# staging en acceptatie, want dat zijn echte deployment-targets:
 # zonder deze overrides is een magazijn-timeout alleen met een nieuwe build te tunen. Alle drie
 # moeten > 0 (MagazijnClientFactory.valideerTimeouts en BerichtensessiecacheService.valideerTimeouts).
 %prod.magazijn-client.connect-timeout-ms=${MAGAZIJN_CONNECT_TIMEOUT_MS:2000}
 %prod.magazijn-client.read-timeout-ms=${MAGAZIJN_READ_TIMEOUT_MS:12000}
 %prod.berichtensessiecache.magazijn-query-timeout-seconds=${MAGAZIJN_QUERY_TIMEOUT_SECONDS:10}
+%staging.magazijn-client.connect-timeout-ms=${MAGAZIJN_CONNECT_TIMEOUT_MS:2000}
+%staging.magazijn-client.read-timeout-ms=${MAGAZIJN_READ_TIMEOUT_MS:12000}
+%staging.berichtensessiecache.magazijn-query-timeout-seconds=${MAGAZIJN_QUERY_TIMEOUT_SECONDS:10}
+%acceptatie.magazijn-client.connect-timeout-ms=${MAGAZIJN_CONNECT_TIMEOUT_MS:2000}
+%acceptatie.magazijn-client.read-timeout-ms=${MAGAZIJN_READ_TIMEOUT_MS:12000}
+%acceptatie.berichtensessiecache.magazijn-query-timeout-seconds=${MAGAZIJN_QUERY_TIMEOUT_SECONDS:10}
 
 # Veerkracht (#557): een concurrency-bulkhead begrenst hoeveel magazijn-aggregatie-calls TEGELIJK
 # de gedeelde default-worker-pool gebruiken, zodat een trage leverancier niet alle threads


### PR DESCRIPTION
> **Gestapeld op #186** (`feature/624-getypeerde-voortgangsberichten`). Beide raken
> `BerichtensessiecacheService`; los van elkaar vanaf `main` zouden ze conflicteren.
> De diff hieronder bevat het werk van #186 tot dat gemerged is.

## Wat er verandert

Zes van de acht restpunten uit het issue. Per acceptatiecriterium:

**Stille uitschakeling door misconfiguratie.** De connect- en read-timeout van de
magazijn-client misten een ondergrens. Voor de REST-client is 0 "onbegrensd wachten", dus een
typefout zette de bescherming niet korter maar volledig uit — waarna een hangend magazijn een
socket en een worker-thread vasthield tot de andere kant iets deed. `valideerTimeouts` weigert
dat nu bij het opstarten, zoals de overige ophaal-timeouts al deden.

**Valse storingsmeldingen.** De herstel-tak na een mislukte cache-write logde élke fout als
`errorf`, en een tweede fout als `fatalf` met de `[ALERT cache_doublefail]`-marker. Een
gebruiker die de pagina sluit of een pod die herstart levert een annulering op — normaal
gedrag dat beheer opbelde en echte alerts liet ondersneeuwen. `isAfbreking` herkent nu
annulering en interrupt (dezelfde lijn die `classifyMagazijnFault` al trok) en logt die op
info-niveau, zonder marker.

**Lekken van interne details.** De OVERFLOW-exception droeg de exacte omvang en de grenswaarde
in zijn tekst. De eindgebruiker zag die tekst niet — de melding komt uit `foutmeldingVoor` —
maar de aantallen hoorden daar langs geen enkel pad te staan; ze staan al in de log.

**Inconsistente afstembaarheid.** De drie magazijn-timeouts misten een `%prod`-override,
anders dan de cache- en profiel-timeouts; ze waren alleen met een nieuwe build te tunen.

Verder: een 3xx die als fout terugkwam werd als eigen bug geclassificeerd, terwijl het betekent
dat het magazijn op een ander adres staat dan wij kennen — upstream-configuratie, dus dezelfde
behandeling als een 4xx. En `MagazijnResult.Failure` was een `data class`, waardoor
`copy(fault = …)` de eenmaal bevroren classificatie alsnog kon herlabelen: van een timeout
stilzwijgend een eigen bug maken, met bijbehorende alert-ruis.

## Bewust niet in deze PR

**Punt 1 — lege resolver overschrijft de cache.** Dit vraagt een besluit dat niet in de code
ligt. De Profiel-service gebruikt 404 zowel voor "deze gebruiker heeft nog geen profiel" als
voor drift of een storing. Van die 404 een foutindicatie maken lost het misleidend lege beeld
op, maar geeft élke nieuwe gebruiker zonder voorkeuren voortaan een foutmelding in plaats van
een lege box. De code beschrijft de structurele oplossing al als een upstream
contract-wijziging (200 + lege voorkeuren voor "geen profiel", 404 alleen bij een echte fout),
afgestemd met het Profiel-team. Graag jullie keuze hierop; daarna is het klein werk.

Het issue vraagt ook te verifiëren of de compenserende alert uit
`docs/operations/profiel-404-alert.md` daadwerkelijk gedeployed is — dat kan ik hier niet
nagaan, dat is een ops-controle.

**Punt 7 — Duration-getypeerde timeouts.** Zou het formaat van élke
timeout-omgevingsvariabele veranderen en daarmee bestaande deployments raken. De
unit-verwarring die het adresseert wordt al bij het opstarten afgevangen door de
kruisvalidatie tussen read- en query-timeout.

## Verificatie

- `./mvnw clean test -pl services/berichtenuitvraag -am` — 318 + 213 tests groen
- `./mvnw detekt:check` — geen bevindingen
- De bestaande test die 399 als eigen bug vastpinde is aangepast; die wijziging is opzet

Closes MinBZK/MijnOverheidZakelijk#606

🤖 Generated with [Claude Code](https://claude.com/claude-code)