### PR TITLE
fix(demo): profiel-stub geeft nog het oude OIN van magazijn A terug

### DIFF
--- a/bruno/berichtenuitvraag/environments/zad-fsc.bru
+++ b/bruno/berichtenuitvraag/environments/zad-fsc.bru
@@ -1,0 +1,11 @@
+vars {
+  baseUrlUitvraag: https://uitvraag-pr-146-mpfb-8wh.rig.prd1.gn2.quattro.rijksapps.nl/api/v1
+  baseUrlMagazijn: http://localhost:8090/api/v1
+  ontvangerHeaderPersoon: BSN:999993653
+  ontvangerHeaderKvk: KVK:12345678
+  berichtId: 86d77423-4823-4b37-a3d1-e30afa69b387
+  bijlageId: fced9895-3168-4346-ba38-fdaafe0278e2
+  magazijnId: 00000000000000100000
+  traceId: 4bf92f3577b34da6a3ce929d0e0e4736
+  parentSpanId: 00f067aa0ba902b7
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -30,7 +30,7 @@ services:
   # MOZA Profiel Service stub voor berichtenmagazijn — simuleert het ophalen van
   # een partij (BSN/KVK/RSIN) inclusief OntvangViaBerichtenbox-voorkeur en scope
   # naar een afzender-OIN. Default mapping geeft een actieve voorkeur voor het
-  # test-OIN 00000001003214345000; voor 403-rookproef is er een mapping op BSN
+  # test-OIN 00000000000000100000 (magazijn A); voor 403-rookproef is er een mapping op BSN
   # 111222333 die een partij zonder voorkeuren teruggeeft.
   profiel-service:
     image: wiremock/wiremock:3.13.2

--- a/wiremock/externe-stubs/mappings/get-partij-actieve-voorkeur.json
+++ b/wiremock/externe-stubs/mappings/get-partij-actieve-voorkeur.json
@@ -21,7 +21,7 @@
             {
               "partij": {
                 "identificatieType": "OIN",
-                "identificatieNummer": "00000001003214345000"
+                "identificatieNummer": "00000000000000100000"
               }
             }
           ]


### PR DESCRIPTION
## Samenvatting

Magazijn A heeft sinds de peer-migratie een nieuw OIN (`00000000000000100000`), maar de generieke profiel-stub gaf voor elke onbekende BSN/KVK/RSIN nog een voorkeur terug richting het oude OIN. Hierdoor matcht deze default-voorkeur in demo-/FSC-scenario's niet meer met een geregistreerd magazijn.

## Technische context

De `magazijn-a-peer-migratie` (`docs/plans/2026-07-31-magazijn-a-peer-migratie-plan.md`) scopede de OIN-wissel bewust smal tot vier config-bestanden (`application.properties` × 2, `zad.bru` × 2) en behandelde overige voorkomens van het oude OIN als losstaande, opzettelijk ongewijzigde testfixtures. `wiremock/externe-stubs/mappings/get-partij-actieve-voorkeur.json` viel buiten die scope, maar is geen testfixture: dit bestand wordt als het `profiel`-component gedeployd op ZAD (project `mpfpsm-lcl`) én lokaal via `docker compose` (poort 8089) — het draait dus daadwerkelijk mee in de FSC-demo-flows.

**Wijzigingen:**
- `wiremock/externe-stubs/mappings/get-partij-actieve-voorkeur.json`: `identificatieNummer` bijgewerkt naar het nieuwe OIN.
- `compose.yaml`: bijbehorend commentaar bij de `profiel-service` bijgewerkt.
- `bruno/berichtenuitvraag/environments/zad-fsc.bru`: `magazijnId` bijgewerkt (nog niet gecommit bestand, zelfde stale waarde als hierboven).

De persona-specifieke stubs (`wiremock/demo-profiel/*`) en de echte magazijn-config waren al correct.

## Test plan

- [x] `python3 -c "import json; json.load(open('wiremock/externe-stubs/mappings/get-partij-actieve-voorkeur.json'))"` — geldige JSON
- [ ] Lokaal `docker compose up -d` en handmatig een BSN zonder persona-mapping opvragen bij `profiel-service` — voorkeur wijst nu naar `00000000000000100000`