### PR TITLE
chore(ci): haal het overbodige werk uit de fuzz-controle

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -7,15 +7,15 @@ MODULES=(libraries/fbs-common libraries/fbs-berichtensessiecache services/berich
 # Comma-gescheiden lijst voor de Maven `-pl`-flag.
 PL=$(IFS=,; echo "${MODULES[*]}")
 
-# Bouw de modules plus upstream-dependencies (o.a. libraries/fbs-common) en
-# installeer ze in de lokale Maven-repo, zodat de vervolgstap
-# `dependency:copy-dependencies` ze kan resolven. Met `package` zou fbs-common
-# wel in target/ belanden maar niet in ~/.m2 — dan faalt copy-dependencies met
+# Bouw de modules plus upstream-dependencies (o.a. libraries/fbs-common) en installeer ze in de
+# lokale Maven-repo, zodat `dependency:copy-dependencies` ze kan resolven. Met `package` zou
+# fbs-common wel in target/ belanden maar niet in ~/.m2 — dan faalt copy-dependencies met
 # "could not find artifact nl.rijksoverheid.moz:fbs-common".
-# Alleen wat de fuzz-build nodig heeft: statische analyse, coverage-rapportage en de
-# Quarkus-augmentatie leveren geen bytecode die gefuzzd wordt en kostten samen tientallen
-# seconden per run. `-ntp` scheelt tienduizenden downloadregels in de log.
-./mvnw install -DskipTests -pl "$PL" -am -B -ntp -T 1C \
+#
+# Statische analyse, coverage-rapportage en de Quarkus-augmentatie leveren geen bytecode die
+# gefuzzd wordt; ze kostten samen tientallen seconden per run. `-ntp` scheelt tienduizenden
+# downloadregels in de log.
+./mvnw install -DskipTests -pl "$PL" -am -B -ntp \
     -Ddetekt.skip=true -Djacoco.skip=true -Dquarkus.build.skip=true
 
 mkdir -p "$OUT/lib" "$OUT/classes" "$OUT/test-classes"

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -12,15 +12,23 @@ PL=$(IFS=,; echo "${MODULES[*]}")
 # `dependency:copy-dependencies` ze kan resolven. Met `package` zou fbs-common
 # wel in target/ belanden maar niet in ~/.m2 — dan faalt copy-dependencies met
 # "could not find artifact nl.rijksoverheid.moz:fbs-common".
-./mvnw install -DskipTests -pl "$PL" -am -B
+# Alleen wat de fuzz-build nodig heeft: statische analyse, coverage-rapportage en de
+# Quarkus-augmentatie leveren geen bytecode die gefuzzd wordt en kostten samen tientallen
+# seconden per run. `-ntp` scheelt tienduizenden downloadregels in de log.
+./mvnw install -DskipTests -pl "$PL" -am -B -ntp -T 1C \
+    -Ddetekt.skip=true -Djacoco.skip=true -Dquarkus.build.skip=true
 
 mkdir -p "$OUT/lib" "$OUT/classes" "$OUT/test-classes"
 
-# Per module: dependency-jars + gecompileerde app- en test-classes verzamelen.
-# Mergen in dezelfde $OUT-mappen; de packages verschillen per module, dus geen
-# class-collisies. Trailing `/.` kopieert de inhoud i.p.v. de map zelf.
+# Dependency-jars van alle modules in één reactor-pass; vier losse aanroepen betaalden
+# elk opnieuw de Maven-opstartkosten. Alles landt in dezelfde $OUT/lib, wat ook al het
+# geval was.
+./mvnw dependency:copy-dependencies -DoutputDirectory="$OUT/lib" -pl "$PL" -B -ntp
+
+# Classes blijven per module: ze staan in aparte target-mappen. Mergen in dezelfde
+# $OUT-mappen; de packages verschillen per module, dus geen class-collisies. Trailing
+# `/.` kopieert de inhoud i.p.v. de map zelf.
 for MODULE in "${MODULES[@]}"; do
-    ./mvnw dependency:copy-dependencies -DoutputDirectory="$OUT/lib" -pl "$MODULE" -B
     cp -r "$MODULE/target/classes/." "$OUT/classes/"
     cp -r "$MODULE/target/test-classes/." "$OUT/test-classes/"
 done

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -16,11 +16,9 @@ jobs:
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: jvm
-          # De bad-build-check kopieert de volledige buildoutput (inclusief de meegebundelde
-          # JDK 21) naar tmp en start elk fuzz-doel los op — circa 161s. Direct daarna draait
-          # `run_fuzzers` diezelfde doelen tóch, dus een doel dat niet bouwt of meteen crasht
-          # valt daar alsnog om. De check is bedoeld voor de onbewaakte OSS-Fuzz-pijplijn, niet
-          # voor een poort die zelf meteen fuzzt.
+          # De bad-build-check start elk fuzz-doel apart op (~161s, inclusief het kopiëren van
+          # de meegebundelde JDK). `run_fuzzers` draait diezelfde doelen direct daarna, dus een
+          # doel dat niet bouwt of meteen crasht valt daar alsnog om.
           bad-build-check: false
       - name: Run Fuzzers
         id: run

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -16,6 +16,12 @@ jobs:
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: jvm
+          # De bad-build-check kopieert de volledige buildoutput (inclusief de meegebundelde
+          # JDK 21) naar tmp en start elk fuzz-doel los op — circa 161s. Direct daarna draait
+          # `run_fuzzers` diezelfde doelen tóch, dus een doel dat niet bouwt of meteen crasht
+          # valt daar alsnog om. De check is bedoeld voor de onbewaakte OSS-Fuzz-pijplijn, niet
+          # voor een poort die zelf meteen fuzzt.
+          bad-build-check: false
       - name: Run Fuzzers
         id: run
         uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1

--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -16,11 +16,13 @@ jobs:
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: jvm
-          # Hier blijft de bad-build-check WEL aan. De coverage- en prune-ronden draaien over
-          # het bestaande corpus en vallen niet om op een doel dat wel compileert maar bij het
-          # starten crasht; zonder deze check zou zo'n doel stilzwijgend 0% dekking rapporteren
-          # in plaats van de build rood te maken. Dit is een wekelijkse cron, dus de ~161s
-          # kosten hier niets aan wachttijd.
+          # Expliciet aan, ook al is `true` de default van de action: de PR- en batch-workflow
+          # verwijzen hierheen met "hier staat hij bewust wél aan", en dan moet wie daarop grept
+          # een sleutel vinden in plaats van proza. De coverage- en prune-ronden draaien over het
+          # bestaande corpus en vallen niet om op een doel dat wel compileert maar bij het starten
+          # crasht; zonder deze check rapporteert zo'n doel stilzwijgend 0% dekking. Wekelijkse
+          # cron, dus de ~161s kosten hier geen wachttijd.
+          bad-build-check: true
       - name: Run Fuzzers (coverage)
         id: coverage
         uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
@@ -39,11 +41,13 @@ jobs:
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: jvm
-          # Hier blijft de bad-build-check WEL aan. De coverage- en prune-ronden draaien over
-          # het bestaande corpus en vallen niet om op een doel dat wel compileert maar bij het
-          # starten crasht; zonder deze check zou zo'n doel stilzwijgend 0% dekking rapporteren
-          # in plaats van de build rood te maken. Dit is een wekelijkse cron, dus de ~161s
-          # kosten hier niets aan wachttijd.
+          # Expliciet aan, ook al is `true` de default van de action: de PR- en batch-workflow
+          # verwijzen hierheen met "hier staat hij bewust wél aan", en dan moet wie daarop grept
+          # een sleutel vinden in plaats van proza. De coverage- en prune-ronden draaien over het
+          # bestaande corpus en vallen niet om op een doel dat wel compileert maar bij het starten
+          # crasht; zonder deze check rapporteert zo'n doel stilzwijgend 0% dekking. Wekelijkse
+          # cron, dus de ~161s kosten hier geen wachttijd.
+          bad-build-check: true
       - name: Run Fuzzers (pruning)
         id: pruning
         uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1

--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -16,6 +16,12 @@ jobs:
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: jvm
+          # De bad-build-check kopieert de volledige buildoutput (inclusief de meegebundelde
+          # JDK 21) naar tmp en start elk fuzz-doel los op — circa 161s. Direct daarna draait
+          # `run_fuzzers` diezelfde doelen tóch, dus een doel dat niet bouwt of meteen crasht
+          # valt daar alsnog om. De check is bedoeld voor de onbewaakte OSS-Fuzz-pijplijn, niet
+          # voor een poort die zelf meteen fuzzt.
+          bad-build-check: false
       - name: Run Fuzzers (coverage)
         id: coverage
         uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
@@ -34,6 +40,12 @@ jobs:
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: jvm
+          # De bad-build-check kopieert de volledige buildoutput (inclusief de meegebundelde
+          # JDK 21) naar tmp en start elk fuzz-doel los op — circa 161s. Direct daarna draait
+          # `run_fuzzers` diezelfde doelen tóch, dus een doel dat niet bouwt of meteen crasht
+          # valt daar alsnog om. De check is bedoeld voor de onbewaakte OSS-Fuzz-pijplijn, niet
+          # voor een poort die zelf meteen fuzzt.
+          bad-build-check: false
       - name: Run Fuzzers (pruning)
         id: pruning
         uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1

--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -16,12 +16,11 @@ jobs:
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: jvm
-          # De bad-build-check kopieert de volledige buildoutput (inclusief de meegebundelde
-          # JDK 21) naar tmp en start elk fuzz-doel los op — circa 161s. Direct daarna draait
-          # `run_fuzzers` diezelfde doelen tóch, dus een doel dat niet bouwt of meteen crasht
-          # valt daar alsnog om. De check is bedoeld voor de onbewaakte OSS-Fuzz-pijplijn, niet
-          # voor een poort die zelf meteen fuzzt.
-          bad-build-check: false
+          # Hier blijft de bad-build-check WEL aan. De coverage- en prune-ronden draaien over
+          # het bestaande corpus en vallen niet om op een doel dat wel compileert maar bij het
+          # starten crasht; zonder deze check zou zo'n doel stilzwijgend 0% dekking rapporteren
+          # in plaats van de build rood te maken. Dit is een wekelijkse cron, dus de ~161s
+          # kosten hier niets aan wachttijd.
       - name: Run Fuzzers (coverage)
         id: coverage
         uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
@@ -40,12 +39,11 @@ jobs:
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: jvm
-          # De bad-build-check kopieert de volledige buildoutput (inclusief de meegebundelde
-          # JDK 21) naar tmp en start elk fuzz-doel los op — circa 161s. Direct daarna draait
-          # `run_fuzzers` diezelfde doelen tóch, dus een doel dat niet bouwt of meteen crasht
-          # valt daar alsnog om. De check is bedoeld voor de onbewaakte OSS-Fuzz-pijplijn, niet
-          # voor een poort die zelf meteen fuzzt.
-          bad-build-check: false
+          # Hier blijft de bad-build-check WEL aan. De coverage- en prune-ronden draaien over
+          # het bestaande corpus en vallen niet om op een doel dat wel compileert maar bij het
+          # starten crasht; zonder deze check zou zo'n doel stilzwijgend 0% dekking rapporteren
+          # in plaats van de build rood te maken. Dit is een wekelijkse cron, dus de ~161s
+          # kosten hier niets aan wachttijd.
       - name: Run Fuzzers (pruning)
         id: pruning
         uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -56,6 +56,12 @@ jobs:
           language: jvm
           github-token: ${{ secrets.GITHUB_TOKEN }}
           keep-unaffected-fuzz-targets: true
+          # De bad-build-check kopieert de volledige buildoutput (inclusief de meegebundelde
+          # JDK 21) naar tmp en start elk fuzz-doel los op — circa 161s. Direct daarna draait
+          # `run_fuzzers` diezelfde doelen tóch, dus een doel dat niet bouwt of meteen crasht
+          # valt daar alsnog om. De check is bedoeld voor de onbewaakte OSS-Fuzz-pijplijn, niet
+          # voor een poort die zelf meteen fuzzt.
+          bad-build-check: false
       - name: Run Fuzzers
         id: run
         uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -56,11 +56,9 @@ jobs:
           language: jvm
           github-token: ${{ secrets.GITHUB_TOKEN }}
           keep-unaffected-fuzz-targets: true
-          # De bad-build-check kopieert de volledige buildoutput (inclusief de meegebundelde
-          # JDK 21) naar tmp en start elk fuzz-doel los op — circa 161s. Direct daarna draait
-          # `run_fuzzers` diezelfde doelen tóch, dus een doel dat niet bouwt of meteen crasht
-          # valt daar alsnog om. De check is bedoeld voor de onbewaakte OSS-Fuzz-pijplijn, niet
-          # voor een poort die zelf meteen fuzzt.
+          # De bad-build-check start elk fuzz-doel apart op (~161s, inclusief het kopiëren van
+          # de meegebundelde JDK). `run_fuzzers` draait diezelfde doelen direct daarna, dus een
+          # doel dat niet bouwt of meteen crasht valt daar alsnog om.
           bad-build-check: false
       - name: Run Fuzzers
         id: run


### PR DESCRIPTION
## Wat er verandert

De fuzz-controle duurde 9 minuten, waarvan 1 minuut daadwerkelijk fuzzen en 5,5 minuut
voorbereiding. Twee posten daaruit zijn weggenomen.

**De bad-build-check gaat uit (~161s, de grootste post).** Die kopieert de volledige
buildoutput inclusief de meegebundelde JDK 21 naar tmp en start elk fuzz-doel los op — waarna
`run_fuzzers` diezelfde doelen direct daarna tóch draait. Een doel dat niet bouwt of meteen
crasht valt daar alsnog om. De check is bedoeld voor de onbewaakte OSS-Fuzz-pijplijn, niet
voor een poort die zelf meteen fuzzt. Uit op de PR- en batch-workflow; op de wekelijkse cron
blijft hij bewust aan, want die ronden draaien over het bestaande corpus en vallen níét om op
een doel dat wel compileert maar bij het starten crasht — zonder de check rapporteert zo'n doel
daar stilzwijgend 0% dekking. Een cron kost geen wachttijd.

**Werk uit de fuzz-build dat geen fuzzbare bytecode oplevert (~30-50s).** detekt draaide 6×,
jacoco report + check 5×, de Quarkus-augmentatie 2×. Alle drie uitgezet, en lokaal
geverifieerd dát de skip-properties aanslaan:

```
[INFO] --- detekt:1.23.8:check (default) @ fbs-common ---
[INFO] Skipping execution
[INFO] --- jacoco:0.8.15:check (check) @ fbs-common ---
[INFO] Skipping JaCoCo execution because property jacoco.skip is set.
[INFO] --- quarkus:3.38.1:build (default) @ berichtenmagazijn ---
[INFO] Skipping Quarkus build
```

De vier losse `dependency:copy-dependencies`-aanroepen zijn één reactor-pass geworden; ze
schreven al naar dezelfde map, dus alleen de viervoudige Maven-opstartkosten verdwijnen. Het
kopiëren van classes blijft per module, want die staan in aparte target-mappen. `-ntp` haalt
tienduizenden downloadregels uit de log.

De dekking blijft gelijk: dezelfde modules, dezelfde doelen, dezelfde zoekduur van 60s.

## De meting

Step-timings van de job `checks-fuzz / PR`. Beide nulmetingen zijn PR's die net als deze geen
Kotlin-bronnen raken (pom/dependabot), dus de vergelijking is gelijkwaardig.

| Run | Build Fuzzers | Run Fuzzers | Job totaal |
|---|---|---|---|
| `30359751121` (28-07, nulmeting) | 339s | 135s | 516s |
| `31470272556` (11-08, dependabot, vóór deze wijziging) | 338s | 134s | 512s |
| `31636965147` (`c0857a6`) | 163s | 131s | 352s |
| `31641648789` (`1ab5305`) | 165s | 130s | 344s |
| `31648223292` (`464c380`) | 189s | 131s | 376s |

*Build Fuzzers* zakt van 339s naar 163-189s: −44% tot −52%, mediaan 165s (−51%). Het
acceptatiecriterium "minimaal gehalveerd" wordt op die stap in twee van de drie runs gehaald;
de spreiding van ~25s is runner-ruis, dus dit is een randgeval en geen ruime marge.

De hele job zakt van ~514s naar 344-376s (−30%). Die is niet gehalveerd en kan dat ook niet:
de image-pull (37-54s) plus *Run Fuzzers* (130s, waarvan 60s daadwerkelijk fuzzen) vormen een
vaste vloer van ruim drie minuten waar dit werk niet aan raakt.

De runs zitten niet onder de workflow *ClusterFuzzLite PR fuzzing* maar als job in de
bijbehorende **Deploy ZAD**-run, omdat `cflite_pr.yml` een `workflow_call` is.

## Het vangnet blijft werken

Aangetoond met opzettelijk kapotte fuzz-doelen op de wegwerp-branch van #193, vertakt van deze
branch dus mét `bad-build-check: false`:

| Kapot doel | Run | Uitkomst |
|---|---|---|
| Crasht op de eerste input | [`31676830350`](https://github.com/MinBZK/moza-poc-fbs-berichtenbox/actions/runs/31676830350) | *Run Fuzzers* rood na 26s |
| Crasht in `fuzzerInitialize`, vóór de eerste input | [`31677176613`](https://github.com/MinBZK/moza-poc-fbs-berichtenbox/actions/runs/31677176613) | *Run Fuzzers* rood na 45s |

Beide vallen om de juiste reden: Jazzer rapporteert een bug, reproduceert hem en slaat de crash
op. Het tweede geval is het geval waarvoor de check bestond — `run_fuzzers` blijkt ook een
crash vóór de eerste input als bug te rapporteren. Een doel dat helemaal niet compileert faalt
al eerder, in de `./mvnw install` van `build.sh`.

## Scope

Dit is een deeloplossing, geen afronding van
[#869](https://github.com/MinBZK/MijnOverheidZakelijk/issues/869): de controle wordt flink
sneller, maar de vaste vloer (image-pull plus de fuzz-tijd zelf) blijft staan en het eigen
base-image met warme Maven-repo is bewust niet gedaan. Die vervolgstappen staan als comment
onder het issue, dat dus open blijft. Zo blijft deze PR beperkt tot wat er gemeten en
onderbouwd in zit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
