### PR TITLE
Contract uitvraag↔magazijnen, idempotent zonder state-file (#782)

### DIFF
--- a/.github/scripts/merge-guard.sh
+++ b/.github/scripts/merge-guard.sh
@@ -46,6 +46,10 @@ fi
 # even gevaarlijk, en de volgende die er een toevoegt verzint gegarandeerd een andere naam.
 LEK=':[0-9]{2,5}$'
 LEK="(^|[= ])(0\\.0\\.0\\.0|\\[::\\]|\\*)?${LEK}"
+# Een bind-adres ZONDER poort ontsnapt aan LEK: `QUARKUS_HTTP_HOST=0.0.0.0` draagt geen `:poort`.
+# Vandaar een tweede patroon op de kale wildcard-waarde. Ook dit staat op de waarde en niet op de
+# naam, zodat een volgende service die zijn bind-adres anders noemt er evengoed onder valt.
+KAAL_LEK='(^|[= ])(0\.0\.0\.0|\[?::\]?|\*)$' 
 
 fail=0
 meld() {
@@ -77,13 +81,42 @@ env_lek=$(jq -r '.services | to_entries[] | . as $s
 
 # Naam-onafhankelijk: elke env-waarde en elk `command`/`entrypoint`-token dat eruitziet als een
 # niet-loopback bind.
-bind_lek=$(jq -r --arg re "$LEK" '.services | to_entries[] | . as $s
+bind_lek=$(jq -r --arg re "$LEK" --arg kaal "$KAAL_LEK" '.services | to_entries[] | . as $s
   | ( ($s.value.environment // {}) | to_entries[]
         | select(.value != null) | "\(.key)=\(.value)" ),
     ( (($s.value.command // []) + ($s.value.entrypoint // []))[]?
         | select(type == "string") )
-  | select(test($re))
+  | select(test($re) or test($kaal))
   | "\($s.key): \(.)"' <<<"$MERGED")
+
+# De checks hierboven toetsen een bind-adres dát er staat. Een ONTBREKENDE bind-directive ontsnapt
+# daaraan: valt `command:` weg uit de overlay, dan erft de service de image-default (`0.0.0.0`) en
+# is er niets meer om op te matchen. Per image-familie dus eisen dát de directive er is én dat hij
+# op loopback staat — dezelfde vorm als de postgres-controle hieronder, die dit al deed.
+#
+# Alleen families die in deze repo voorkomen; een service zonder van deze images valt terug op de
+# waarde-checks hierboven.
+bind_mist=$(jq -r '.services | to_entries[] | . as $s
+  | ($s.value.image // "") as $img
+  | ((($s.value.command // []) + ($s.value.entrypoint // [])) | map(select(type == "string")) | join(" ")) as $cmd
+  | ($s.value.environment // {}) as $env
+  | if ($img | test("redis")) then
+      (if ($cmd | test("--bind +127\\.")) then empty
+       else "\($s.key): redis zonder `--bind 127.x` (image-default is elke interface)" end)
+    elif ($img | test("wiremock")) then
+      (if ($cmd | test("--bind-address +127\\.")) then empty
+       else "\($s.key): wiremock zonder `--bind-address 127.x` (image-default is elke interface)" end)
+    elif ($img | test("toxiproxy")) then
+      (if ($cmd | test("-host=127\\.")) then empty
+       else "\($s.key): toxiproxy zonder `-host=127.x` (image-default is elke interface)" end)
+    elif ($img | test("(^|/)fbs-")) then
+      # Op de image-familie en niet op `has("QUARKUS_HTTP_HOST")`: die gate maakte de tak leeg voor
+      # precies het geval waarvoor hij bestaat — een ONTBREKENDE variabele viel dan door naar
+      # `else empty`. Onze eigen services bakken `quarkus.http.host=0.0.0.0` in hun
+      # application.properties, dus afwezigheid betekent hier een wildcard-bind.
+      (if (($env.QUARKUS_HTTP_HOST // "") | tostring | test("^127\\.")) then empty
+       else "\($s.key): QUARKUS_HTTP_HOST=\($env.QUARKUS_HTTP_HOST // "<niet gezet>") staat niet op 127.x" end)
+    else empty end' <<<"$MERGED")
 
 # De overlay hoort elke `ports:` uit de basis te resetten; een gepubliceerde poort in een gedeelde
 # netns is betekenisloos en verraadt een vergeten `!reset`.
@@ -108,8 +141,11 @@ pg_lek=$(jq -r '.services | to_entries[] | . as $s
 # --postgres. Die vlag stuurt alleen of postgres AANWEZIG moet zijn. Hing de eis aan de vlag, dan
 # zou een gast die zijn postgres uit het inactieve profiel haalt het image-default
 # `listen_addresses='*'` krijgen: de DB met harness-credentials op elke interface, en de guard groen.
+# Elke postgres in de merge, niet alleen een service die letterlijk `postgres` heet: de demo-stack
+# draait er drie (postgres-a, postgres-b, postgres-uitvraag). Op de naam én op de image matchen,
+# zodat een hernoemde service niet stil buiten de controle valt.
 pg_mist=$(jq -r '.services | to_entries[]
-  | select(.key == "postgres")
+  | select((.key | test("postgres")) or ((.value.image // "") | test("postgres")))
   | select(((.value.command // []) | map(select(test("listen_addresses="))) | length) == 0)
   | .key' <<<"$MERGED")
 
@@ -151,6 +187,7 @@ meld "bind-adres dat niet op loopback staat:" "$bind_lek"
 meld "nog een gepubliceerde poort in de merge (mist een 'ports: !reset []'):" "$poorten"
 meld "onbegrensde herstartlus (zet een maximum in de overlay):" "$ongelimiteerd"
 meld "postgres luistert niet uitsluitend op loopback (127.x):" "$pg_lek"
+meld "bind-directive ontbreekt of staat niet op loopback:" "$bind_mist"
 meld "postgres zonder expliciete listen_addresses (het image kiest dan '*'):" "$pg_mist"
 meld "bind-regel in de gemounte haproxy-config die niet op loopback (127.x) staat:" "$haproxy_lek"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -251,6 +251,11 @@ jobs:
           #
           # deploy.yml zelf, .github/actions/ en de zad-actions staan er bewust NIET bij: die
           # bepalen de uitrol, dus juist daar is een preview het bewijs dat de wijziging klopt.
+          #
+          # Het contract-bootstrap-image komt óók uit demo/, maar wordt alleen op push naar main
+          # uitgerold; op een PR bouwt en draait `fsc-harness-overlays.yml` hem. Een uitzondering
+          # hier zou dus de hele deploy-keten (twee jib-images, de stubs en drie previews)
+          # openzetten voor een wijziging die daar niets mee te maken heeft.
           niet_deploybaar='(^docs/|\.md$|^bruno/|^demo/|^services/demo-console/|^\.clusterfuzzlite/|^\.github/workflows/(test|detekt|codeql|scorecard|architecture|pin-consistency|cflite_pr|cflite_batch|cflite_cron|fsc-harness-overlays|fuzz-base-image)\.yml$)'
 
           if [ "${BOT_PR:-false}" = "true" ]; then
@@ -408,6 +413,36 @@ jobs:
           echo "$GHCR_TOKEN" | docker login "$REGISTRY" -u "$GHCR_USER" --password-stdin
           IMG="$REGISTRY/$OWNER/fbs-externe-stubs:$TAG"
           docker build -t "$IMG" wiremock/externe-stubs
+          docker push "$IMG"
+
+  # De contract-bootstrap draait op ZAD als component náást de manager van zijn eigen peer: de
+  # interne manager-API heeft daar geen route en de tenant-baseline-NetworkPolicy laat alleen
+  # verkeer binnen hetzelfde deployment toe. Eén image, twee rollen — welke, leest het entrypoint
+  # uit FSC_ROL in de component-env.
+  build-contract-bootstrap:
+    if: github.event_name == 'push' || (github.event.action != 'closed' && needs.changes.outputs.run == 'true')
+    needs: [meta, changes]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: build-contract-bootstrap-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Build + push contract-bootstrap
+        env:
+          OWNER: ${{ needs.meta.outputs.owner }}
+          TAG: ${{ needs.meta.outputs.tag }}
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "$GHCR_TOKEN" | docker login "$REGISTRY" -u "$GHCR_USER" --password-stdin
+          IMG="$REGISTRY/$OWNER/fbs-fsc-contract-bootstrap:$TAG"
+          # Context is demo/environment/ en niet de contracts-map: de scripts leunen op ../../lib.
+          docker build -f demo/environment/federatie/contracts/Dockerfile -t "$IMG" demo/environment
           docker push "$IMG"
 
   # De vier toetsende workflows draaien als aangeroepen (`workflow_call`) job ín deze workflow,
@@ -762,9 +797,9 @@ jobs:
           # Expliciete lijst, bewust niet afgeleid uit alle org-packages: de prefix `pr-<n>-`
           # is niet uniek binnen de organisatie, dus een brede sweep zou images van een
           # gelijkgenummerde PR in een andere repo kunnen wissen. Houd deze lijst in sync met
-          # de `build`-matrix en `build-externe-stubs`; een vergeten package laat weesversies
-          # achter.
-          for pkg in fbs-berichtenuitvraag fbs-berichtenmagazijn fbs-externe-stubs; do
+          # de `build`-matrix, `build-externe-stubs` en `build-contract-bootstrap`; een vergeten
+          # package laat weesversies achter.
+          for pkg in fbs-berichtenuitvraag fbs-berichtenmagazijn fbs-externe-stubs fbs-fsc-contract-bootstrap; do
             if ! versions=$(gh api --paginate "orgs/$ORG/packages/container/$pkg/versions?per_page=100"); then
               echo "::warning::Kon de versies van $pkg niet ophalen — images van deze PR blijven mogelijk staan."
               fail=1
@@ -808,10 +843,11 @@ jobs:
       && needs.meta.result == 'success'
       && needs.build.result == 'success'
       && needs.build-externe-stubs.result == 'success'
+      && needs.build-contract-bootstrap.result == 'success'
       && needs.gate.result == 'success'
       && github.event_name == 'push'
       && github.ref == 'refs/heads/main'
-    needs: [meta, build, build-externe-stubs, gate]
+    needs: [meta, build, build-externe-stubs, build-contract-bootstrap, gate]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # Eén ZAD-taak tegelijk op de `test`-deployment van dit project; twee snel opeenvolgende merges
@@ -855,7 +891,8 @@ jobs:
               {"name": "logius-fscctl", "image": "ghcr.io/minbzk/moza-fsc-testnet-controller-migrate:v2.5.2"},
               {"name": "logius-fscoutway", "image": "docker.io/federatedserviceconnectivity/outway:v2.5.2"},
               {"name": "logius-fscinway", "image": "docker.io/federatedserviceconnectivity/inway:v2.5.2"},
-              {"name": "logius-fsctxlog", "image": "ghcr.io/minbzk/moza-fsc-testnet-txlog-migrate:v2.5.2"}
+              {"name": "logius-fsctxlog", "image": "ghcr.io/minbzk/moza-fsc-testnet-txlog-migrate:v2.5.2"},
+              {"name": "logius-fscbootstrap", "image": "${{ env.REGISTRY }}/${{ needs.meta.outputs.owner }}/fbs-fsc-contract-bootstrap:${{ needs.meta.outputs.tag }}"}
             ]
 
   deploy-test-externe-stubs:
@@ -898,10 +935,11 @@ jobs:
       && needs.meta.result == 'success'
       && needs.build.result == 'success'
       && needs.build-externe-stubs.result == 'success'
+      && needs.build-contract-bootstrap.result == 'success'
       && needs.gate.result == 'success'
       && github.event_name == 'push'
       && github.ref == 'refs/heads/main'
-    needs: [meta, build, build-externe-stubs, gate]
+    needs: [meta, build, build-externe-stubs, build-contract-bootstrap, gate]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # Dekt ook de tweede stap (deployment `fsc-magazijna`) — die hoort bij hetzelfde project.
@@ -941,5 +979,6 @@ jobs:
               {"name": "magazijna-fscmgr", "image": "ghcr.io/minbzk/moza-fsc-testnet-manager-migrate:v2.5.2"},
               {"name": "magazijna-fscctl", "image": "ghcr.io/minbzk/moza-fsc-testnet-controller-migrate:v2.5.2"},
               {"name": "magazijna-fscinway", "image": "docker.io/federatedserviceconnectivity/inway:v2.5.2"},
-              {"name": "magazijna-fsctxlog", "image": "ghcr.io/minbzk/moza-fsc-testnet-txlog-migrate:v2.5.2"}
+              {"name": "magazijna-fsctxlog", "image": "ghcr.io/minbzk/moza-fsc-testnet-txlog-migrate:v2.5.2"},
+              {"name": "magazijna-fscbootstrap", "image": "${{ env.REGISTRY }}/${{ needs.meta.outputs.owner }}/fbs-fsc-contract-bootstrap:${{ needs.meta.outputs.tag }}"}
             ]

--- a/.github/workflows/fsc-harness-overlays.yml
+++ b/.github/workflows/fsc-harness-overlays.yml
@@ -275,6 +275,7 @@ jobs:
           if ! shellcheck -x -S warning \
                  demo/environment/lib/*.sh \
                  demo/environment/federatie/*.sh \
+                 demo/environment/federatie/contracts/*.sh \
                  demo/environment/*/deploy/local/*.sh \
                  demo/environment/*/pki/*.sh \
                  .github/scripts/*.sh; then

--- a/.github/workflows/fsc-harness-overlays.yml
+++ b/.github/workflows/fsc-harness-overlays.yml
@@ -28,10 +28,10 @@ on:
     types: [opened, synchronize, reopened]
     # De workflow staat in zijn eigen pad-filter: anders komt een verzwakking van de guard binnen
     # zonder dat de guard zelf ooit gedraaid heeft.
-    paths: ['demo/environment/**', '.github/workflows/fsc-harness-overlays.yml', '.github/scripts/merge-guard.sh']
+    paths: ['demo/environment/**', 'compose.yaml', 'compose.podman*.yaml', 'demo/*.sh', 'demo/genereer-magazijnen.py', 'toxiproxy/proxies.json', '.github/workflows/fsc-harness-overlays.yml', '.github/scripts/merge-guard.sh']
   push:
     branches: [main]
-    paths: ['demo/environment/**', '.github/workflows/fsc-harness-overlays.yml', '.github/scripts/merge-guard.sh']
+    paths: ['demo/environment/**', 'compose.yaml', 'compose.podman*.yaml', 'demo/*.sh', 'demo/genereer-magazijnen.py', 'toxiproxy/proxies.json', '.github/workflows/fsc-harness-overlays.yml', '.github/scripts/merge-guard.sh']
 
 # LET OP: `pull_request`, niet `pull_request_target`, en read-only zonder secrets. Beide jobs
 # `source`n demo/environment/federatie/peers.env respectievelijk renderen compose-bestanden uit de
@@ -251,6 +251,30 @@ jobs:
 
           exit "$fail"
 
+  # De demo-stack uit compose.yaml draait in dezelfde netns-modus als de harnessen, en dus onder
+  # dezelfde eis: geen enkele listener buiten loopback. Zonder deze job stond die stack op élke
+  # interface van de machine — Redis zonder wachtwoord en twee PostgreSQL-instanties met
+  # demo-credentials — en botste een wildcard-bind bovendien met elke specifieke bind van een
+  # federatie in dezelfde netns.
+  demo-stack-op-loopback:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Elke demo-service op de gedeelde netns, elke listener op loopback
+        run: |
+          set -euo pipefail
+
+          # `--profile demo` erbij: zonder dat profiel rendert compose de vier Quarkus-services en
+          # toxiproxy niet, en meet deze job precies de helft van de stack.
+          DEMO_HOST=localhost DEMO_MAGAZIJN_STUBS=2 docker compose --profile demo \
+            -f compose.yaml \
+            -f compose.podman.yaml \
+            -f compose.podman-hostnet.yaml config --format json \
+            | "$GITHUB_WORKSPACE/.github/scripts/merge-guard.sh" "demo-stack (hostnet-merge)"
+
   harness-scripts:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -278,6 +302,7 @@ jobs:
                  demo/environment/federatie/contracts/*.sh \
                  demo/environment/*/deploy/local/*.sh \
                  demo/environment/*/pki/*.sh \
+                 demo/*.sh \
                  .github/scripts/*.sh; then
             fail=1
           fi

--- a/.github/workflows/fsc-harness-overlays.yml
+++ b/.github/workflows/fsc-harness-overlays.yml
@@ -35,8 +35,9 @@ on:
 
 # LET OP: `pull_request`, niet `pull_request_target`, en read-only zonder secrets. Beide jobs
 # `source`n demo/environment/federatie/peers.env respectievelijk renderen compose-bestanden uit de
-# PR — dat is PR-gestuurde uitvoering. Dat is alleen aanvaardbaar zolang deze workflow geen
-# schrijfrechten, geen secrets en geen cache heeft. Wijzig geen van drieën.
+# PR — dat is PR-gestuurde uitvoering, net als de bash-unittests en de docker build/run in
+# `harness-scripts`. Dat is alleen aanvaardbaar zolang deze workflow geen schrijfrechten, geen
+# secrets en geen cache heeft. Wijzig geen van drieën.
 permissions:
   contents: read
 
@@ -326,3 +327,47 @@ jobs:
           fi
 
           exit "$fail"
+
+      - name: Contract-bootstrap-image bouwt en draait onder een willekeurige UID
+        # Het image draait op ZAD als component; zonder deze stap blijkt een verkeerd COPY-pad, een
+        # ontbrekend pakket of een rechtenprobleem pas daar. OpenShift start containers onder een
+        # willekeurige UID in groep 0 — dat is de aanname waar de hele opstelling op rust, dus die
+        # wordt hier expliciet uitgeoefend en niet alleen in de Dockerfile opgeschreven.
+        run: |
+          set -euo pipefail
+
+          docker build -f demo/environment/federatie/contracts/Dockerfile \
+            -t fbs-fsc-contract-bootstrap:ci demo/environment
+
+          echo "== gereedschap en leesbaarheid onder UID 12345, groep 0 =="
+          docker run --rm -u 12345:0 --entrypoint sh fbs-fsc-contract-bootstrap:ci -c '
+            set -eu
+            command -v bash curl jq openssl >/dev/null
+            test -r /opt/fsc/lib/fsc-contract.sh
+            test -r /opt/fsc/lib/fsc-harness.sh
+            test -x /opt/fsc/contracts/zad-lus.sh
+            test -x /opt/fsc/contracts/bootstrap-consumer.sh
+            test -x /opt/fsc/contracts/bootstrap-provider.sh'
+
+          # De twee scripts die met béíde managers praten horen niet in het image: op ZAD kan dat
+          # niet en een operator die ze daar aantreft, gaat ze gebruiken.
+          echo "== bootstrap.sh en fbs-contracten.sh zitten er NIET in =="
+          docker run --rm -u 12345:0 --entrypoint sh fbs-fsc-contract-bootstrap:ci -c '
+            ! test -e /opt/fsc/contracts/bootstrap.sh && ! test -e /opt/fsc/contracts/fbs-contracten.sh'
+
+          # Exit 2 = "configuratie deugt niet". Daar stopt de lus op, en dat maakt er een zichtbare
+          # crashloop van in plaats van een pod die draait en niets doet.
+          echo "== configuratiefouten eindigen op 2 =="
+          for geval in "" "FSC_ROL=onzin"; do
+            rc=0
+            if [ -n "$geval" ]; then
+              docker run --rm -u 12345:0 -e "$geval" fbs-fsc-contract-bootstrap:ci || rc=$?
+            else
+              docker run --rm -u 12345:0 fbs-fsc-contract-bootstrap:ci || rc=$?
+            fi
+
+            if [ "$rc" -ne 2 ]; then
+              echo "::error::verwachtte exit 2 voor '${geval:-<geen env>}', kreeg ${rc}"
+              exit 1
+            fi
+          done

--- a/compose.podman-hostnet.yaml
+++ b/compose.podman-hostnet.yaml
@@ -28,36 +28,40 @@ services:
     network_mode: host
     ports: !reset []
     healthcheck: !reset null
+    # redis-stack-server start zonder bind op alle interfaces; in een gedeelde netns is dat de hele
+    # machine, en deze Redis heeft geen wachtwoord.
+    command: ["redis-stack-server", "--bind", "127.0.0.1"]
 
   magazijn-a:
     network_mode: host
     ports: !reset []
-    command: ["--port", "8081", "--verbose", "--global-response-templating"]
+    command: ["--bind-address", "127.0.0.1", "--port", "8081", "--verbose", "--global-response-templating"]
 
   magazijn-b:
     network_mode: host
     ports: !reset []
-    command: ["--port", "8082", "--verbose", "--global-response-templating"]
+    command: ["--bind-address", "127.0.0.1", "--port", "8082", "--verbose", "--global-response-templating"]
 
   profiel-service:
     network_mode: host
     ports: !reset []
-    command: ["--port", "8089", "--verbose"]
+    command: ["--bind-address", "127.0.0.1", "--port", "8089", "--verbose"]
 
   aanmeld-stub:
     network_mode: host
     ports: !reset []
-    command: ["--port", "8083", "--verbose", "--global-response-templating"]
+    command: ["--bind-address", "127.0.0.1", "--port", "8083", "--verbose", "--global-response-templating"]
 
   notificatie-stub:
     network_mode: host
     ports: !reset []
-    command: ["--port", "8084", "--verbose", "--global-response-templating"]
+    command: ["--bind-address", "127.0.0.1", "--port", "8084", "--verbose", "--global-response-templating"]
 
   postgres-a:
     network_mode: host
     ports: !reset []
     healthcheck: !reset null
+    command: ["postgres", "-c", "listen_addresses=127.0.0.1"]
 
   # PGPORT verplaatst zowel de server als pg_isready naar 5433; in een gedeelde netns kan de
   # tweede Postgres niet óók op 5432 luisteren.
@@ -65,6 +69,7 @@ services:
     network_mode: host
     ports: !reset []
     healthcheck: !reset null
+    command: ["postgres", "-c", "listen_addresses=127.0.0.1"]
     environment:
       PGPORT: "5433"
 
@@ -75,19 +80,21 @@ services:
     network_mode: host
     ports: !reset []
     healthcheck: !reset null
+    command: ["postgres", "-c", "listen_addresses=127.0.0.1"]
     environment:
       PGPORT: "5434"
 
   toxiproxy:
     network_mode: host
     ports: !reset []
+    command: ["-host=127.0.0.1", "-config=/proxies.json"]
     volumes:
       - ./demo/generated/proxies-host.json:/proxies.json:ro,z
 
   magazijn-stubs:
     network_mode: host
     ports: !reset []
-    command: ["--port", "8092", "--verbose"]
+    command: ["--bind-address", "127.0.0.1", "--port", "8092", "--verbose"]
 
   berichtenmagazijn-a:
     network_mode: host
@@ -96,6 +103,8 @@ services:
       postgres-a:
         condition: service_started
     environment:
+      # 0.0.0.0 uit de basis zou in een gedeelde netns op élke interface van de machine binden.
+      QUARKUS_HTTP_HOST: 127.0.0.1
       DB_JDBC_URL: jdbc:postgresql://127.0.0.1:5432/berichtenmagazijn
       AANMELD_URL: http://127.0.0.1:18086/api/v1/aanmeldingen
       NOTIFICATIE_URL: http://127.0.0.1:18084/events
@@ -108,6 +117,8 @@ services:
       postgres-b:
         condition: service_started
     environment:
+      # 0.0.0.0 uit de basis zou in een gedeelde netns op élke interface van de machine binden.
+      QUARKUS_HTTP_HOST: 127.0.0.1
       # Beide magazijnen luisteren in de basis op 8090; b wijkt hier uit naar zijn eigen poort.
       QUARKUS_HTTP_PORT: "8091"
       DB_JDBC_URL: jdbc:postgresql://127.0.0.1:5433/berichtenmagazijn
@@ -118,12 +129,30 @@ services:
   berichtenuitvraag:
     network_mode: host
     ports: !reset []
+    # Het grant-hash per magazijn komt uit de contract-bootstrap van de federatie
+    # (demo/environment/federatie/contracts/fbs-contracten.sh). Ontbreekt het bestand — geen
+    # federatie op deze machine — dan start de stack gewoon zonder, en valt de uitvraag terug op
+    # rechtstreeks verkeer: `magazijnen."<OIN>".grantHash` leeg betekent "geen FSC-headers".
+    env_file:
+      - path: demo/generated/fsc-grants.env
+        required: false
     depends_on:
       redis:
         condition: service_started
+      # Deze overlay reset élke healthcheck (podman draait die via systemd-timers, en juist in de
+      # omgevingen die hostnet nodig hebben ontbreekt systemd). Een `condition: service_healthy`
+      # die uit de basis blijft staan, faalt dan met "has no healthcheck configured" — en omdat
+      # depends_on per sleutel gemerged wordt, moet elke wachtende sleutel hier expliciet terug.
+      postgres-uitvraag:
+        condition: service_started
     environment:
+      # 0.0.0.0 uit de basis zou in een gedeelde netns op élke interface van de machine binden.
+      QUARKUS_HTTP_HOST: 127.0.0.1
       REDIS_HOSTS: redis://127.0.0.1:16379
-      MAGAZIJN_A_URL: http://127.0.0.1:18090
+      # Default: rechtstreeks via toxiproxy, zodat de storing-knop van de demo werkt. Zet
+      # MAGAZIJN_A_URL op de outway van de federatie (http://127.20.1.5:8443) om dit magazijn via
+      # de FSC-keten te laten lopen; het grant-hash komt dan uit env_file hierboven.
+      MAGAZIJN_A_URL: ${MAGAZIJN_A_URL:-http://127.0.0.1:18090}
       MAGAZIJN_B_URL: http://127.0.0.1:18091
       PROFIEL_SERVICE_URL: http://127.0.0.1:18089
       LDV_POSTGRES_URL: jdbc:postgresql://127.0.0.1:5434/ldv_logging
@@ -135,6 +164,8 @@ services:
       redis:
         condition: service_started
     environment:
+      # 0.0.0.0 uit de basis zou in een gedeelde netns op élke interface van de machine binden.
+      QUARKUS_HTTP_HOST: 127.0.0.1
       TOXIPROXY_ADMIN_URL: http://127.0.0.1:8474
       REDIS_HOSTS: redis://127.0.0.1:6379
       UITVRAAG_URL: http://127.0.0.1:8086

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,11 +2,22 @@
 # impliciet aan, podman alleen met ingestelde `unqualified-search-registries` en faalt anders
 # non-interactief. De zelfgebouwde `fbs-demo/…`-images blijven kaal; compose.podman.yaml zet daar
 # `localhost/` voor.
+#
+# `DEMO_BIND` bepaalt op welk hostadres de stack publiceert; default `127.0.0.1`, en verder wordt
+# alleen `0.0.0.0` ondersteund — `demo/podman-up.sh` controleert elke service over 127.0.0.1 en een
+# specifiek adres laat die controles aflopen. Zonder die binding staat de hele demo op élke
+# interface van de machine: Redis zonder wachtwoord, drie PostgreSQL-instanties met
+# demo-credentials en de WireMock-admin-API's. Op een ontwikkelmachine
+# aan een kantoor- of thuisnetwerk is dat het hele subnet.
+#
+# Wil je de demo aan iemand anders tonen, zet 'm dan bewust open met `DEMO_BIND=0.0.0.0`, in plaats
+# van dat het de default is. `demo-console` doet hier NIET aan mee en
+# blijft altijd op loopback; zie de toelichting daar.
 services:
   redis:
     image: docker.io/redis/redis-stack-server:7.4.0-v3
     ports:
-      - "6379:6379"
+      - "${DEMO_BIND:-127.0.0.1}:6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s
@@ -21,7 +32,7 @@ services:
   magazijn-a:
     image: docker.io/wiremock/wiremock:3.13.2
     ports:
-      - "8081:8080"
+      - "${DEMO_BIND:-127.0.0.1}:8081:8080"
     volumes:
       - ./wiremock/magazijn-a/mappings:/home/wiremock/mappings
       - ./wiremock/magazijn-a/__files:/home/wiremock/__files
@@ -30,7 +41,7 @@ services:
   magazijn-b:
     image: docker.io/wiremock/wiremock:3.13.2
     ports:
-      - "8082:8080"
+      - "${DEMO_BIND:-127.0.0.1}:8082:8080"
     volumes:
       - ./wiremock/magazijn-b/mappings:/home/wiremock/mappings
       - ./wiremock/magazijn-b/__files:/home/wiremock/__files
@@ -44,7 +55,7 @@ services:
   profiel-service:
     image: docker.io/wiremock/wiremock:3.13.2
     ports:
-      - "8089:8080"
+      - "${DEMO_BIND:-127.0.0.1}:8089:8080"
     volumes:
       # Gedeelde mappings met de ZAD externe-stubs-image (profiel + notificatie). WireMock
       # laadt álle mappings in deze map, dus ook notificatie-events.json (POST /events); lokaal
@@ -66,7 +77,7 @@ services:
   aanmeld-stub:
     image: docker.io/wiremock/wiremock:3.13.2
     ports:
-      - "8083:8080"
+      - "${DEMO_BIND:-127.0.0.1}:8083:8080"
     volumes:
       - ./wiremock/aanmeld-stub/mappings:/home/wiremock/mappings
     command: ["--verbose", "--global-response-templating"]
@@ -74,7 +85,7 @@ services:
   notificatie-stub:
     image: docker.io/wiremock/wiremock:3.13.2
     ports:
-      - "8084:8080"
+      - "${DEMO_BIND:-127.0.0.1}:8084:8080"
     volumes:
       - ./wiremock/notificatie-stub/mappings:/home/wiremock/mappings
     command: ["--verbose", "--global-response-templating"]
@@ -84,7 +95,7 @@ services:
   postgres-uitvraag:
     image: docker.io/library/postgres:18
     ports:
-      - "5434:5432"
+      - "${DEMO_BIND:-127.0.0.1}:5434:5432"
     environment:
       POSTGRES_USER: ldv
       POSTGRES_PASSWORD: ldv
@@ -100,7 +111,7 @@ services:
   postgres-a:
     image: docker.io/library/postgres:18
     ports:
-      - "5432:5432"
+      - "${DEMO_BIND:-127.0.0.1}:5432:5432"
     environment:
       POSTGRES_USER: berichtenmagazijn
       POSTGRES_PASSWORD: berichtenmagazijn
@@ -120,7 +131,7 @@ services:
   postgres-b:
     image: docker.io/library/postgres:18
     ports:
-      - "5433:5432"
+      - "${DEMO_BIND:-127.0.0.1}:5433:5432"
     environment:
       POSTGRES_USER: berichtenmagazijn
       POSTGRES_PASSWORD: berichtenmagazijn
@@ -152,7 +163,7 @@ services:
     image: fbs-demo/fbs-berichtenmagazijn:demo
     profiles: [demo]
     ports:
-      - "8090:8090"
+      - "${DEMO_BIND:-127.0.0.1}:8090:8090"
     depends_on:
       postgres-a:
         condition: service_healthy
@@ -185,7 +196,7 @@ services:
     image: fbs-demo/fbs-berichtenmagazijn:demo
     profiles: [demo]
     ports:
-      - "8091:8090"
+      - "${DEMO_BIND:-127.0.0.1}:8091:8090"
     depends_on:
       postgres-b:
         condition: service_healthy
@@ -211,7 +222,7 @@ services:
     image: ghcr.io/shopify/toxiproxy:2.12.0
     profiles: [demo]
     ports:
-      - "8474:8474"
+      - "${DEMO_BIND:-127.0.0.1}:8474:8474"
     volumes:
       - ./toxiproxy/proxies.json:/proxies.json:ro
     command: ["-host=0.0.0.0", "-config=/proxies.json"]
@@ -223,7 +234,7 @@ services:
     image: docker.io/wiremock/wiremock:3.13.2
     profiles: [demo]
     ports:
-      - "8092:8080"
+      - "${DEMO_BIND:-127.0.0.1}:8092:8080"
     volumes:
       - ./demo/generated/magazijn-stubs-mappings:/home/wiremock/mappings
     command: ["--verbose"]
@@ -232,7 +243,7 @@ services:
     image: fbs-demo/fbs-berichtenuitvraag:demo
     profiles: [demo]
     ports:
-      - "8086:8086"
+      - "${DEMO_BIND:-127.0.0.1}:8086:8086"
     depends_on:
       redis:
         condition: service_healthy
@@ -290,8 +301,8 @@ services:
       # Uitsluitend op loopback publiceren. Deze console heeft geen authenticatie en
       # POST /api/demo/legen doet een TRUNCATE op beide magazijn-databases; op 0.0.0.0 is dat
       # vanaf het hele netwerk bereikbaar. De Berichtenbox-UI praat sowieso alleen vanaf
-      # localhost: de API-basis staat vast op localhost:8086.
-      - "127.0.0.1:8095:8095"
+      # localhost (vaste API-basis localhost:8086 plus de CORS-allowlist van de uitvraag).
+      - "127.0.0.1:8095:8095"  # NIET via DEMO_BIND: zie de toelichting hierboven
     depends_on:
       berichtenmagazijn-a:
         condition: service_started

--- a/demo/environment/.dockerignore
+++ b/demo/environment/.dockerignore
@@ -1,0 +1,9 @@
+# Build-context voor federatie/contracts/Dockerfile is deze hele map, omdat de scripts op ../../lib
+# leunen. Sleutelmateriaal hoort daar niet in: `pki/issue.sh` laat op een ontwikkelmachine private
+# keys achter onder pki/out en pki/internal, en die zouden anders bij elke lokale build de
+# container-daemon en de build-cache in gaan. In CI bestaan ze niet (ze staan niet in git), dus daar
+# verandert dit niets.
+*/pki/out/
+*/pki/internal/
+*/pki/ca/
+*/pki/zad-upload/

--- a/demo/environment/federatie/README.md
+++ b/demo/environment/federatie/README.md
@@ -150,6 +150,31 @@ Daarna:
 respecteert `depends_on` niet, dus dat gooit postgres tegelijk met zijn afnemers om en laat de
 managers achter op `Exited`. Voor een volledige cyclus is `down` + `up` de weg.
 
+## Contracten
+
+Een peer mag pas iets afnemen als er een wederzijds ondertekend `ServiceConnectionGrant`-contract
+ligt. `contracts/fbs-contracten.sh` zet die op voor de FBS-rollen uit `peers.env`: één contract per
+magazijn, zodat de uitvraag-outway `berichtenmagazijn` bij elk van hen mag ophalen.
+
+```bash
+./federatie/contracts/fbs-contracten.sh   # één contract per magazijn uit MAGAZIJNEN
+./federatie/smoke-contract.sh             # bewijst contract, data-pad, afdwinging en verantwoording
+```
+
+Een magazijn toevoegen is één naam in `MAGAZIJNEN`.
+
+`contracts/bootstrap.sh` eronder is generiek — alle peers, adressen en certificaten komen uit env —
+en is **idempotent zonder lokale state**. De generieke variant in `moza-fsc-testnet` onthoudt de
+content-hash in een bestand; dat werkt op een ontwikkelmachine, maar niet in een deploy waar elke
+job met een lege schijf start: daar maakt elke run er nóg een geldig contract bij. Deze variant
+leidt het bestaan af uit de contracten zelf — service, provider, consumer-outway en thumbprint
+samen vormen de identiteit — zodat een herhaalde run overal een no-op is.
+
+De provider tekent niet vanzelf: `AUTO_SIGN_GRANTS` dekt alleen (delegated)servicePublication, dus
+de accept is een expliciete `PUT`. Landt de accept-handtekening daarna niet bij de consumer (die
+push is best-effort, met begrensde backoff en zonder cron-retry), dan blijft het contract daar
+`proposed` en ziet de outway de grant nooit; het script forceert dan de her-distributie.
+
 ## Een peer toevoegen
 
 1. **`peers.env`** — de peer aan `GASTEN` toevoegen, met zijn `OIN_<peer>` en het volgende vrije

--- a/demo/environment/federatie/README.md
+++ b/demo/environment/federatie/README.md
@@ -159,21 +159,46 @@ magazijn, zodat de uitvraag-outway `berichtenmagazijn` bij elk van hen mag ophal
 ```bash
 ./federatie/contracts/fbs-contracten.sh   # één contract per magazijn uit MAGAZIJNEN
 ./federatie/smoke-contract.sh             # bewijst contract, data-pad, afdwinging en verantwoording
+./federatie/smoke-contract-split.sh       # bewijst dat de twee helften los werken en convergeren
 ```
 
 Een magazijn toevoegen is één naam in `MAGAZIJNEN`.
 
-`contracts/bootstrap.sh` eronder is generiek — alle peers, adressen en certificaten komen uit env —
-en is **idempotent zonder lokale state**. De generieke variant in `moza-fsc-testnet` onthoudt de
-content-hash in een bestand; dat werkt op een ontwikkelmachine, maar niet in een deploy waar elke
-job met een lege schijf start: daar maakt elke run er nóg een geldig contract bij. Deze variant
-leidt het bestaan af uit de contracten zelf — service, provider, consumer-outway en thumbprint
-samen vormen de identiteit — zodat een herhaalde run overal een no-op is.
+### Twee helften
+
+De bootstrap bestaat uit twee losse scripts: `contracts/bootstrap-consumer.sh` dient het contract in
+bij de manager van de consumer, `contracts/bootstrap-provider.sh` tekent het bij die van de
+provider. Elk praat met precies één manager.
+
+Dat is geen stijlkeuze. Op ZAD isoleert de tenant-baseline-NetworkPolicy per deployment en heeft de
+manager-internal-API geen route, dus één proces dat beide managers aanspreekt bestaat daar niet. Het
+contract kruist in plaats daarvan via de FSC-mesh. Zie `contracts/zad-runbook.md`.
+
+`contracts/bootstrap.sh` is de lokale aanroeper van diezelfde twee helften — niet een aparte,
+eenvoudigere variant. Wat hier lokaal getoetst wordt, is dus de code die op ZAD draait. De scheiding
+wordt daarbij afgedwongen en niet alleen afgesproken: elke helft start met `env -u` op de adres- en
+certificaat-variabelen van de overkant.
+
+De provider-helft krijgt geen hash mee maar besluit zelf of hij tekent, en dat is een
+autorisatiebesluit: hij tekent alleen een contract met **precies één** grant, van type
+`GRANT_TYPE_SERVICE_CONNECTION`, voor een eigen dienst uit `FSC_DIENSTEN` en een consumer uit
+`FSC_CONSUMERS`. De eis "precies één" staat er omdat een contract een lijst grants draagt: wie
+alleen toetst of er één passende grant in zit, tekent een meegestuurde tweede mee.
+
+### Idempotentie
+
+De bootstrap is **idempotent zonder lokale state**. De generieke variant in `moza-fsc-testnet`
+onthoudt de content-hash in een bestand; dat werkt op een ontwikkelmachine, maar niet in een deploy
+waar elke job met een lege schijf start: daar maakt elke run er nóg een geldig contract bij. Deze
+variant leidt het bestaan af uit de contracten zelf — service, provider, consumer-outway en
+thumbprint samen vormen de identiteit — zodat een herhaalde run overal een no-op is. Op ZAD is
+herhaling geen randgeval maar de normale werking: beide componenten draaien in een lus.
 
 De provider tekent niet vanzelf: `AUTO_SIGN_GRANTS` dekt alleen (delegated)servicePublication, dus
 de accept is een expliciete `PUT`. Landt de accept-handtekening daarna niet bij de consumer (die
 push is best-effort, met begrensde backoff en zonder cron-retry), dan blijft het contract daar
-`proposed` en ziet de outway de grant nooit; het script forceert dan de her-distributie.
+`proposed` en ziet de outway de grant nooit; de provider-helft stuurt daarom na elke accept één keer
+na, en `bootstrap.sh` forceert de her-distributie als het contract alsnog niet geldig wordt.
 
 ## De FBS-applicatie door de keten
 

--- a/demo/environment/federatie/README.md
+++ b/demo/environment/federatie/README.md
@@ -175,6 +175,41 @@ de accept is een expliciete `PUT`. Landt de accept-handtekening daarna niet bij 
 push is best-effort, met begrensde backoff en zonder cron-retry), dan blijft het contract daar
 `proposed` en ziet de outway de grant nooit; het script forceert dan de her-distributie.
 
+## De FBS-applicatie door de keten
+
+Standaard front de inway een `stub-upstream` (http-echo) en praat de demo-stack rechtstreeks met de
+magazijnen. Met drie ingrepen loopt `berichtenuitvraag` bij magazijn-a écht door FSC:
+
+```bash
+# 1. de inway naar het echte magazijn laten wijzen (in plaats van de echo-stub)
+FSC_UPSTREAM_URL=http://127.0.0.1:8090 \
+  ../magazijn-a/deploy/local/publish-service.sh
+
+# 2. contract + grant-hash; schrijft demo/generated/fsc-grants.env
+./contracts/fbs-contracten.sh
+
+# 3. de demo-stack met de uitvraag door de outway van logius
+MODUS=hostnet MAGAZIJN_A_URL=http://127.20.1.5:8443 ../../podman-up.sh
+
+./smoke-keten.sh
+```
+
+`smoke-keten.sh` bewijst het in drie asserts: een bericht dat alleen in magazijn-a bestaat komt via
+de uitvraag terug, er staat een **nieuwe** transactie in beide txlogs, en magazijn-b blijft
+rechtstreeks werken. Die tweede assert is de eigenlijke: zonder nulmeting zou een transactie uit een
+eerdere run de smoke groen houden terwijl het verkeer buiten de outway om ging.
+
+Drie dingen om te weten:
+
+- **`MAGAZIJN_A_URL` moet ook in `%dev` doorwerken.** De demo draait met `QUARKUS_PROFILE=dev`, en
+  een kale `%dev.magazijnen."…".url=http://localhost:8090` overrulet de omgeving. Het ophalen slaagt
+  dan gewoon — alleen langs de verkeerde weg, en het transactielogboek blijft leeg.
+- **De sessiecache maskeert de keten.** Een tweede ophaling voor dezelfde ontvanger komt uit Redis
+  en raakt het magazijn niet; `smoke-keten.sh` gebruikt daarom per run een verse, elfproef-geldige
+  BSN.
+- **`publish-service.sh` werkt een gewijzigde upstream bij**, maar het `servicePublication`-contract
+  blijft staan. Wisselt de dienst van betekenis, dan hoort daar een nieuwe publicatie bij.
+
 ## Een peer toevoegen
 
 1. **`peers.env`** — de peer aan `GASTEN` toevoegen, met zijn `OIN_<peer>` en het volgende vrije

--- a/demo/environment/federatie/contracts/Dockerfile
+++ b/demo/environment/federatie/contracts/Dockerfile
@@ -1,0 +1,33 @@
+# Image voor de contract-bootstrap als ZAD-component: één per peer, in de deployment van díé peer.
+#
+# Waarom een component en geen CI-stap: de interne manager-API heeft op ZAD geen route en de
+# tenant-baseline-NetworkPolicy laat alleen verkeer binnen hetzelfde deployment toe. Alleen een pod
+# náást de manager kan hem bereiken. En omdat ZAD geen component-args toestaat, leest het entrypoint
+# zijn rol uit env in plaats van uit een argument. Zie contracts/zad-runbook.md.
+#
+# Build-context is demo/environment/ (niet deze map): de scripts leunen op ../../lib.
+FROM docker.io/library/alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce
+
+# bash — de scripts gebruiken arrays; curl — de manager-API; jq — de idempotentie leest contract-JSON;
+# openssl — de outway-thumbprint uit een certificaat, alleen nodig als FSC_OUTWAY_THUMBPRINT niet
+# gezet is. Géén ca-certificates: elke call geeft zijn eigen --cacert mee (de interne PKI), dus de
+# publieke trust store wordt nergens geraadpleegd.
+RUN apk add --no-cache bash curl jq openssl
+
+# Alleen wat draait. De hele map kopiëren zou ook de fixture-tests meenemen en, erger, `bootstrap.sh`
+# en `fbs-contracten.sh` uitvoerbaar in de pod zetten — twee scripts die hier niets te zoeken hebben
+# omdat ze met beide managers tegelijk praten.
+#
+# ZAD/OpenShift start containers onder een willekeurige UID in groep 0, vandaar groep-0-eigendom en
+# leesrechten voor die groep.
+COPY --chown=1001:0 lib/fsc-harness.sh lib/fsc-contract.sh /opt/fsc/lib/
+COPY --chown=1001:0 federatie/contracts/bootstrap-consumer.sh \
+                    federatie/contracts/bootstrap-provider.sh \
+                    federatie/contracts/zad-lus.sh /opt/fsc/contracts/
+
+RUN chmod -R g=u /opt/fsc && chmod 0755 /opt/fsc/contracts/*.sh
+
+USER 1001
+ENV FSC_LIBDIR=/opt/fsc/lib
+
+ENTRYPOINT ["/opt/fsc/contracts/zad-lus.sh"]

--- a/demo/environment/federatie/contracts/bootstrap-consumer.sh
+++ b/demo/environment/federatie/contracts/bootstrap-consumer.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# De consumer-helft van de contract-bootstrap: dien een ServiceConnectionGrant in bij de EIGEN
+# manager en stel vast of hij geldig is geworden. Raakt de manager van de provider niet aan — daar
+# is geen adres, cert of CA voor, dus dat kan ook niet per ongeluk terugsluipen.
+#
+# Stroom:
+#   1. bereken de SPKI-SHA256-thumbprint van het GROUP-cert van de eigen outway (of neem hem uit
+#      env). Dat is waarmee de outway zich naar de provider-inway identificeert, en hij is stabiel
+#      bij cert-rotatie binnen hetzelfde sleutelpaar;
+#   2. staat er al een contract voor deze combinatie? Geldig en door de provider getekend: klaar.
+#      Wel ingediend maar nog niet getekend: wachten is aan de provider-helft;
+#   3. anders `POST /v1/contracts` op de eigen manager. Die tekent server-side namens ons en synct
+#      het contract via de mesh naar de provider.
+#
+# Uitgangen: 0 = contract geldig, 3 = ingediend maar nog niet getekend, 1 = fout, 2 = configuratie.
+# De 3 is geen fout: in de gesplitste opzet draaien de helften onafhankelijk, dus "de provider is
+# nog niet langsgeweest" is de normale tussenstand. De aanroeper (lokaal bootstrap.sh, op ZAD de
+# lus) draait gewoon opnieuw.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LIBDIR="${FSC_LIBDIR:-$(cd "${HERE}/../../lib" && pwd)}"
+
+# shellcheck source=../../lib/fsc-harness.sh
+. "${LIBDIR}/fsc-harness.sh"
+# shellcheck source=../../lib/fsc-contract.sh
+. "${LIBDIR}/fsc-contract.sh"
+
+fsc_errlog_init
+fsc_have_jq
+
+CONSUMER_OIN="$(fsc_env_vereist FSC_CONSUMER_OIN 'de OIN van deze peer')"
+PROVIDER_OIN="$(fsc_env_vereist FSC_PROVIDER_OIN 'de OIN van de aanbiedende peer')"
+SERVICE_NAME="$(fsc_env_vereist FSC_SERVICE_NAME 'de dienst die we willen afnemen')"
+GROUP_ID="${FSC_GROUP_ID:-moza-fbs-test}"
+
+MANAGER="$(fsc_env_vereist FSC_CONSUMER_MANAGER 'https://<eigen-manager>:9443')"
+CERT="$(fsc_env_vereist FSC_CONSUMER_CERT)"
+KEY="$(fsc_env_vereist FSC_CONSUMER_KEY)"
+CA="$(fsc_env_vereist FSC_CONSUMER_CA)"
+ADRES="${FSC_CONSUMER_ADRES:-}"
+
+fsc_contract_manager_ok "$MANAGER" || exit 2
+
+[ "$HAVE_JQ" -eq 1 ] || {
+  echo "FAIL: jq is vereist. De idempotentie leunt op het uitlezen van de contract-JSON; zonder jq" >&2
+  echo "  zou elke run een nieuw contract aanmaken in plaats van een bestaand te herkennen." >&2
+  exit 2
+}
+
+api() { fsc_contract_api "$MANAGER" "$CERT" "$KEY" "$CA" "$ADRES" "$@"; }
+
+# De lijst is cursor-gepagineerd met een default van honderd en een maximum van duizend, en bevat
+# álles: publicatiecontracten,
+# ingetrokken en afgewezen contracten, van alle peers. In een langlevend deployment groeit dat
+# monotoon, en zodra ons eigen contract van pagina 1 valt zou de consumer elke ronde een nieuw
+# indienen. Een ruime limiet houdt de guard in fsc-contract.sh een vangrail in plaats van een
+# dagelijkse blokkade.
+CONTRACT_LIMIET="$(fsc_getal_hoogstens FSC_CONTRACT_LIMIET "${FSC_CONTRACT_LIMIET:-1000}" 1000)"
+
+# --- 1. Outway-thumbprint -----------------------------------------------------------------------
+# Uit env óf uit het certificaat. Op ZAD is env de weg: het group-cert van de outway hangt daar aan
+# het outway-component, en het aan een tweede component koppelen zou die identiteit verspreiden.
+THUMB="${FSC_OUTWAY_THUMBPRINT:-}"
+
+if [ -z "$THUMB" ]; then
+  OUTWAY_CERT="$(fsc_env_vereist FSC_OUTWAY_CERT 'of zet FSC_OUTWAY_THUMBPRINT rechtstreeks')"
+  command -v openssl >/dev/null 2>&1 || { echo "FAIL: openssl niet gevonden." >&2; exit 2; }
+
+  THUMB="$(fsc_outway_thumbprint "$OUTWAY_CERT")" || {
+    echo "FAIL: kon de outway-thumbprint niet berekenen uit ${OUTWAY_CERT}: $(fsc_last_error)" >&2
+    exit 1
+  }
+fi
+
+# Een meegegeven thumbprint gaat ongezien in de grant en bepaalt welke outway de dienst mag afnemen;
+# een typefout levert een contract op dat geldig heet en nooit werkt. De waarde wordt bovendien
+# ongeëscaped in de JSON-body hieronder geïnterpoleerd, dus een aanhalingsteken erin zou de
+# contract-content herschrijven — vandaar een volledige vormcontrole en niet alleen de lengte.
+fsc_hex64 "$THUMB" || {
+  echo "FAIL: thumbprint is geen 64 lowercase hex-tekens: '${THUMB}'" >&2
+  exit 2
+}
+
+echo "consumer: outway public-key-thumbprint = ${THUMB}"
+
+# --- 2. Staat er al iets uit? -------------------------------------------------------------------
+eigen_contracten() {
+  local json
+  json="$(api "${MANAGER}/v1/contracts?limit=${CONTRACT_LIMIET}")" || {
+    echo "FAIL: kon de eigen contractenlijst niet ophalen: $(fsc_last_error)" >&2
+    return 1
+  }
+
+  # Met eigen melding, mét de reden erbij: de manager kan met 200 antwoorden en toch iets anders
+  # sturen dan een contractenlijst — een ander schema, een proxy-foutpagina, een afgekapt antwoord.
+  # "geen geldige JSON" zou daarbij vaak onwaar zijn en de operator de verkeerde kant op sturen.
+  fsc_contract_voor_combinatie "$json" "$SERVICE_NAME" "$PROVIDER_OIN" "$CONSUMER_OIN" "$THUMB" | sort || {
+    echo "FAIL: de eigen contractenlijst is niet te lezen: $(fsc_last_error)" >&2
+    return 1
+  }
+}
+
+# geldige_hashes <regels>: de hashes uit `<hash> <state> <getekend> <afgewezen>`-regels die klaar zijn.
+geldige_hashes() {
+  printf '%s' "${1:-}" | awk '$2 == "contract_state_valid" && $3 == "ja" { print $1 }'
+}
+
+REVOKE_FOUTEN=0
+REGELS="$(eigen_contracten)" || exit 1
+GELDIG="$(geldige_hashes "$REGELS")"
+
+# `ontbreekt` betekent dat de manager het state-veld niet meestuurde — niet dat het contract
+# ongeldig is. Stil als "nog niet klaar" lezen zou hier eeuwig wachten opleveren op iets dat er al
+# staat, dus dat geval wordt gemeld.
+# Een afgewezen contract is het antwoord van de overkant op onze aanvraag. Het blijft in de lijst
+# staan, dus we dienen niet meteen opnieuw in — maar het moet wel blijken, anders wacht de operator
+# op iets dat nooit komt.
+if printf '%s' "$REGELS" | awk '$4 == "afgewezen" { gevonden = 1 } END { exit !gevonden }'; then
+  echo "WARN: de provider heeft minstens één van onze contracten AFGEWEZEN:" >&2
+  printf '%s\n' "$REGELS" | sed 's/^/  /' >&2
+  echo "  Kijk aan providerkant naar de WEIGER-regels; opnieuw indienen heeft pas zin na een fix." >&2
+fi
+
+if printf '%s' "$REGELS" | awk '$2 == "ontbreekt" { gevonden = 1 } END { exit !gevonden }'; then
+  echo "WARN: de manager gaf voor minstens één contract geen state terug; die tellen hier niet als geldig." >&2
+  printf '%s\n' "$REGELS" | sed 's/^/  /' >&2
+fi
+
+if [ -n "$GELDIG" ]; then
+  AANTAL="$(printf '%s\n' "$GELDIG" | grep -c .)"
+  HASH="$(printf '%s\n' "$GELDIG" | head -n1)"
+  echo "OK: er is al een geldig contract voor ${SERVICE_NAME} (${CONSUMER_OIN} -> ${PROVIDER_OIN})."
+  printf '%s\n' "$GELDIG" | sed 's/^/  contract: /'
+
+  if [ "$AANTAL" -gt 1 ]; then
+    # Kan ontstaan doordat de existence-check en de POST niet atomair zijn: twee gelijktijdige of
+    # herhaalde runs kunnen allebei posten. Ze zijn functioneel inwisselbaar — zelfde dienst, zelfde
+    # peers, zelfde outway — dus we houden er één aan en trekken de rest in. Welke dat is doet er
+    # niet toe zolang de keuze stabiel is over runs heen; vandaar gesorteerd en dan de eerste.
+    # `fbs-contracten.sh` leidt het grant-hash voor de `Fsc-Grant-Hash`-header uit datzelfde
+    # gesorteerd-eerste contract af, dus beide kanten komen bij hetzelfde uit.
+    echo "  ${AANTAL} geldige contracten voor dezelfde combinatie; de overtollige worden ingetrokken." >&2
+
+    while IFS= read -r dup; do
+      [ -n "$dup" ] || continue
+
+      # Het hash komt uit de respons en gaat een URL-pad in; een waarde met een schuine streep zou
+      # dat pad verleggen naar een ander endpoint.
+      if ! fsc_hash_ok "$dup"; then
+        echo "  FAIL: contract-hash met een onverwachte vorm overgeslagen: '${dup}'" >&2
+        REVOKE_FOUTEN=$((REVOKE_FOUTEN + 1))
+        continue
+      fi
+
+      if uit="$(api -X PUT "${MANAGER}/v1/contracts/${dup}/revoke" -H 'Content-Type: application/json')"; then
+        echo "  ingetrokken: ${dup}" >&2
+      else
+        # Geteld en niet alleen gemeld: blijft dit mislukken, dan groeit het aantal geldige
+        # contracten elke ronde door en is er niets dat dat rood maakt.
+        echo "  FAIL: kon duplicaat ${dup} niet intrekken: ${uit:-<leeg>} $(fsc_last_error)" >&2
+        REVOKE_FOUTEN=$((REVOKE_FOUTEN + 1))
+      fi
+    done <<EOF
+$(printf '%s\n' "$GELDIG" | tail -n +2)
+EOF
+
+    [ "$REVOKE_FOUTEN" -eq 0 ] || {
+      echo "FAIL: ${REVOKE_FOUTEN} duplicaat/duplicaten bleven staan." >&2
+      exit 1
+    }
+  fi
+
+  echo "CONSUMER OK (bestaand contract ${HASH})."
+  exit 0
+fi
+
+if [ -n "$REGELS" ]; then
+  # Bewust niet "de provider moet nog tekenen": de derde kolom kan `ja` zijn terwijl het contract
+  # hier nog niet geldig is — dan is de handtekening er wel maar de state nog niet, en zou die
+  # melding de operator naar de verkeerde helft sturen.
+  echo "consumer: contract is ingediend maar hier nog niet geldig:" >&2
+  printf '%s\n' "$REGELS" | sed 's/^/  /' >&2
+  echo "CONSUMER WACHT (nog niet geldig bij ons)."
+  exit 3
+fi
+
+# --- 3. Contract opstellen en indienen ----------------------------------------------------------
+IV="$(fsc_new_iv)"
+fsc_validity
+
+echo "consumer: serviceConnection-contract indienen bij de eigen manager..."
+# `service.type` is verplicht op een connection-grant (de publicatie-grant defaultte 'm, deze niet),
+# en `outway.identification` is sinds OpenFSC v2.0.0 een union met `type` als discriminator — de
+# platte v1-vorm wordt niet meer geaccepteerd. `fsc_version` zetten we niet zelf: de POST neemt
+# `createContractContent`, waar dat veld ontbreekt; de manager vult 'm en neemt 'm mee in de hash.
+#
+# Precies één grant, want dat is wat de provider-helft tekent: een contract met meer grants wordt
+# daar geweigerd in plaats van gedeeltelijk geaccepteerd.
+RESP="$(api -X POST "${MANAGER}/v1/contracts" -H 'Content-Type: application/json' -d "{
+  \"contract_content\": {
+    \"iv\": \"${IV}\",
+    \"group_id\": \"${GROUP_ID}\",
+    \"hash_algorithm\": \"HASH_ALGORITHM_SHA3_512\",
+    \"created_at\": ${NBF},
+    \"validity\": { \"not_before\": $((NBF - 60)), \"not_after\": ${NAF} },
+    \"grants\": [ {
+      \"type\": \"GRANT_TYPE_SERVICE_CONNECTION\",
+      \"service\": { \"type\": \"SERVICE_TYPE_SERVICE\", \"peer_id\": \"${PROVIDER_OIN}\", \"name\": \"${SERVICE_NAME}\" },
+      \"outway\": {
+        \"peer_id\": \"${CONSUMER_OIN}\",
+        \"identification\": {
+          \"type\": \"OUTWAY_IDENTIFICATION_TYPE_PUBLIC_KEY_THUMBPRINT\",
+          \"public_key_thumbprint\": \"${THUMB}\"
+        }
+      }
+    } ]
+  }
+}")" || { echo "FAIL: POST /v1/contracts geweigerd: ${RESP:-<leeg>} $(fsc_last_error)" >&2; exit 1; }
+
+HASH="$(printf '%s' "$RESP" | jq -r '.content_hash // empty' 2>/dev/null)" || HASH=""
+[ -n "$HASH" ] || { echo "FAIL: respons zonder content_hash (formaat geweigerd?): ${RESP}" >&2; exit 1; }
+
+echo "  eigen handtekening gezet; mesh-sync gestart; content_hash=${HASH}"
+
+# Hier niet wachten. De provider-helft is een los proces dat op dit moment nog niet langs is
+# geweest, dus elke seconde pollen levert gegarandeerd niets op; de aanroeper draait opnieuw.
+echo "CONSUMER WACHT (contract ${HASH} ingediend; provider-helft moet nog tekenen)."
+exit 3

--- a/demo/environment/federatie/contracts/bootstrap-provider.sh
+++ b/demo/environment/federatie/contracts/bootstrap-provider.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# De provider-helft van de contract-bootstrap: teken de binnengekomen ServiceConnectionGrants op de
+# EIGEN manager. Raakt de manager van de consumer niet aan — daar is geen adres, cert of CA voor,
+# dus dat kan ook niet per ongeluk terugsluipen.
+#
+# Welk contract getekend mag worden, besluit `fsc_contract_beoordeling()`; lees daar waarom "precies
+# één grant" de eis is en waarom van de thumbprint wel het type maar niet de waarde telt.
+#
+# Uitgangen:
+#   0  klaar — er is iets getekend, of alles wat ons aangaat stond er al
+#   1  fout — een call mislukte, of een contract kon niet getekend worden
+#   2  configuratie deugt niet
+#   3  er is nog niets van een toegelaten consumer binnengekomen — wachten op de overkant
+#   4  er is niets getekend én er ligt iets dat aandacht vraagt: een contract dat de toets niet
+#      haalt, of een contract dat wij ooit tekenden en dat de toets nu niet meer haalt
+#
+# De 3 en de 4 zijn er omdat "niets gedaan" drie heel verschillende dingen kan betekenen. Zonder
+# die twee meldt een lege lijst hetzelfde als een gezonde ronde, en een verkeerd gezette allowlist
+# ook — waarna de aanroeper een uur gaat slapen terwijl de consumer elke vijftien seconden wacht.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LIBDIR="${FSC_LIBDIR:-$(cd "${HERE}/../../lib" && pwd)}"
+
+# shellcheck source=../../lib/fsc-harness.sh
+. "${LIBDIR}/fsc-harness.sh"
+# shellcheck source=../../lib/fsc-contract.sh
+. "${LIBDIR}/fsc-contract.sh"
+
+fsc_errlog_init
+fsc_have_jq
+
+PROVIDER_OIN="$(fsc_env_vereist FSC_PROVIDER_OIN 'de OIN van deze peer')"
+
+# Welke diensten wij aanbieden en welke consumers een contract van ons mogen krijgen. Dit is de
+# autorisatiegrens: alles wat er niet in staat, tekenen we niet.
+DIENSTEN="$(fsc_env_vereist FSC_DIENSTEN 'dienstnamen die deze peer aanbiedt, gescheiden door witruimte')"
+CONSUMERS="$(fsc_env_vereist FSC_CONSUMERS 'consumer-OINs die een contract mogen krijgen, gescheiden door witruimte')"
+
+GROUP_ID="${FSC_GROUP_ID:-moza-fbs-test}"
+
+# Bovengrens op de RESTERENDE geldigheid (`not_after` min nu), niet op de vensterlengte: de vraag is
+# hoe lang een tegenpartij een claim op ons kan houden. De consumer-helft vraagt tien jaar; deze
+# grens ligt er ongeveer tien dagen boven, zodat een gewone aanvraag doorkomt maar een contract van
+# honderd jaar niet. Die tien dagen zijn tegelijk het volledige budget voor klokverschil tussen de
+# twee peers — wie deze waarde richting 315360000 bijstelt, haalt dat weg.
+MAX_GELDIGHEID="$(fsc_getal_vereist FSC_MAX_GELDIGHEID_SECONDEN "${FSC_MAX_GELDIGHEID_SECONDEN:-316224000}")"
+
+MANAGER="$(fsc_env_vereist FSC_PROVIDER_MANAGER 'https://<eigen-manager>:9443')"
+CERT="$(fsc_env_vereist FSC_PROVIDER_CERT)"
+KEY="$(fsc_env_vereist FSC_PROVIDER_KEY)"
+CA="$(fsc_env_vereist FSC_PROVIDER_CA)"
+ADRES="${FSC_PROVIDER_ADRES:-}"
+
+# Her-distributie van de accept-handtekening ook forceren voor contracten die we eerder al tekenden.
+# Uit by default: die push lukt normaal, en elke ronde opnieuw pushen is een call per contract per
+# ronde voor niets. Aan zetten is de knop voor een gestrande push (zie `distribueer`).
+FORCEER_DISTRIBUTIE="${FSC_FORCEER_DISTRIBUTIE:-0}"
+
+fsc_contract_manager_ok "$MANAGER" || exit 2
+
+[ "$HAVE_JQ" -eq 1 ] || {
+  echo "FAIL: jq is vereist. Zonder jq is niet vast te stellen wélk contract getekend mag worden," >&2
+  echo "  en blind tekenen zou elke aangeboden grant ondertekenen." >&2
+  exit 2
+}
+
+api() { fsc_contract_api "$MANAGER" "$CERT" "$KEY" "$CA" "$ADRES" "$@"; }
+
+# De lijst is cursor-gepagineerd met een default van honderd en een maximum van duizend, en bevat
+# álles: publicatiecontracten, ingetrokken en afgewezen contracten, van alle peers. In een langlevend
+# deployment groeit dat monotoon, en zodra ons eigen contract van pagina 1 valt zou de consumer elke
+# ronde een nieuw indienen. Een ruime limiet houdt de guard in fsc-contract.sh een vangrail in plaats
+# van een dagelijkse blokkade. Boven duizend geeft de manager een 400.
+CONTRACT_LIMIET="$(fsc_getal_hoogstens FSC_CONTRACT_LIMIET "${FSC_CONTRACT_LIMIET:-1000}" 1000)"
+
+DIENSTEN_JSON="$(fsc_lijst_naar_json FSC_DIENSTEN "$DIENSTEN")" || exit 2
+CONSUMERS_JSON="$(fsc_lijst_naar_json FSC_CONSUMERS "$CONSUMERS")" || exit 2
+
+# --- De contracten ophalen en beoordelen ---------------------------------------------------------
+JSON="$(api "${MANAGER}/v1/contracts?limit=${CONTRACT_LIMIET}")" || {
+  echo "FAIL: kon de eigen contractenlijst niet ophalen: $(fsc_last_error)" >&2
+  exit 1
+}
+
+BEOORDELING="$(fsc_contract_beoordeling \
+  "$JSON" "$PROVIDER_OIN" "$DIENSTEN_JSON" "$CONSUMERS_JSON" "$GROUP_ID" "$MAX_GELDIGHEID" \
+  "$(date -u +%s)")" || {
+  echo "FAIL: de contractenlijst is niet te beoordelen: $(fsc_last_error)" >&2
+  exit 1
+}
+
+AFGEWEZEN="$(fsc_contract_regels "$BEOORDELING" WEIGER)"
+
+# Contracten die wij ooit tekenden en die nu de toets niet meer halen. Geen besluit meer — het staat
+# er al — maar wel iets waar een operator van moet weten: doorgaans een gecorrigeerde allowlist of
+# een looptijd die inmiddels buiten de grens valt.
+AANDACHT="$(fsc_contract_regels "$BEOORDELING" AANDACHT)"
+
+if [ -n "$AANDACHT" ]; then
+  echo "provider: eerder getekende contracten die de toets nu niet meer halen:" >&2
+  printf '%s\n' "$AANDACHT" | sed 's/^/  /' >&2
+fi
+
+if [ -n "$AFGEWEZEN" ]; then
+  # Niet-tekenen is de stille uitkomst: zonder deze regels ziet een operator alleen dat er niets
+  # gebeurde, niet waarom.
+  echo "provider: contracten die de toets niet halen en dus niet getekend worden:" >&2
+  printf '%s\n' "$AFGEWEZEN" | sed 's/^/  /' >&2
+fi
+
+# --- Tekenen -------------------------------------------------------------------------------------
+# `distribueer <hash> <consumer_oin>`: laat de accept-handtekening (opnieuw) naar de consumer sturen.
+#
+# De manager pusht die na de accept zelf, maar best-effort: begrensde backoff, geen cron-retry.
+# Strandt die push, dan blijft het contract bij de consumer `proposed` en ziet de outway de grant
+# nooit, terwijl het hier geldig heet. Vóór de splitsing merkte het script dat doordat het bij de
+# consumer keek; die kant is nu een ander proces op een andere manager. Deze helft kan het dus niet
+# waarnemen en stuurt daarom één keer na. Strandt hij later alsnog, dan is FSC_FORCEER_DISTRIBUTIE=1
+# de knop.
+#
+# De uitkomst telt mee in FOUTEN: deze call ís het herstelmechanisme voor een gestrande push, dus
+# een mislukking hier stil laten verdwijnen zou juist het geval verbergen waarvoor hij bestaat.
+distribueer() {
+  local hash="$1" consumer="$2" uit
+
+  uit="$(api -X PUT \
+    "${MANAGER}/v1/contracts/${hash}/distributions/${consumer}/DISTRIBUTION_ACTION_SUBMIT_ACCEPT_SIGNATURE/retry" \
+    -H 'Content-Type: application/json')" || {
+    echo "  FAIL: her-distributie van ${hash} naar ${consumer} geweigerd: ${uit:-<leeg>} $(fsc_last_error)" >&2
+    return 1
+  }
+}
+
+GETEKEND=0
+FOUTEN=0
+
+# Verwerk één beoordelingsregel. `hash` en `consumer` komen uit de respons en gaan een URL-pad in;
+# een waarde met een schuine streep of witruimte zou dat pad verleggen, dus eerst de vorm toetsen.
+verwerk() {
+  local soort="$1" hash="$2" consumer="$3" uit
+
+  if ! fsc_hash_ok "$hash"; then
+    echo "  FAIL: contract-hash met een onverwachte vorm overgeslagen: '${hash}'" >&2
+    FOUTEN=$((FOUTEN + 1))
+    return
+  fi
+
+  case "$consumer" in
+    ""|*[!0-9]*)
+      echo "  FAIL: consumer-OIN met een onverwachte vorm overgeslagen: '${consumer}'" >&2
+      FOUTEN=$((FOUTEN + 1))
+      return
+      ;;
+  esac
+
+  if [ "$soort" = GETEKEND ]; then
+    echo "provider: her-distributie forceren voor ${hash} (consumer ${consumer})..."
+    distribueer "$hash" "$consumer" || FOUTEN=$((FOUTEN + 1))
+    return
+  fi
+
+  echo "provider: tekenen ${hash} (consumer ${consumer})..."
+
+  if uit="$(api -X PUT "${MANAGER}/v1/contracts/${hash}/accept" -H 'Content-Type: application/json')"; then
+    GETEKEND=$((GETEKEND + 1))
+    distribueer "$hash" "$consumer" || FOUTEN=$((FOUTEN + 1))
+  else
+    echo "  FAIL: accept van ${hash} geweigerd: ${uit:-<leeg>} $(fsc_last_error)" >&2
+    FOUTEN=$((FOUTEN + 1))
+  fi
+}
+
+# Geen `| while`: dat draait in een subshell en dan komen GETEKEND/FOUTEN niet terug.
+while IFS=' ' read -r hash consumer; do
+  [ -n "$hash" ] || continue
+
+  verwerk TEKEN "$hash" "$consumer"
+done <<EOF
+$(fsc_contract_regels "$BEOORDELING" TEKEN)
+EOF
+
+if [ "$FORCEER_DISTRIBUTIE" = 1 ]; then
+  while IFS=' ' read -r hash consumer; do
+    [ -n "$hash" ] || continue
+
+    verwerk GETEKEND "$hash" "$consumer"
+  done <<EOF
+$(fsc_contract_regels "$BEOORDELING" GETEKEND)
+EOF
+fi
+
+if [ "$FOUTEN" -gt 0 ]; then
+  echo "PROVIDER ROOD: ${FOUTEN} handeling(en) mislukt, ${GETEKEND} contract(en) getekend." >&2
+  exit 1
+fi
+
+# Uitgang 4 alleen als er níéts getekend is. Anders was deze ronde gewoon productief en zou de
+# aanroeper hem onterecht als "beslissing, niets meer te doen" lezen — waarna één blijvend
+# onbetekenbaar contract van een oude consumer de lus permanent op het lange interval zet, en elke
+# nieuwe consumer daardoor tot een uur op zijn handtekening wacht.
+if [ -n "$AFGEWEZEN" ] && [ "$GETEKEND" -eq 0 ]; then
+  echo "PROVIDER GEWEIGERD ($(printf '%s\n' "$AFGEWEZEN" | grep -c .) contract(en) haalden de toets niet)." >&2
+  exit 4
+fi
+
+# Ook een uitsluitend-AANDACHT-ronde is geen succes. Er ligt dan een contract dat wij ooit tekenden
+# en dat nu de toets niet meer haalt: het datapad is stuk terwijl de consumer zijn contract geldig
+# ziet. Zou dit 0 opleveren, dan zet de lus de wachtteller op nul en blijft het component eeuwig
+# groen, met één stderr-regel per uur als enige spoor.
+if [ -n "$AANDACHT" ] && [ "$GETEKEND" -eq 0 ]; then
+  echo "PROVIDER GEWEIGERD ($(printf '%s\n' "$AANDACHT" | grep -c .) eerder getekend contract(en) halen de toets niet meer)." >&2
+  exit 4
+fi
+
+if [ "$GETEKEND" -gt 0 ]; then
+  echo "PROVIDER OK (${GETEKEND} contract(en) getekend${AFGEWEZEN:+, $(printf '%s\n' "$AFGEWEZEN" | grep -c .) geweigerd}${AANDACHT:+, $(printf '%s\n' "$AANDACHT" | grep -c .) met aandacht})."
+  exit 0
+fi
+
+# Niets getekend en niets dat ons aangaat in de lijst: het contract van de consumer is hier nog niet.
+# Dat is wachten op de overkant en geen eindtoestand — de aanroeper hoort er kort op terug te komen
+# in plaats van naar het lange interval te gaan, anders duurt een verse bootstrap tot een uur.
+# Alleen echt "nog niets binnen": geen getekend contract van ons, en ook geen contract dat ooit van
+# ons was. Zonder die tweede voorwaarde meldt een provider met een afgekeurd eigen contract elke
+# ronde dat er niets binnen is, terwijl het er wel ligt — en stuurt de lus de operator naar
+# WEIGER-regels die er niet zijn.
+if [ -z "$(fsc_contract_regels "$BEOORDELING" GETEKEND)" ] && [ -z "$AANDACHT" ]; then
+  echo "PROVIDER WACHT (nog geen contract van een toegelaten consumer binnen)."
+  exit 3
+fi
+
+echo "PROVIDER OK (niets te tekenen)."

--- a/demo/environment/federatie/contracts/bootstrap.sh
+++ b/demo/environment/federatie/contracts/bootstrap.sh
@@ -89,25 +89,32 @@ done
 # Rechtstreeks vanaf de host: onder hostnet luisteren alle managers in de netns van de aanroeper.
 # De namen staan niet in /etc/hosts (extra_hosts geldt alleen binnen containers), vandaar --resolve
 # op elk manager-adres.
+#
+# Welk adres dat is, verschilt per opstelling: in een standalone harness luistert alles op
+# 127.0.0.1, in de federatie heeft elke component een eigen adres. Vandaar per kant overrulebaar,
+# met de standalone-waarde als default.
+CONSUMER_ADRES="${FSC_CONSUMER_ADRES:-127.0.0.1}"
+PROVIDER_ADRES="${FSC_PROVIDER_ADRES:-127.0.0.1}"
+
 resolve_args() {
-  local url="$1" hostnaam poort
+  local url="$1" adres="$2" hostnaam poort
   hostnaam="${url#https://}"; hostnaam="${hostnaam%%/*}"
   poort="${hostnaam##*:}"; hostnaam="${hostnaam%%:*}"
-  printf '%s\n' --resolve "${hostnaam}:${poort}:127.0.0.1"
+  printf '%s\n' --resolve "${hostnaam}:${poort}:${adres}"
 }
 
-# api <manager-url> <cert> <key> <ca> <curl-args...>
+# api <manager-url> <cert> <key> <ca> <adres> <curl-args...>
 api() {
-  local url="$1" cert="$2" key="$3" ca="$4"; shift 4
+  local url="$1" cert="$2" key="$3" ca="$4" adres="$5"; shift 5
   local r args=()
-  while IFS= read -r r; do args+=("$r"); done < <(resolve_args "$url")
+  while IFS= read -r r; do args+=("$r"); done < <(resolve_args "$url" "$adres")
 
   curl -sS --fail-with-body --noproxy '*' "${args[@]}" \
     --cert "$cert" --key "$key" --cacert "$ca" "$@" 2>"$ERRLOG"
 }
 
-consumer_api() { api "$CONSUMER_MANAGER" "$CONSUMER_CERT" "$CONSUMER_KEY" "$CONSUMER_CA" "$@"; }
-provider_api() { api "$PROVIDER_MANAGER" "$PROVIDER_CERT" "$PROVIDER_KEY" "$PROVIDER_CA" "$@"; }
+consumer_api() { api "$CONSUMER_MANAGER" "$CONSUMER_CERT" "$CONSUMER_KEY" "$CONSUMER_CA" "$CONSUMER_ADRES" "$@"; }
+provider_api() { api "$PROVIDER_MANAGER" "$PROVIDER_CERT" "$PROVIDER_KEY" "$PROVIDER_CA" "$PROVIDER_ADRES" "$@"; }
 
 # --- 1. Outway-thumbprint -----------------------------------------------------------------------
 command -v openssl >/dev/null 2>&1 || { echo "FAIL: openssl niet gevonden." >&2; exit 1; }

--- a/demo/environment/federatie/contracts/bootstrap.sh
+++ b/demo/environment/federatie/contracts/bootstrap.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# Zet idempotent een geldig, wederzijds ondertekend ServiceConnectionGrant-contract op tussen een
+# consumer-peer en een provider-peer.
+#
+# Generiek: alle peers, adressen en certificaten komen uit env. `fbs-contracten.sh` ernaast vult
+# die in voor de FBS-peers en loopt over de magazijnen.
+#
+# Stroom (OpenFSC Manager Internal-API):
+#   1. bereken de SPKI-SHA256-thumbprint van het GROUP-cert van de consumer-outway. Dat is waarmee
+#      de outway zich naar de provider-inway identificeert, en het is stabiel bij cert-rotatie
+#      binnen hetzelfde sleutelpaar;
+#   2. bestaat er al een geldig contract voor precies deze combinatie? -> klaar;
+#   3. POST /v1/contracts op de EIGEN manager. Die tekent server-side namens de consumer en synct
+#      het contract via de mesh naar de provider;
+#   4. poll de provider tot het contract er is, dan PUT /v1/contracts/{hash}/accept op de
+#      PROVIDER-manager. Expliciet, want `AUTO_SIGN_GRANTS` dekt alleen (delegated)servicePublication;
+#   5. poll tot de CONSUMER het contract als `CONTRACT_STATE_VALID` ziet. De provider-accept wordt
+#      async naar de consumer gepusht met een begrensde backoff en zonder cron-retry; landt die
+#      niet, dan blijft het contract daar `proposed` en ziet de outway de grant nooit. Blijft het
+#      hangen, dan forceren we de her-distributie.
+#
+# IDEMPOTENTIE ZONDER STATE-FILE. De generieke variant in `moza-fsc-testnet` onthoudt de
+# content-hash van het geaccepteerde contract in een bestand. Dat werkt op een ontwikkelmachine,
+# maar niet in een deploy: elke job start met een lege schijf, dus elke run maakt er nóg een
+# geldig contract bij. Deze variant leidt het bestaan af uit de contracten zelf — service, provider,
+# consumer-outway en thumbprint samen zijn de identiteit — zodat een herhaalde run een no-op is,
+# waar hij ook draait.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ENVDIR="$(cd "${HERE}/../.." && pwd)"
+
+# shellcheck source=../../lib/fsc-harness.sh
+. "${ENVDIR}/lib/fsc-harness.sh"
+
+fsc_errlog_init
+fsc_have_jq
+
+# --- Parameters ---------------------------------------------------------------------------------
+CONSUMER_OIN="${FSC_CONSUMER_OIN:?zet FSC_CONSUMER_OIN}"
+PROVIDER_OIN="${FSC_PROVIDER_OIN:?zet FSC_PROVIDER_OIN}"
+SERVICE_NAME="${FSC_SERVICE_NAME:?zet FSC_SERVICE_NAME}"
+GROUP_ID="${FSC_GROUP_ID:-moza-fbs-test}"
+
+# Het GROUP-cert van de consumer-outway (host-pad). Bewust het group- en niet het internal-cert:
+# de outway registreert bij zijn controller met zijn group-cert en stuurt datzelfde thumbprint naar
+# GetOutwayServices, waar de manager het tegen de grant matcht.
+OUTWAY_CERT="${FSC_OUTWAY_CERT:?zet FSC_OUTWAY_CERT}"
+
+CONSUMER_MANAGER="${FSC_CONSUMER_MANAGER:?zet FSC_CONSUMER_MANAGER}"
+CONSUMER_CERT="${FSC_CONSUMER_CERT:?zet FSC_CONSUMER_CERT}"
+CONSUMER_KEY="${FSC_CONSUMER_KEY:?zet FSC_CONSUMER_KEY}"
+CONSUMER_CA="${FSC_CONSUMER_CA:?zet FSC_CONSUMER_CA}"
+
+PROVIDER_MANAGER="${FSC_PROVIDER_MANAGER:?zet FSC_PROVIDER_MANAGER}"
+PROVIDER_CERT="${FSC_PROVIDER_CERT:?zet FSC_PROVIDER_CERT}"
+PROVIDER_KEY="${FSC_PROVIDER_KEY:?zet FSC_PROVIDER_KEY}"
+PROVIDER_CA="${FSC_PROVIDER_CA:?zet FSC_PROVIDER_CA}"
+
+SYNC_TIMEOUT="${FSC_SYNC_TIMEOUT:-20}"
+SYNC_INTERVAL="${FSC_SYNC_INTERVAL:-2}"
+
+# De adressen worden geconcateneerd tot curl's URL-argument; een waarde die met `-` begint zou curl
+# als optie lezen (`-K/pad` maakt er een config-file-lees van).
+for _adres in "$CONSUMER_MANAGER" "$PROVIDER_MANAGER"; do
+  case "$_adres" in
+    https://*) ;;
+    *) echo "FAIL: manager-adres moet met https:// beginnen: '${_adres}'" >&2; exit 2 ;;
+  esac
+done
+
+[ "$HAVE_JQ" -eq 1 ] || {
+  echo "FAIL: jq is vereist. De idempotentie leunt op het uitlezen van de contract-JSON; zonder jq" >&2
+  echo "  zou elke run een nieuw contract aanmaken in plaats van een bestaand te herkennen." >&2
+  exit 1
+}
+
+# --- curl-helpers -------------------------------------------------------------------------------
+# Rechtstreeks vanaf de host: onder hostnet luisteren alle managers in de netns van de aanroeper.
+# De namen staan niet in /etc/hosts (extra_hosts geldt alleen binnen containers), vandaar --resolve
+# op elk manager-adres.
+resolve_args() {
+  local url="$1" hostnaam poort
+  hostnaam="${url#https://}"; hostnaam="${hostnaam%%/*}"
+  poort="${hostnaam##*:}"; hostnaam="${hostnaam%%:*}"
+  printf '%s\n' --resolve "${hostnaam}:${poort}:127.0.0.1"
+}
+
+# api <manager-url> <cert> <key> <ca> <curl-args...>
+api() {
+  local url="$1" cert="$2" key="$3" ca="$4"; shift 4
+  local r args=()
+  while IFS= read -r r; do args+=("$r"); done < <(resolve_args "$url")
+
+  curl -sS --fail-with-body --noproxy '*' "${args[@]}" \
+    --cert "$cert" --key "$key" --cacert "$ca" "$@" 2>"$ERRLOG"
+}
+
+consumer_api() { api "$CONSUMER_MANAGER" "$CONSUMER_CERT" "$CONSUMER_KEY" "$CONSUMER_CA" "$@"; }
+provider_api() { api "$PROVIDER_MANAGER" "$PROVIDER_CERT" "$PROVIDER_KEY" "$PROVIDER_CA" "$@"; }
+
+# --- 1. Outway-thumbprint -----------------------------------------------------------------------
+command -v openssl >/dev/null 2>&1 || { echo "FAIL: openssl niet gevonden." >&2; exit 1; }
+[ -r "$OUTWAY_CERT" ] || { echo "FAIL: outway-cert niet leesbaar: ${OUTWAY_CERT} (pki/issue.sh gedraaid?)" >&2; exit 1; }
+
+THUMB="$(openssl x509 -in "$OUTWAY_CERT" -pubkey -noout 2>"$ERRLOG" \
+           | openssl pkey -pubin -outform DER 2>>"$ERRLOG" \
+           | openssl dgst -sha256 -r 2>>"$ERRLOG" | cut -d' ' -f1)" || THUMB=""
+case "$THUMB" in
+  [0-9a-f]*) [ "${#THUMB}" -eq 64 ] || { echo "FAIL: thumbprint is geen 64 hex-tekens: '${THUMB}'" >&2; exit 1; } ;;
+  *) echo "FAIL: kon de outway-thumbprint niet berekenen uit ${OUTWAY_CERT}: $(fsc_last_error)" >&2; exit 1 ;;
+esac
+echo "bootstrap: outway public-key-thumbprint = ${THUMB}"
+
+# --- 2. Bestaat het contract al? ----------------------------------------------------------------
+# De identiteit van een serviceConnection is de combinatie service + provider + consumer-outway +
+# thumbprint. Alleen op servicenaam matchen zou het servicePublication-contract voor dezelfde
+# dienst meetellen, dat op dezelfde manager staat en altijd matcht.
+bestaande_contracten() {  # echoot de hashes van geldige, niet-ingetrokken contracten voor deze combinatie
+  local json
+  json="$(provider_api "${PROVIDER_MANAGER}/v1/contracts")" || {
+    echo "FAIL: kon de contracten van de provider niet ophalen: $(fsc_last_error)" >&2
+    return 1
+  }
+
+  printf '%s' "$json" | jq -r \
+    --arg svc "$SERVICE_NAME" --arg prov "$PROVIDER_OIN" \
+    --arg cons "$CONSUMER_OIN" --arg thumb "$THUMB" '
+    [ .contracts[]?
+      | select(.state == "CONTRACT_STATE_VALID" and (.has_revoked // false) == false)
+      | select(any(.content.grants[]?;
+            .type == "GRANT_TYPE_SERVICE_CONNECTION"
+            and .service.name == $svc
+            and .service.peer_id == $prov
+            and .outway.peer_id == $cons
+            and .outway.identification.public_key_thumbprint == $thumb))
+      | .hash ] | .[]' 2>"$ERRLOG" || {
+    echo "FAIL: contract-JSON niet te parsen: $(fsc_last_error)" >&2
+    return 1
+  }
+}
+
+BESTAAND="$(bestaande_contracten)" || exit 1
+if [ -n "$BESTAAND" ]; then
+  AANTAL="$(printf '%s\n' "$BESTAAND" | grep -c .)"
+  echo "OK: er is al een geldig contract voor ${SERVICE_NAME} (${CONSUMER_OIN} -> ${PROVIDER_OIN})."
+
+  if [ "$AANTAL" -gt 1 ]; then
+    # Duplicaten zijn niet fataal — de outway gebruikt er één — maar ze wijzen op een eerdere run
+    # zonder deze controle, en ze stapelen zich op.
+    echo "  WAARSCHUWING: ${AANTAL} geldige contracten voor dezelfde combinatie; ruim de overtollige op." >&2
+  fi
+
+  printf '%s\n' "$BESTAAND" | sed 's/^/  contract: /'
+  echo "BOOTSTRAP OK (bestaand contract)."
+  exit 0
+fi
+
+# --- 3. Contract opstellen en indienen bij de eigen manager --------------------------------------
+IV="$(fsc_new_iv)"
+fsc_validity
+
+echo "bootstrap: serviceConnection-contract indienen bij de consumer-manager..."
+# `service.type` is verplicht op een connection-grant (de publicatie-grant defaultte 'm, deze niet),
+# en `outway.identification` is sinds OpenFSC v2.0.0 een union met `type` als discriminator — de
+# platte v1-vorm wordt niet meer geaccepteerd. `fsc_version` zetten we niet zelf: de POST neemt
+# `createContractContent`, waar dat veld ontbreekt; de manager vult 'm en neemt 'm mee in de hash.
+RESP="$(consumer_api -X POST "${CONSUMER_MANAGER}/v1/contracts" -H 'Content-Type: application/json' -d "{
+  \"contract_content\": {
+    \"iv\": \"${IV}\",
+    \"group_id\": \"${GROUP_ID}\",
+    \"hash_algorithm\": \"HASH_ALGORITHM_SHA3_512\",
+    \"created_at\": ${NBF},
+    \"validity\": { \"not_before\": $((NBF - 60)), \"not_after\": ${NAF} },
+    \"grants\": [ {
+      \"type\": \"GRANT_TYPE_SERVICE_CONNECTION\",
+      \"service\": { \"type\": \"SERVICE_TYPE_SERVICE\", \"peer_id\": \"${PROVIDER_OIN}\", \"name\": \"${SERVICE_NAME}\" },
+      \"outway\": {
+        \"peer_id\": \"${CONSUMER_OIN}\",
+        \"identification\": {
+          \"type\": \"OUTWAY_IDENTIFICATION_TYPE_PUBLIC_KEY_THUMBPRINT\",
+          \"public_key_thumbprint\": \"${THUMB}\"
+        }
+      }
+    } ]
+  }
+}")" || { echo "FAIL: POST /v1/contracts geweigerd: ${RESP:-<leeg>} $(fsc_last_error)" >&2; exit 1; }
+
+HASH="$(printf '%s' "$RESP" | jq -r '.content_hash // empty' 2>/dev/null)"
+[ -n "$HASH" ] || { echo "FAIL: respons zonder content_hash (formaat geweigerd?): ${RESP}" >&2; exit 1; }
+echo "  consumer-handtekening gezet; mesh-sync gestart; content_hash=${HASH}"
+
+# --- 4. Provider accepteert ----------------------------------------------------------------------
+contract_zichtbaar() {
+  provider_api "${PROVIDER_MANAGER}/v1/contracts" 2>/dev/null \
+    | jq -e --arg h "$HASH" 'any(.contracts[]?; .hash == $h)' >/dev/null 2>&1
+}
+
+echo "bootstrap: wachten tot het contract naar de provider gesynct is..."
+elapsed=0; gesynct=0
+while [ "$elapsed" -lt "$SYNC_TIMEOUT" ]; do
+  if contract_zichtbaar; then gesynct=1; break; fi
+
+  sleep "$SYNC_INTERVAL"; elapsed=$((elapsed + SYNC_INTERVAL))
+  echo "  ...nog niet gesynct (${elapsed}s)" >&2
+done
+
+[ "$gesynct" -eq 1 ] || {
+  echo "FAIL: contract ${HASH} is niet binnen ${SYNC_TIMEOUT}s naar de provider gesynct." >&2
+  exit 1
+}
+
+echo "bootstrap: provider accepteert..."
+provider_api -X PUT "${PROVIDER_MANAGER}/v1/contracts/${HASH}/accept" -H 'Content-Type: application/json' >/dev/null \
+  || { echo "FAIL: PUT accept (${HASH}) geweigerd: $(fsc_last_error)" >&2; exit 1; }
+echo "  provider-handtekening gezet."
+
+# --- 5. Wachten tot de consumer het contract als geldig ziet --------------------------------------
+consumer_state() {
+  consumer_api "${CONSUMER_MANAGER}/v1/contracts" 2>/dev/null \
+    | jq -r --arg h "$HASH" 'first(.contracts[]? | select(.hash == $h) | .state) // "onbekend"' 2>/dev/null \
+    || echo onbekend
+}
+
+wacht_op_valid() {
+  local elapsed=0
+  while [ "$elapsed" -lt "$SYNC_TIMEOUT" ]; do
+    [ "$(consumer_state)" = "CONTRACT_STATE_VALID" ] && return 0
+
+    sleep "$SYNC_INTERVAL"; elapsed=$((elapsed + SYNC_INTERVAL))
+    echo "  ...contract nog niet 'valid' op de consumer (${elapsed}s)" >&2
+  done
+  return 1
+}
+
+echo "bootstrap: wachten tot de consumer het contract als geldig ziet..."
+if ! wacht_op_valid; then
+  # De accept-handtekening wordt best-effort naar de consumer gepusht; strandt die, dan blijft het
+  # contract daar `proposed` en ziet de outway de grant nooit. Dit is het canonieke herstel.
+  echo "bootstrap: accept-handtekening opnieuw laten distribueren..." >&2
+  provider_api -X POST \
+    "${PROVIDER_MANAGER}/v1/contracts/${HASH}/distributions/${CONSUMER_OIN}/DISTRIBUTION_ACTION_SUBMIT_ACCEPT_SIGNATURE/retry" \
+    -H 'Content-Type: application/json' >/dev/null \
+    || echo "  WARN: her-distributie gaf een fout: $(fsc_last_error)" >&2
+
+  wacht_op_valid || {
+    echo "FAIL: contract ${HASH} werd niet 'valid' op de consumer (state: $(consumer_state))." >&2
+    exit 1
+  }
+fi
+
+echo "OK: contract ${HASH} is wederzijds ondertekend en geldig."
+echo "BOOTSTRAP OK."

--- a/demo/environment/federatie/contracts/bootstrap.sh
+++ b/demo/environment/federatie/contracts/bootstrap.sh
@@ -1,301 +1,151 @@
 #!/usr/bin/env bash
 # Zet idempotent een geldig, wederzijds ondertekend ServiceConnectionGrant-contract op tussen een
-# consumer-peer en een provider-peer.
+# consumer-peer en een provider-peer, door de twee helften achter elkaar te draaien.
 #
-# Generiek: alle peers, adressen en certificaten komen uit env. `fbs-contracten.sh` ernaast vult
-# die in voor de FBS-peers en loopt over de magazijnen.
+# Generiek: alle peers, adressen en certificaten komen uit env. `fbs-contracten.sh` ernaast vult die
+# in voor de FBS-peers en loopt over de magazijnen.
 #
-# Stroom (OpenFSC Manager Internal-API):
-#   1. bereken de SPKI-SHA256-thumbprint van het GROUP-cert van de consumer-outway. Dat is waarmee
-#      de outway zich naar de provider-inway identificeert, en het is stabiel bij cert-rotatie
-#      binnen hetzelfde sleutelpaar;
-#   2. bestaat er al een geldig contract voor precies deze combinatie? Zo ja, en staat het ook al
-#      geldig bij de consumer: klaar. Staat het alleen bij de provider geldig (de accept-push naar
-#      de consumer kan stranden, zie stap 5), dan wordt hier hetzelfde herstel toegepast als bij een
-#      verse bootstrap, zónder opnieuw te posten;
-#   3. POST /v1/contracts op de EIGEN manager. Die tekent server-side namens de consumer en synct
-#      het contract via de mesh naar de provider;
-#   4. poll de provider tot het contract er is, dan PUT /v1/contracts/{hash}/accept op de
-#      PROVIDER-manager. Expliciet, want `AUTO_SIGN_GRANTS` dekt alleen (delegated)servicePublication;
-#   5. poll tot de CONSUMER het contract als `CONTRACT_STATE_VALID` ziet. De provider-accept wordt
-#      async naar de consumer gepusht met een begrensde backoff en zonder cron-retry; landt die
-#      niet, dan blijft het contract daar `proposed` en ziet de outway de grant nooit. Blijft het
-#      hangen, dan forceren we de her-distributie.
+# WAAROM TWEE HELFTEN. Op ZAD isoleert de tenant-baseline-NetworkPolicy per deployment en heeft de
+# interne manager-API geen route: één proces dat beide managers aanspreekt bestaat daar niet. De
+# helften praten daarom elk met precies één manager en het contract kruist via de FSC-mesh. Dit
+# script is de lokale aanroeper van diezelfde twee helften — niet een aparte, eenvoudigere variant.
+# Wat hier lokaal getoetst wordt, is dus de code die op ZAD draait.
 #
-# IDEMPOTENTIE ZONDER STATE-FILE. De generieke variant in `moza-fsc-testnet` onthoudt de
-# content-hash van het geaccepteerde contract in een bestand. Dat werkt op een ontwikkelmachine,
-# maar niet in een deploy: elke job start met een lege schijf, dus elke run maakt er nóg een
-# geldig contract bij. Deze variant leidt het bestaan af uit de contracten zelf — service, provider,
-# consumer-outway en thumbprint samen zijn de identiteit — zodat een herhaalde run een no-op is,
-# waar hij ook draait.
+# De scheiding wordt hier afgedwongen en niet alleen afgesproken: elke helft start met `env -u` op
+# de adres- en certificaat-variabelen van de overkant. Zou er ooit een call naar de andere manager
+# in sluipen, dan faalt die hier meteen in plaats van pas op ZAD.
 #
-# De existence-check (stap 2) en de POST (stap 3) zijn niet atomair: twee gelijktijdige of
-# herhaalde runs kunnen allebei een nieuw contract posten. Dat wordt hier niet voorkomen (dat vergt
-# een lock, en dus weer state), maar wel zelf-herstellend gemaakt: bij meer dan één geldig contract
-# voor dezelfde combinatie trekt de eerstvolgende run de overtollige in via
-# `PUT /v1/contracts/{hash}/revoke` en gebruikt verder altijd het (sorteer-)eerste hash — stabiel
-# over runs heen, ook als de volgorde van de manager-API zelf niet gegarandeerd stabiel is.
+# Stroom:
+#   1. consumer-helft: contract indienen bij de eigen manager (of vaststellen dat het er al is);
+#   2. provider-helft: het binnengekomen contract tekenen, na de autorisatietoets;
+#   3. consumer-helft opnieuw: vaststellen dat het contract nu geldig is.
+#
+# Bestaat het contract al, dan eindigt stap 1 meteen op 0 en zijn de andere twee niet nodig. Bij een
+# verse bootstrap eindigt hij op 3 ("ingediend, nog niet getekend") — de normale tussenstand, geen
+# fout. Zie de moduledocs van de twee helften voor de details per kant.
+#
+# Uitgangen: 0 = contract staat, 2 = configuratie deugt niet (doorgegeven uit de helft die het
+# vaststelde), 1 = al het overige.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
-ENVDIR="$(cd "${HERE}/../.." && pwd)"
 
+HERE_LIB="${FSC_LIBDIR:-$(cd "${HERE}/../../lib" && pwd)}"
 # shellcheck source=../../lib/fsc-harness.sh
-. "${ENVDIR}/lib/fsc-harness.sh"
+. "${HERE_LIB}/fsc-harness.sh"
+# shellcheck source=../../lib/fsc-contract.sh
+. "${HERE_LIB}/fsc-contract.sh"
 
-fsc_errlog_init
-fsc_have_jq
+CONSUMER_OIN="$(fsc_env_vereist FSC_CONSUMER_OIN 'de OIN van de afnemende peer')"
+SERVICE_NAME="$(fsc_env_vereist FSC_SERVICE_NAME 'de dienst die afgenomen wordt')"
 
-# --- Parameters ---------------------------------------------------------------------------------
-CONSUMER_OIN="${FSC_CONSUMER_OIN:?zet FSC_CONSUMER_OIN}"
-PROVIDER_OIN="${FSC_PROVIDER_OIN:?zet FSC_PROVIDER_OIN}"
-SERVICE_NAME="${FSC_SERVICE_NAME:?zet FSC_SERVICE_NAME}"
-GROUP_ID="${FSC_GROUP_ID:-moza-fbs-test}"
+# De variabelen die de ene helft nooit mag zien. Alleen adressen en sleutelmateriaal: de OIN's zijn
+# publieke organisatienummers en beide helften hebben ze nodig om te weten waar het contract over
+# gaat.
+PROVIDER_GEHEIM=(FSC_PROVIDER_MANAGER FSC_PROVIDER_CERT FSC_PROVIDER_KEY FSC_PROVIDER_CA FSC_PROVIDER_ADRES)
+# Het outway-cert hoort óók bij de consumer-kant: het is het group-cert van díé peer, en de
+# provider-helft heeft er niets mee te maken.
+CONSUMER_GEHEIM=(FSC_CONSUMER_MANAGER FSC_CONSUMER_CERT FSC_CONSUMER_KEY FSC_CONSUMER_CA FSC_CONSUMER_ADRES
+                 FSC_OUTWAY_CERT FSC_OUTWAY_THUMBPRINT)
 
-# Het GROUP-cert van de consumer-outway (host-pad). Bewust het group- en niet het internal-cert:
-# de outway registreert bij zijn controller met zijn group-cert en stuurt datzelfde thumbprint naar
-# GetOutwayServices, waar de manager het tegen de grant matcht.
-OUTWAY_CERT="${FSC_OUTWAY_CERT:?zet FSC_OUTWAY_CERT}"
+# zonder <var...> -- <commando...>: draai het commando zonder die variabelen in zijn omgeving.
+zonder() {
+  local args=()
+  while [ "$1" != -- ]; do args+=(-u "$1"); shift; done
+  shift
 
-CONSUMER_MANAGER="${FSC_CONSUMER_MANAGER:?zet FSC_CONSUMER_MANAGER}"
-CONSUMER_CERT="${FSC_CONSUMER_CERT:?zet FSC_CONSUMER_CERT}"
-CONSUMER_KEY="${FSC_CONSUMER_KEY:?zet FSC_CONSUMER_KEY}"
-CONSUMER_CA="${FSC_CONSUMER_CA:?zet FSC_CONSUMER_CA}"
-
-PROVIDER_MANAGER="${FSC_PROVIDER_MANAGER:?zet FSC_PROVIDER_MANAGER}"
-PROVIDER_CERT="${FSC_PROVIDER_CERT:?zet FSC_PROVIDER_CERT}"
-PROVIDER_KEY="${FSC_PROVIDER_KEY:?zet FSC_PROVIDER_KEY}"
-PROVIDER_CA="${FSC_PROVIDER_CA:?zet FSC_PROVIDER_CA}"
-
-SYNC_TIMEOUT="${FSC_SYNC_TIMEOUT:-20}"
-SYNC_INTERVAL="${FSC_SYNC_INTERVAL:-2}"
-
-# De adressen worden geconcateneerd tot curl's URL-argument; een waarde die met `-` begint zou curl
-# als optie lezen (`-K/pad` maakt er een config-file-lees van).
-for _adres in "$CONSUMER_MANAGER" "$PROVIDER_MANAGER"; do
-  case "$_adres" in
-    https://*) ;;
-    *) echo "FAIL: manager-adres moet met https:// beginnen: '${_adres}'" >&2; exit 2 ;;
-  esac
-done
-
-[ "$HAVE_JQ" -eq 1 ] || {
-  echo "FAIL: jq is vereist. De idempotentie leunt op het uitlezen van de contract-JSON; zonder jq" >&2
-  echo "  zou elke run een nieuw contract aanmaken in plaats van een bestaand te herkennen." >&2
-  exit 1
+  env "${args[@]}" "$@"
 }
 
-# --- curl-helpers -------------------------------------------------------------------------------
-# Rechtstreeks vanaf de host: onder hostnet luisteren alle managers in de netns van de aanroeper.
-# De namen staan niet in /etc/hosts (extra_hosts geldt alleen binnen containers), vandaar --resolve
-# op elk manager-adres.
-#
-# Welk adres dat is, verschilt per opstelling: in een standalone harness luistert alles op
-# 127.0.0.1, in de federatie heeft elke component een eigen adres. Vandaar per kant overrulebaar,
-# met de standalone-waarde als default.
-CONSUMER_ADRES="${FSC_CONSUMER_ADRES:-127.0.0.1}"
-PROVIDER_ADRES="${FSC_PROVIDER_ADRES:-127.0.0.1}"
-
-resolve_args() {
-  local url="$1" adres="$2" hostnaam poort
-  hostnaam="${url#https://}"; hostnaam="${hostnaam%%/*}"
-  poort="${hostnaam##*:}"; hostnaam="${hostnaam%%:*}"
-  printf '%s\n' --resolve "${hostnaam}:${poort}:${adres}"
+consumer_helft() {
+  zonder "${PROVIDER_GEHEIM[@]}" -- "${HERE}/bootstrap-consumer.sh"
 }
 
-# api <manager-url> <cert> <key> <ca> <adres> <curl-args...>
-api() {
-  local url="$1" cert="$2" key="$3" ca="$4" adres="$5"; shift 5
-  local r args=()
-  while IFS= read -r r; do args+=("$r"); done < <(resolve_args "$url" "$adres")
-
-  curl -sS --fail-with-body --noproxy '*' "${args[@]}" \
-    --cert "$cert" --key "$key" --cacert "$ca" "$@" 2>"$ERRLOG"
+provider_helft() {
+  # De allowlist van de provider is hier precies één dienst en één consumer: dit script zet één
+  # contract op en heeft geen reden een bredere toestemming te openen. Op ZAD staat de lijst in de
+  # component-env en kan hij meer dan één regel dragen.
+  zonder "${CONSUMER_GEHEIM[@]}" -- \
+    FSC_DIENSTEN="$SERVICE_NAME" FSC_CONSUMERS="$CONSUMER_OIN" \
+    "${HERE}/bootstrap-provider.sh"
 }
 
-consumer_api() { api "$CONSUMER_MANAGER" "$CONSUMER_CERT" "$CONSUMER_KEY" "$CONSUMER_CA" "$CONSUMER_ADRES" "$@"; }
-provider_api() { api "$PROVIDER_MANAGER" "$PROVIDER_CERT" "$PROVIDER_KEY" "$PROVIDER_CA" "$PROVIDER_ADRES" "$@"; }
+# --- 1. Consumer dient in -------------------------------------------------------------------------
+rc=0
+consumer_helft || rc=$?
 
-# --- 1. Outway-thumbprint -----------------------------------------------------------------------
-command -v openssl >/dev/null 2>&1 || { echo "FAIL: openssl niet gevonden." >&2; exit 1; }
-[ -r "$OUTWAY_CERT" ] || { echo "FAIL: outway-cert niet leesbaar: ${OUTWAY_CERT} (pki/issue.sh gedraaid?)" >&2; exit 1; }
-
-THUMB="$(fsc_outway_thumbprint "$OUTWAY_CERT")" \
-  || { echo "FAIL: kon de outway-thumbprint niet berekenen uit ${OUTWAY_CERT}: $(fsc_last_error)" >&2; exit 1; }
-echo "bootstrap: outway public-key-thumbprint = ${THUMB}"
-
-# --- Sync-helpers (gebruikt door zowel de existence-check als de verse bootstrap-flow) -----------
-VALID_STATE=contract_state_valid
-
-# contract_zichtbaar <hash>: staat dit contract al in de contractenlijst van de provider?
-contract_zichtbaar() {
-  local hash="$1" rc
-  provider_api "${PROVIDER_MANAGER}/v1/contracts" 2>"$ERRLOG" \
-    | jq -e --arg h "$hash" 'any(.contracts[]?; .hash == $h)' >/dev/null 2>>"$ERRLOG"
-  rc=$?
-  fsc_warn_errlog "sync-poll (provider)"
-  return "$rc"
-}
-
-# consumer_state <hash>: manager-state van dit contract op de consumer, of "onbekend".
-consumer_state() {
-  local hash="$1" json rc state
-  json="$(consumer_api "${CONSUMER_MANAGER}/v1/contracts" 2>"$ERRLOG")"
-  rc=$?
-  fsc_warn_errlog "state-poll (consumer)"
-  [ "$rc" -eq 0 ] || { echo onbekend; return; }
-
-  state="$(fsc_contract_state "$json" "$hash")"
-  [ "$state" = unknown ] && echo onbekend || printf '%s\n' "$state"
-}
-
-# wacht_op_valid <hash>: pollt tot de consumer het contract als geldig ziet, of tot SYNC_TIMEOUT.
-wacht_op_valid() {
-  local hash="$1" elapsed=0
-  while [ "$elapsed" -lt "$SYNC_TIMEOUT" ]; do
-    [ "$(consumer_state "$hash")" = "$VALID_STATE" ] && return 0
-
-    sleep "$SYNC_INTERVAL"; elapsed=$((elapsed + SYNC_INTERVAL))
-    echo "  ...contract nog niet 'valid' op de consumer (${elapsed}s)" >&2
-  done
-  return 1
-}
-
-# zorg_dat_consumer_gesynct <hash>: wacht tot de consumer het contract geldig ziet; forceert één
-# keer de her-distributie van de accept-handtekening als dat niet vanzelf lukt binnen SYNC_TIMEOUT
-# (het canonieke herstel voor een gestrande best-effort-push, zie de moduledoc).
-zorg_dat_consumer_gesynct() {
-  local hash="$1"
-  wacht_op_valid "$hash" && return 0
-
-  echo "bootstrap: accept-handtekening opnieuw laten distribueren..." >&2
-  provider_api -X PUT \
-    "${PROVIDER_MANAGER}/v1/contracts/${hash}/distributions/${CONSUMER_OIN}/DISTRIBUTION_ACTION_SUBMIT_ACCEPT_SIGNATURE/retry" \
-    -H 'Content-Type: application/json' >/dev/null \
-    || echo "  WARN: her-distributie gaf een fout: $(fsc_last_error)" >&2
-
-  wacht_op_valid "$hash"
-}
-
-# --- 2. Bestaat het contract al? ------------------------------------------------------------------
-# De identiteit van een serviceConnection is de combinatie service + provider + consumer-outway +
-# thumbprint. Alleen op servicenaam matchen zou het servicePublication-contract voor dezelfde
-# dienst meetellen, dat op dezelfde manager staat en altijd matcht.
-bestaande_contracten() {  # hashes van geldige, niet-ingetrokken contracten voor deze combinatie, gesorteerd
-  local json
-  json="$(provider_api "${PROVIDER_MANAGER}/v1/contracts")" || {
-    echo "FAIL: kon de contracten van de provider niet ophalen: $(fsc_last_error)" >&2
-    return 1
-  }
-
-  # Met eigen melding: `fsc_grant_actief` eindigt op `jq … 2>/dev/null` en heeft geen
-  # fallback-waarde. Antwoordt de manager met 200 maar zonder geldige JSON (een proxy-foutpagina,
-  # een afgekapt antwoord), dan faalt deze pipeline onder `pipefail` en zou de aanroeper zonder
-  # deze tak zwijgend afbreken — de laag erboven meldt dan alleen "contract niet opgezet".
-  fsc_grant_actief "$json" "$SERVICE_NAME" "$PROVIDER_OIN" "$CONSUMER_OIN" "$THUMB" | sort || {
-    echo "FAIL: de contractenlijst van de provider is niet te lezen — geen geldige JSON?" >&2
-    return 1
-  }
-}
-
-BESTAAND="$(bestaande_contracten)" || exit 1
-if [ -n "$BESTAAND" ]; then
-  AANTAL="$(printf '%s\n' "$BESTAAND" | grep -c .)"
-  HASH="$(printf '%s\n' "$BESTAAND" | head -n1)"
-  echo "OK: er is al een geldig contract voor ${SERVICE_NAME} (${CONSUMER_OIN} -> ${PROVIDER_OIN})."
-  printf '%s\n' "$BESTAAND" | sed 's/^/  contract: /'
-
-  if [ "$AANTAL" -gt 1 ]; then
-    # Kan ontstaan doordat deze existence-check en de POST (stap 3) niet atomair zijn: twee
-    # gelijktijdige of herhaalde runs kunnen allebei een nieuw contract posten. De outway gebruikt
-    # er sowieso maar één — het gesorteerd-eerste hash hierboven — maar de rest ruimt zichzelf hier
-    # op, zodat een volgende run weer bij één contract uitkomt.
-    echo "  WAARSCHUWING: ${AANTAL} geldige contracten voor dezelfde combinatie; trek de overtollige in." >&2
-    printf '%s\n' "$BESTAAND" | tail -n +2 | while IFS= read -r dup; do
-      provider_api -X PUT "${PROVIDER_MANAGER}/v1/contracts/${dup}/revoke" \
-          -H 'Content-Type: application/json' >/dev/null 2>"$ERRLOG" \
-        && echo "  ingetrokken: ${dup}" >&2 \
-        || echo "  WARN: kon duplicaat ${dup} niet intrekken: $(fsc_last_error)" >&2
-    done
-  fi
-
-  if [ "$(consumer_state "$HASH")" = "$VALID_STATE" ]; then
-    echo "BOOTSTRAP OK (bestaand contract)."
-    exit 0
-  fi
-
-  # Geldig op de provider, maar (nog) niet gesynct naar de consumer — zonder deze controle zou een
-  # retry hier ten onrechte "klaar" melden terwijl de outway de grant nooit ziet (zie moduledoc).
-  echo "bootstrap: contract ${HASH} is geldig op de provider maar nog niet gesynct naar de consumer..." >&2
-  zorg_dat_consumer_gesynct "$HASH" || {
-    echo "FAIL: contract ${HASH} werd niet 'valid' op de consumer (state: $(consumer_state "$HASH"))." >&2
-    exit 1
-  }
-  echo "OK: contract ${HASH} is alsnog wederzijds gesynct."
-  echo "BOOTSTRAP OK (bestaand contract, opnieuw gesynct)."
+if [ "$rc" -eq 0 ]; then
+  echo "BOOTSTRAP OK (bestaand contract)."
   exit 0
 fi
 
-# --- 3. Contract opstellen en indienen bij de eigen manager --------------------------------------
-IV="$(fsc_new_iv)"
-fsc_validity
-
-echo "bootstrap: serviceConnection-contract indienen bij de consumer-manager..."
-# `service.type` is verplicht op een connection-grant (de publicatie-grant defaultte 'm, deze niet),
-# en `outway.identification` is sinds OpenFSC v2.0.0 een union met `type` als discriminator — de
-# platte v1-vorm wordt niet meer geaccepteerd. `fsc_version` zetten we niet zelf: de POST neemt
-# `createContractContent`, waar dat veld ontbreekt; de manager vult 'm en neemt 'm mee in de hash.
-RESP="$(consumer_api -X POST "${CONSUMER_MANAGER}/v1/contracts" -H 'Content-Type: application/json' -d "{
-  \"contract_content\": {
-    \"iv\": \"${IV}\",
-    \"group_id\": \"${GROUP_ID}\",
-    \"hash_algorithm\": \"HASH_ALGORITHM_SHA3_512\",
-    \"created_at\": ${NBF},
-    \"validity\": { \"not_before\": $((NBF - 60)), \"not_after\": ${NAF} },
-    \"grants\": [ {
-      \"type\": \"GRANT_TYPE_SERVICE_CONNECTION\",
-      \"service\": { \"type\": \"SERVICE_TYPE_SERVICE\", \"peer_id\": \"${PROVIDER_OIN}\", \"name\": \"${SERVICE_NAME}\" },
-      \"outway\": {
-        \"peer_id\": \"${CONSUMER_OIN}\",
-        \"identification\": {
-          \"type\": \"OUTWAY_IDENTIFICATION_TYPE_PUBLIC_KEY_THUMBPRINT\",
-          \"public_key_thumbprint\": \"${THUMB}\"
-        }
-      }
-    } ]
-  }
-}")" || { echo "FAIL: POST /v1/contracts geweigerd: ${RESP:-<leeg>} $(fsc_last_error)" >&2; exit 1; }
-
-HASH="$(printf '%s' "$RESP" | jq -r '.content_hash // empty' 2>/dev/null)" || HASH=""
-[ -n "$HASH" ] || { echo "FAIL: respons zonder content_hash (formaat geweigerd?): ${RESP}" >&2; exit 1; }
-echo "  consumer-handtekening gezet; mesh-sync gestart; content_hash=${HASH}"
-
-# --- 4. Provider accepteert ----------------------------------------------------------------------
-echo "bootstrap: wachten tot het contract naar de provider gesynct is..."
-elapsed=0; gesynct=0
-while [ "$elapsed" -lt "$SYNC_TIMEOUT" ]; do
-  if contract_zichtbaar "$HASH"; then gesynct=1; break; fi
-
-  sleep "$SYNC_INTERVAL"; elapsed=$((elapsed + SYNC_INTERVAL))
-  echo "  ...nog niet gesynct (${elapsed}s)" >&2
-done
-
-[ "$gesynct" -eq 1 ] || {
-  echo "FAIL: contract ${HASH} is niet binnen ${SYNC_TIMEOUT}s naar de provider gesynct." >&2
-  exit 1
+[ "$rc" -eq 3 ] || {
+  echo "FAIL: de consumer-helft brak af (exit ${rc})." >&2
+  exit "$rc"
 }
 
-echo "bootstrap: provider accepteert..."
-provider_api -X PUT "${PROVIDER_MANAGER}/v1/contracts/${HASH}/accept" -H 'Content-Type: application/json' >/dev/null \
-  || { echo "FAIL: PUT accept (${HASH}) geweigerd: $(fsc_last_error)" >&2; exit 1; }
-echo "  provider-handtekening gezet."
+# --- 2. Provider tekent ---------------------------------------------------------------------------
+echo
+rc=0
+provider_helft || rc=$?
 
-# --- 5. Wachten tot de consumer het contract als geldig ziet --------------------------------------
-echo "bootstrap: wachten tot de consumer het contract als geldig ziet..."
-zorg_dat_consumer_gesynct "$HASH" || {
-  echo "FAIL: contract ${HASH} werd niet 'valid' op de consumer (state: $(consumer_state "$HASH"))." >&2
-  exit 1
+# 4 = er lagen contracten die de autorisatietoets niet haalden. Die melding staat al in de log van
+# de helft zelf; hier telt alleen dat er niet getekend is, en stap 3 stelt dat vervolgens vast.
+if [ "$rc" -ne 0 ] && [ "$rc" -ne 4 ]; then
+  echo "FAIL: de provider-helft brak af (exit ${rc})." >&2
+  exit "$rc"
+fi
+
+# --- 3. Consumer stelt vast dat het contract geldig is --------------------------------------------
+# Het wachten staat hier en niet in de consumer-helft. Die weet niet of de provider al getekend
+# heeft, dus daar zou elke aanroep blind pollen — ook de allereerste, waar de provider gegarandeerd
+# nog niet langs is geweest. Deze aanroeper weet het wél: stap 2 is net klaar. Op ZAD vervult de
+# lus om de helften heen dezelfde rol.
+wacht_tot_geldig() {
+  local timeout="${FSC_SYNC_TIMEOUT:-20}" interval="${FSC_SYNC_INTERVAL:-2}" elapsed=0 uitkomst
+
+  # Interval 0 zou `elapsed` nooit laten groeien en er een tight loop van maken.
+  [ "$interval" -gt 0 ] || interval=1
+
+  while :; do
+    uitkomst=0
+    consumer_helft || uitkomst=$?
+
+    # Alleen 3 ("ingediend, nog niet getekend") is het wachten waard; 0 is klaar en de rest is fout.
+    [ "$uitkomst" -eq 3 ] || return "$uitkomst"
+    [ "$elapsed" -lt "$timeout" ] || return 3
+
+    sleep "$interval"; elapsed=$((elapsed + interval))
+    echo "  ...contract nog niet geldig bij de consumer (${elapsed}s)" >&2
+  done
 }
 
-echo "OK: contract ${HASH} is wederzijds ondertekend en geldig."
+echo
+rc=0
+wacht_tot_geldig || rc=$?
+
+if [ "$rc" -eq 3 ]; then
+  # De provider heeft getekend, dus als de consumer het contract nog niet geldig ziet is de
+  # accept-handtekening onderweg blijven steken. Dat is precies het geval waar de provider-helft
+  # zijn her-distributie voor heeft; die is al één keer gestuurd, dus hier nog eens forceren.
+  echo
+  echo "bootstrap: contract nog niet geldig bij de consumer; her-distributie forceren..." >&2
+  rc=0
+  FSC_FORCEER_DISTRIBUTIE=1 provider_helft || rc=$?
+
+  if [ "$rc" -ne 0 ] && [ "$rc" -ne 4 ]; then
+    echo "FAIL: her-distributie via de provider-helft brak af (exit ${rc})." >&2
+    exit "$rc"
+  fi
+
+  echo
+  rc=0
+  wacht_tot_geldig || rc=$?
+fi
+
+[ "$rc" -eq 0 ] || {
+  echo "FAIL: het contract werd niet geldig bij de consumer (exit ${rc})." >&2
+  exit "$rc"
+}
+
 echo "BOOTSTRAP OK."

--- a/demo/environment/federatie/contracts/bootstrap.sh
+++ b/demo/environment/federatie/contracts/bootstrap.sh
@@ -9,7 +9,10 @@
 #   1. bereken de SPKI-SHA256-thumbprint van het GROUP-cert van de consumer-outway. Dat is waarmee
 #      de outway zich naar de provider-inway identificeert, en het is stabiel bij cert-rotatie
 #      binnen hetzelfde sleutelpaar;
-#   2. bestaat er al een geldig contract voor precies deze combinatie? -> klaar;
+#   2. bestaat er al een geldig contract voor precies deze combinatie? Zo ja, en staat het ook al
+#      geldig bij de consumer: klaar. Staat het alleen bij de provider geldig (de accept-push naar
+#      de consumer kan stranden, zie stap 5), dan wordt hier hetzelfde herstel toegepast als bij een
+#      verse bootstrap, zónder opnieuw te posten;
 #   3. POST /v1/contracts op de EIGEN manager. Die tekent server-side namens de consumer en synct
 #      het contract via de mesh naar de provider;
 #   4. poll de provider tot het contract er is, dan PUT /v1/contracts/{hash}/accept op de
@@ -25,6 +28,13 @@
 # geldig contract bij. Deze variant leidt het bestaan af uit de contracten zelf — service, provider,
 # consumer-outway en thumbprint samen zijn de identiteit — zodat een herhaalde run een no-op is,
 # waar hij ook draait.
+#
+# De existence-check (stap 2) en de POST (stap 3) zijn niet atomair: twee gelijktijdige of
+# herhaalde runs kunnen allebei een nieuw contract posten. Dat wordt hier niet voorkomen (dat vergt
+# een lock, en dus weer state), maar wel zelf-herstellend gemaakt: bij meer dan één geldig contract
+# voor dezelfde combinatie trekt de eerstvolgende run de overtollige in via
+# `PUT /v1/contracts/{hash}/revoke` en gebruikt verder altijd het (sorteer-)eerste hash — stabiel
+# over runs heen, ook als de volgorde van de manager-API zelf niet gegarandeerd stabiel is.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
@@ -103,56 +113,112 @@ provider_api() { api "$PROVIDER_MANAGER" "$PROVIDER_CERT" "$PROVIDER_KEY" "$PROV
 command -v openssl >/dev/null 2>&1 || { echo "FAIL: openssl niet gevonden." >&2; exit 1; }
 [ -r "$OUTWAY_CERT" ] || { echo "FAIL: outway-cert niet leesbaar: ${OUTWAY_CERT} (pki/issue.sh gedraaid?)" >&2; exit 1; }
 
-THUMB="$(openssl x509 -in "$OUTWAY_CERT" -pubkey -noout 2>"$ERRLOG" \
-           | openssl pkey -pubin -outform DER 2>>"$ERRLOG" \
-           | openssl dgst -sha256 -r 2>>"$ERRLOG" | cut -d' ' -f1)" || THUMB=""
-case "$THUMB" in
-  [0-9a-f]*) [ "${#THUMB}" -eq 64 ] || { echo "FAIL: thumbprint is geen 64 hex-tekens: '${THUMB}'" >&2; exit 1; } ;;
-  *) echo "FAIL: kon de outway-thumbprint niet berekenen uit ${OUTWAY_CERT}: $(fsc_last_error)" >&2; exit 1 ;;
-esac
+THUMB="$(fsc_outway_thumbprint "$OUTWAY_CERT")" \
+  || { echo "FAIL: kon de outway-thumbprint niet berekenen uit ${OUTWAY_CERT}: $(fsc_last_error)" >&2; exit 1; }
 echo "bootstrap: outway public-key-thumbprint = ${THUMB}"
 
-# --- 2. Bestaat het contract al? ----------------------------------------------------------------
+# --- Sync-helpers (gebruikt door zowel de existence-check als de verse bootstrap-flow) -----------
+VALID_STATE=contract_state_valid
+
+# contract_zichtbaar <hash>: staat dit contract al in de contractenlijst van de provider?
+contract_zichtbaar() {
+  local hash="$1" rc
+  provider_api "${PROVIDER_MANAGER}/v1/contracts" 2>"$ERRLOG" \
+    | jq -e --arg h "$hash" 'any(.contracts[]?; .hash == $h)' >/dev/null 2>>"$ERRLOG"
+  rc=$?
+  fsc_warn_errlog "sync-poll (provider)"
+  return "$rc"
+}
+
+# consumer_state <hash>: manager-state van dit contract op de consumer, of "onbekend".
+consumer_state() {
+  local hash="$1" json rc state
+  json="$(consumer_api "${CONSUMER_MANAGER}/v1/contracts" 2>"$ERRLOG")"
+  rc=$?
+  fsc_warn_errlog "state-poll (consumer)"
+  [ "$rc" -eq 0 ] || { echo onbekend; return; }
+
+  state="$(fsc_contract_state "$json" "$hash")"
+  [ "$state" = unknown ] && echo onbekend || printf '%s\n' "$state"
+}
+
+# wacht_op_valid <hash>: pollt tot de consumer het contract als geldig ziet, of tot SYNC_TIMEOUT.
+wacht_op_valid() {
+  local hash="$1" elapsed=0
+  while [ "$elapsed" -lt "$SYNC_TIMEOUT" ]; do
+    [ "$(consumer_state "$hash")" = "$VALID_STATE" ] && return 0
+
+    sleep "$SYNC_INTERVAL"; elapsed=$((elapsed + SYNC_INTERVAL))
+    echo "  ...contract nog niet 'valid' op de consumer (${elapsed}s)" >&2
+  done
+  return 1
+}
+
+# zorg_dat_consumer_gesynct <hash>: wacht tot de consumer het contract geldig ziet; forceert één
+# keer de her-distributie van de accept-handtekening als dat niet vanzelf lukt binnen SYNC_TIMEOUT
+# (het canonieke herstel voor een gestrande best-effort-push, zie de moduledoc).
+zorg_dat_consumer_gesynct() {
+  local hash="$1"
+  wacht_op_valid "$hash" && return 0
+
+  echo "bootstrap: accept-handtekening opnieuw laten distribueren..." >&2
+  provider_api -X PUT \
+    "${PROVIDER_MANAGER}/v1/contracts/${hash}/distributions/${CONSUMER_OIN}/DISTRIBUTION_ACTION_SUBMIT_ACCEPT_SIGNATURE/retry" \
+    -H 'Content-Type: application/json' >/dev/null \
+    || echo "  WARN: her-distributie gaf een fout: $(fsc_last_error)" >&2
+
+  wacht_op_valid "$hash"
+}
+
+# --- 2. Bestaat het contract al? ------------------------------------------------------------------
 # De identiteit van een serviceConnection is de combinatie service + provider + consumer-outway +
 # thumbprint. Alleen op servicenaam matchen zou het servicePublication-contract voor dezelfde
 # dienst meetellen, dat op dezelfde manager staat en altijd matcht.
-bestaande_contracten() {  # echoot de hashes van geldige, niet-ingetrokken contracten voor deze combinatie
+bestaande_contracten() {  # hashes van geldige, niet-ingetrokken contracten voor deze combinatie, gesorteerd
   local json
   json="$(provider_api "${PROVIDER_MANAGER}/v1/contracts")" || {
     echo "FAIL: kon de contracten van de provider niet ophalen: $(fsc_last_error)" >&2
     return 1
   }
 
-  printf '%s' "$json" | jq -r \
-    --arg svc "$SERVICE_NAME" --arg prov "$PROVIDER_OIN" \
-    --arg cons "$CONSUMER_OIN" --arg thumb "$THUMB" '
-    [ .contracts[]?
-      | select(.state == "CONTRACT_STATE_VALID" and (.has_revoked // false) == false)
-      | select(any(.content.grants[]?;
-            .type == "GRANT_TYPE_SERVICE_CONNECTION"
-            and .service.name == $svc
-            and .service.peer_id == $prov
-            and .outway.peer_id == $cons
-            and .outway.identification.public_key_thumbprint == $thumb))
-      | .hash ] | .[]' 2>"$ERRLOG" || {
-    echo "FAIL: contract-JSON niet te parsen: $(fsc_last_error)" >&2
-    return 1
-  }
+  fsc_grant_actief "$json" "$SERVICE_NAME" "$PROVIDER_OIN" "$CONSUMER_OIN" "$THUMB" | sort
 }
 
 BESTAAND="$(bestaande_contracten)" || exit 1
 if [ -n "$BESTAAND" ]; then
   AANTAL="$(printf '%s\n' "$BESTAAND" | grep -c .)"
+  HASH="$(printf '%s\n' "$BESTAAND" | head -n1)"
   echo "OK: er is al een geldig contract voor ${SERVICE_NAME} (${CONSUMER_OIN} -> ${PROVIDER_OIN})."
+  printf '%s\n' "$BESTAAND" | sed 's/^/  contract: /'
 
   if [ "$AANTAL" -gt 1 ]; then
-    # Duplicaten zijn niet fataal — de outway gebruikt er één — maar ze wijzen op een eerdere run
-    # zonder deze controle, en ze stapelen zich op.
-    echo "  WAARSCHUWING: ${AANTAL} geldige contracten voor dezelfde combinatie; ruim de overtollige op." >&2
+    # Kan ontstaan doordat deze existence-check en de POST (stap 3) niet atomair zijn: twee
+    # gelijktijdige of herhaalde runs kunnen allebei een nieuw contract posten. De outway gebruikt
+    # er sowieso maar één — het gesorteerd-eerste hash hierboven — maar de rest ruimt zichzelf hier
+    # op, zodat een volgende run weer bij één contract uitkomt.
+    echo "  WAARSCHUWING: ${AANTAL} geldige contracten voor dezelfde combinatie; trek de overtollige in." >&2
+    printf '%s\n' "$BESTAAND" | tail -n +2 | while IFS= read -r dup; do
+      provider_api -X PUT "${PROVIDER_MANAGER}/v1/contracts/${dup}/revoke" \
+          -H 'Content-Type: application/json' >/dev/null 2>"$ERRLOG" \
+        && echo "  ingetrokken: ${dup}" >&2 \
+        || echo "  WARN: kon duplicaat ${dup} niet intrekken: $(fsc_last_error)" >&2
+    done
   fi
 
-  printf '%s\n' "$BESTAAND" | sed 's/^/  contract: /'
-  echo "BOOTSTRAP OK (bestaand contract)."
+  if [ "$(consumer_state "$HASH")" = "$VALID_STATE" ]; then
+    echo "BOOTSTRAP OK (bestaand contract)."
+    exit 0
+  fi
+
+  # Geldig op de provider, maar (nog) niet gesynct naar de consumer — zonder deze controle zou een
+  # retry hier ten onrechte "klaar" melden terwijl de outway de grant nooit ziet (zie moduledoc).
+  echo "bootstrap: contract ${HASH} is geldig op de provider maar nog niet gesynct naar de consumer..." >&2
+  zorg_dat_consumer_gesynct "$HASH" || {
+    echo "FAIL: contract ${HASH} werd niet 'valid' op de consumer (state: $(consumer_state "$HASH"))." >&2
+    exit 1
+  }
+  echo "OK: contract ${HASH} is alsnog wederzijds gesynct."
+  echo "BOOTSTRAP OK (bestaand contract, opnieuw gesynct)."
   exit 0
 fi
 
@@ -186,20 +252,15 @@ RESP="$(consumer_api -X POST "${CONSUMER_MANAGER}/v1/contracts" -H 'Content-Type
   }
 }")" || { echo "FAIL: POST /v1/contracts geweigerd: ${RESP:-<leeg>} $(fsc_last_error)" >&2; exit 1; }
 
-HASH="$(printf '%s' "$RESP" | jq -r '.content_hash // empty' 2>/dev/null)"
+HASH="$(printf '%s' "$RESP" | jq -r '.content_hash // empty' 2>/dev/null)" || HASH=""
 [ -n "$HASH" ] || { echo "FAIL: respons zonder content_hash (formaat geweigerd?): ${RESP}" >&2; exit 1; }
 echo "  consumer-handtekening gezet; mesh-sync gestart; content_hash=${HASH}"
 
 # --- 4. Provider accepteert ----------------------------------------------------------------------
-contract_zichtbaar() {
-  provider_api "${PROVIDER_MANAGER}/v1/contracts" 2>/dev/null \
-    | jq -e --arg h "$HASH" 'any(.contracts[]?; .hash == $h)' >/dev/null 2>&1
-}
-
 echo "bootstrap: wachten tot het contract naar de provider gesynct is..."
 elapsed=0; gesynct=0
 while [ "$elapsed" -lt "$SYNC_TIMEOUT" ]; do
-  if contract_zichtbaar; then gesynct=1; break; fi
+  if contract_zichtbaar "$HASH"; then gesynct=1; break; fi
 
   sleep "$SYNC_INTERVAL"; elapsed=$((elapsed + SYNC_INTERVAL))
   echo "  ...nog niet gesynct (${elapsed}s)" >&2
@@ -216,38 +277,11 @@ provider_api -X PUT "${PROVIDER_MANAGER}/v1/contracts/${HASH}/accept" -H 'Conten
 echo "  provider-handtekening gezet."
 
 # --- 5. Wachten tot de consumer het contract als geldig ziet --------------------------------------
-consumer_state() {
-  consumer_api "${CONSUMER_MANAGER}/v1/contracts" 2>/dev/null \
-    | jq -r --arg h "$HASH" 'first(.contracts[]? | select(.hash == $h) | .state) // "onbekend"' 2>/dev/null \
-    || echo onbekend
-}
-
-wacht_op_valid() {
-  local elapsed=0
-  while [ "$elapsed" -lt "$SYNC_TIMEOUT" ]; do
-    [ "$(consumer_state)" = "CONTRACT_STATE_VALID" ] && return 0
-
-    sleep "$SYNC_INTERVAL"; elapsed=$((elapsed + SYNC_INTERVAL))
-    echo "  ...contract nog niet 'valid' op de consumer (${elapsed}s)" >&2
-  done
-  return 1
-}
-
 echo "bootstrap: wachten tot de consumer het contract als geldig ziet..."
-if ! wacht_op_valid; then
-  # De accept-handtekening wordt best-effort naar de consumer gepusht; strandt die, dan blijft het
-  # contract daar `proposed` en ziet de outway de grant nooit. Dit is het canonieke herstel.
-  echo "bootstrap: accept-handtekening opnieuw laten distribueren..." >&2
-  provider_api -X POST \
-    "${PROVIDER_MANAGER}/v1/contracts/${HASH}/distributions/${CONSUMER_OIN}/DISTRIBUTION_ACTION_SUBMIT_ACCEPT_SIGNATURE/retry" \
-    -H 'Content-Type: application/json' >/dev/null \
-    || echo "  WARN: her-distributie gaf een fout: $(fsc_last_error)" >&2
-
-  wacht_op_valid || {
-    echo "FAIL: contract ${HASH} werd niet 'valid' op de consumer (state: $(consumer_state))." >&2
-    exit 1
-  }
-fi
+zorg_dat_consumer_gesynct "$HASH" || {
+  echo "FAIL: contract ${HASH} werd niet 'valid' op de consumer (state: $(consumer_state "$HASH"))." >&2
+  exit 1
+}
 
 echo "OK: contract ${HASH} is wederzijds ondertekend en geldig."
 echo "BOOTSTRAP OK."

--- a/demo/environment/federatie/contracts/bootstrap.sh
+++ b/demo/environment/federatie/contracts/bootstrap.sh
@@ -188,7 +188,14 @@ bestaande_contracten() {  # hashes van geldige, niet-ingetrokken contracten voor
     return 1
   }
 
-  fsc_grant_actief "$json" "$SERVICE_NAME" "$PROVIDER_OIN" "$CONSUMER_OIN" "$THUMB" | sort
+  # Met eigen melding: `fsc_grant_actief` eindigt op `jq … 2>/dev/null` en heeft geen
+  # fallback-waarde. Antwoordt de manager met 200 maar zonder geldige JSON (een proxy-foutpagina,
+  # een afgekapt antwoord), dan faalt deze pipeline onder `pipefail` en zou de aanroeper zonder
+  # deze tak zwijgend afbreken — de laag erboven meldt dan alleen "contract niet opgezet".
+  fsc_grant_actief "$json" "$SERVICE_NAME" "$PROVIDER_OIN" "$CONSUMER_OIN" "$THUMB" | sort || {
+    echo "FAIL: de contractenlijst van de provider is niet te lezen — geen geldige JSON?" >&2
+    return 1
+  }
 }
 
 BESTAAND="$(bestaande_contracten)" || exit 1

--- a/demo/environment/federatie/contracts/fbs-contracten.sh
+++ b/demo/environment/federatie/contracts/fbs-contracten.sh
@@ -28,10 +28,10 @@ ENVDIR="$(cd "${FEDDIR}/.." && pwd)"
 : "${MAGAZIJNEN:?geen MAGAZIJNEN in peers.env}"
 : "${MAGAZIJN_DIENST:?geen MAGAZIJN_DIENST in peers.env}"
 
-CONS_BLOK="$(fsc_peer_waarde BLOK "$UITVRAAG")"
+CONS_NET="$(fsc_peer_waarde NET "$UITVRAAG")"
 CONS_OIN="$(fsc_peer_waarde OIN "$UITVRAAG")"
-[ -n "$CONS_BLOK" ] && [ -n "$CONS_OIN" ] || {
-  echo "FAIL: BLOK_/OIN_ ontbreekt voor de uitvraag-peer '${UITVRAAG}' in peers.env." >&2
+[ -n "$CONS_NET" ] && [ -n "$CONS_OIN" ] || {
+  echo "FAIL: NET_/OIN_ ontbreekt voor de uitvraag-peer '${UITVRAAG}' in peers.env." >&2
   exit 1
 }
 
@@ -39,11 +39,11 @@ FOUTEN=0
 GEDAAN=0
 
 for magazijn in $MAGAZIJNEN; do
-  PROV_BLOK="$(fsc_peer_waarde BLOK "$magazijn")"
+  PROV_NET="$(fsc_peer_waarde NET "$magazijn")"
   PROV_OIN="$(fsc_peer_waarde OIN "$magazijn")"
 
-  if [ -z "$PROV_BLOK" ] || [ -z "$PROV_OIN" ]; then
-    echo "FAIL: BLOK_/OIN_ ontbreekt voor magazijn '${magazijn}' in peers.env." >&2
+  if [ -z "$PROV_NET" ] || [ -z "$PROV_OIN" ]; then
+    echo "FAIL: NET_/OIN_ ontbreekt voor magazijn '${magazijn}' in peers.env." >&2
     FOUTEN=$((FOUTEN + 1))
     continue
   fi
@@ -59,17 +59,19 @@ for magazijn in $MAGAZIJNEN; do
 
   echo "== contract ${UITVRAAG} -> ${magazijn} (${MAGAZIJN_DIENST}) =="
 
-  # De interne manager-API zit op blok+01; de outway van de consumer op blok+40. Die offsets staan
-  # in federatie/README.md en gelden voor elke peer gelijk.
+  # De interne manager-API zit op het manager-adres van de peer, op de standaardpoort 9443. De
+  # octet-toewijzing staat in federatie/README.md en geldt voor elke peer gelijk.
   if FSC_CONSUMER_OIN="$CONS_OIN" \
      FSC_PROVIDER_OIN="$PROV_OIN" \
      FSC_SERVICE_NAME="$MAGAZIJN_DIENST" \
      FSC_OUTWAY_CERT="${ENVDIR}/${UITVRAAG}/pki/out/${UITVRAAG}/outway/cert.pem" \
-     FSC_CONSUMER_MANAGER="https://manager.${UITVRAAG}.fsc-test.local:$((CONS_BLOK + 1))" \
+     FSC_CONSUMER_MANAGER="https://manager.${UITVRAAG}.fsc-test.local:9443" \
+     FSC_CONSUMER_ADRES="$(fsc_component_adres "$CONS_NET" manager)" \
      FSC_CONSUMER_CERT="${ENVDIR}/${UITVRAAG}/pki/internal/${UITVRAAG}/manager/cert.pem" \
      FSC_CONSUMER_KEY="${ENVDIR}/${UITVRAAG}/pki/internal/${UITVRAAG}/manager/key.pem" \
      FSC_CONSUMER_CA="${ENVDIR}/${UITVRAAG}/pki/internal/${UITVRAAG}/ca/root.pem" \
-     FSC_PROVIDER_MANAGER="https://manager.${magazijn}.fsc-test.local:$((PROV_BLOK + 1))" \
+     FSC_PROVIDER_MANAGER="https://manager.${magazijn}.fsc-test.local:9443" \
+     FSC_PROVIDER_ADRES="$(fsc_component_adres "$PROV_NET" manager)" \
      FSC_PROVIDER_CERT="${ENVDIR}/${magazijn}/pki/internal/${magazijn}/manager/cert.pem" \
      FSC_PROVIDER_KEY="${ENVDIR}/${magazijn}/pki/internal/${magazijn}/manager/key.pem" \
      FSC_PROVIDER_CA="${ENVDIR}/${magazijn}/pki/internal/${magazijn}/ca/root.pem" \

--- a/demo/environment/federatie/contracts/fbs-contracten.sh
+++ b/demo/environment/federatie/contracts/fbs-contracten.sh
@@ -3,7 +3,7 @@
 # magazijn, zodat de uitvraag-outway `berichtenmagazijn` bij elk van hen mag afnemen.
 #
 # Wie meedoet staat in peers.env (`UITVRAAG`, `MAGAZIJNEN`, `MAGAZIJN_DIENST`); dit script vertaalt
-# dat naar de peer-blokken en cert-paden en roept per magazijn `bootstrap.sh` aan. Een magazijn
+# dat naar de component-adressen en cert-paden en roept per magazijn `bootstrap.sh` aan. Een magazijn
 # toevoegen is daarmee één naam in `MAGAZIJNEN`.
 #
 # Idempotent, ook zonder lokale state: `bootstrap.sh` leidt uit de contracten zelf af of er al een
@@ -24,6 +24,11 @@ ENVDIR="$(cd "${FEDDIR}/.." && pwd)"
 # shellcheck source=../peers.env
 . "${FEDDIR}/peers.env"
 
+fsc_errlog_init
+# Zet $HAVE_JQ, waar fsc_grant_actief/fsc_grant_hash op leunen. bootstrap.sh doet dit voor zichzelf;
+# sinds dit script zélf het grant-hash afleidt, heeft het de vlag ook nodig.
+fsc_have_jq
+
 : "${UITVRAAG:?geen UITVRAAG in peers.env}"
 : "${MAGAZIJNEN:?geen MAGAZIJNEN in peers.env}"
 : "${MAGAZIJN_DIENST:?geen MAGAZIJN_DIENST in peers.env}"
@@ -37,6 +42,48 @@ CONS_OIN="$(fsc_peer_waarde OIN "$UITVRAAG")"
 
 FOUTEN=0
 GEDAAN=0
+
+# De demo-stack moet het grant-hash kennen om `Fsc-Grant-Hash` te kunnen zetten, en compose kan dat
+# niet uit een draaiende manager halen. Vandaar een gegenereerd env-bestand dat de uitvraag inleest.
+# Naar `.tmp` en pas aan het eind verplaatsen: een half geschreven bestand zou de uitvraag met een
+# grant-hash van het ene magazijn en niets voor het andere laten starten.
+GRANTS="$(cd "${ENVDIR}/.." && pwd)/generated/fsc-grants.env"
+mkdir -p "$(dirname "$GRANTS")"
+: > "$GRANTS.tmp"
+# Eén trap voor beide tijdelijke bestanden: fsc_errlog_init zette er al een op $ERRLOG, en een
+# tweede `trap ... EXIT` vervangt die in plaats van hem aan te vullen.
+trap 'rm -f "$GRANTS.tmp" "$ERRLOG"' EXIT
+
+# Het grant-hash is NIET het contract-hash: de outway routeert op de grant uit `content.grants[]`,
+# en wie het contract-hash op de header zet krijgt structureel 400 UNKNOWN_GRANT_HASH_IN_HEADER.
+CONS_THUMB="$(fsc_outway_thumbprint "${ENVDIR}/${UITVRAAG}/pki/out/${UITVRAAG}/outway/cert.pem")" || {
+  echo "FAIL: kon de outway-thumbprint van '${UITVRAAG}' niet berekenen: $(fsc_last_error)" >&2
+  exit 1
+}
+
+# grant_regel_voor <magazijn> <oin>: één `<PEER>_GRANT_HASH=<hash>`-regel op stdout.
+#
+# De env-naam is de peernaam in hoofdletters: `magazijn-a` -> `MAGAZIJN_A_GRANT_HASH`. Dat is
+# precies de naam die application.properties van de uitvraag leest voor het magazijn met die OIN.
+# Hernoem je een peer in peers.env, dan moet die property mee.
+#
+# De contracten komen van de manager van de CONSUMER: dat is de kant waar de outway zijn grant
+# vandaan haalt. Bij de provider staat hetzelfde contract, maar de uitvraag praat daar niet mee.
+grant_regel_voor() {
+  local magazijn="$1" oin="$2" json contract grant naam
+
+  json="$(fsc_manager_contracts "$ENVDIR" "$UITVRAAG" "$(fsc_component_adres "$CONS_NET" manager)")" || return 1
+  contract="$(fsc_grant_actief "$json" "$MAGAZIJN_DIENST" "$oin" "$CONS_OIN" "$CONS_THUMB" | sort | head -n1)"
+  [ -n "$contract" ] || return 1
+
+  grant="$(fsc_grant_hash "$json" "$contract" "$MAGAZIJN_DIENST" "$CONS_THUMB")"
+  fsc_grant_bruikbaar "$grant" || return 1
+
+  naam="$(printf '%s' "$magazijn" | tr '[:lower:]-' '[:upper:]_')"
+  # Escapen voor compose: een kale `$` in dit bestand wordt als variabele-verwijzing gelezen en
+  # vreet de rest van het hash op. Zie fsc_compose_env_waarde.
+  printf '%s_GRANT_HASH=%s\n' "$naam" "$(fsc_compose_env_waarde "$grant")"
+}
 
 for magazijn in $MAGAZIJNEN; do
   PROV_NET="$(fsc_peer_waarde NET "$magazijn")"
@@ -77,6 +124,10 @@ for magazijn in $MAGAZIJNEN; do
      FSC_PROVIDER_CA="${ENVDIR}/${magazijn}/pki/internal/${magazijn}/ca/root.pem" \
        "${HERE}/bootstrap.sh"; then
     GEDAAN=$((GEDAAN + 1))
+    grant_regel_voor "$magazijn" "$PROV_OIN" >> "$GRANTS.tmp" || {
+      echo "FAIL: contract staat, maar het grant-hash van ${magazijn} is niet af te leiden." >&2
+      FOUTEN=$((FOUTEN + 1))
+    }
   else
     echo "FAIL: contract ${UITVRAAG} -> ${magazijn} niet opgezet." >&2
     FOUTEN=$((FOUTEN + 1))
@@ -87,13 +138,33 @@ done
 
 # Nul magazijnen is geen succes maar een lege configuratie.
 if [ "$GEDAAN" -eq 0 ] && [ "$FOUTEN" -eq 0 ]; then
+  # Ook hier het oude bestand weg, om dezelfde reden als bij de foutuitgang hieronder: een
+  # grant-hash van een vorige federatie zou anders blijven staan en de demo-stack een dode grant
+  # laten sturen. `MAGAZIJNEN` met alleen spaties komt langs de `:?`-controle hierboven.
+  rm -f "$GRANTS"
   echo "FAIL: MAGAZIJNEN is leeg; er is geen enkel contract opgezet." >&2
   exit 1
 fi
 
 if [ "$FOUTEN" -eq 0 ]; then
+  # Overschrijven en niet aanvullen: hashes uit een eerdere run zouden anders blijven staan nadat
+  # een contract is ingetrokken of opnieuw uitgegeven, en de uitvraag zou dan een dode grant sturen.
+  mv "$GRANTS.tmp" "$GRANTS"
+  echo "grant-hashes weggeschreven naar ${GRANTS}."
   echo "FBS-CONTRACTEN OK (${GEDAAN} magazijn(en))."
 else
+  # Ook het BESTAANDE bestand weg. Anders overleeft een grant-hash uit een eerdere federatie een
+  # mislukte run: na `federatie.sh down` (die de volumes wist) en een nieuwe `up` bestaat die grant
+  # niet meer, maar zou de demo-stack er wél mee starten en op elke magazijn-call een
+  # 400 UNKNOWN_GRANT_HASH_IN_HEADER krijgen. Geen bestand = geen FSC-headers = rechtstreeks
+  # verkeer, en dat is een eerlijke uitkomst van een mislukte contract-run.
+  if [ -e "$GRANTS" ]; then
+    rm -f "$GRANTS"
+    echo "grant-hashes uit een eerdere run verwijderd (${GRANTS})." >&2
+    echo "  Let op: compose leest env_file bij het AANMAKEN van een container, dus een al draaiende" >&2
+    echo "  uitvraag houdt de oude grant-hash tot je hem hercreëert (demo/podman-up.sh)." >&2
+  fi
+
   echo "FBS-CONTRACTEN ROOD: ${FOUTEN} van $((GEDAAN + FOUTEN)) mislukt." >&2
   exit 1
 fi

--- a/demo/environment/federatie/contracts/fbs-contracten.sh
+++ b/demo/environment/federatie/contracts/fbs-contracten.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Zet de contracten op die het uitvraag-systeem nodig heeft: één ServiceConnectionGrant per
+# magazijn, zodat de uitvraag-outway `berichtenmagazijn` bij elk van hen mag afnemen.
+#
+# Wie meedoet staat in peers.env (`UITVRAAG`, `MAGAZIJNEN`, `MAGAZIJN_DIENST`); dit script vertaalt
+# dat naar de peer-blokken en cert-paden en roept per magazijn `bootstrap.sh` aan. Een magazijn
+# toevoegen is daarmee één naam in `MAGAZIJNEN`.
+#
+# Idempotent, ook zonder lokale state: `bootstrap.sh` leidt uit de contracten zelf af of er al een
+# geldig contract voor die combinatie bestaat. Twee keer draaien levert dus geen tweede contract op,
+# en dat geldt net zo goed in een deploy-job met een lege schijf.
+#
+# Voorwaarden: de federatie draait (`../federatie.sh up`) en elk magazijn heeft zijn dienst
+# gepubliceerd (`<magazijn>/deploy/local/publish-service.sh`). `../smoke-federatie.sh` doet dat
+# laatste voor de peers die het toetst.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+FEDDIR="$(cd "${HERE}/.." && pwd)"
+ENVDIR="$(cd "${FEDDIR}/.." && pwd)"
+
+# shellcheck source=../../lib/fsc-harness.sh
+. "${ENVDIR}/lib/fsc-harness.sh"
+# shellcheck source=../peers.env
+. "${FEDDIR}/peers.env"
+
+: "${UITVRAAG:?geen UITVRAAG in peers.env}"
+: "${MAGAZIJNEN:?geen MAGAZIJNEN in peers.env}"
+: "${MAGAZIJN_DIENST:?geen MAGAZIJN_DIENST in peers.env}"
+
+CONS_BLOK="$(fsc_peer_waarde BLOK "$UITVRAAG")"
+CONS_OIN="$(fsc_peer_waarde OIN "$UITVRAAG")"
+[ -n "$CONS_BLOK" ] && [ -n "$CONS_OIN" ] || {
+  echo "FAIL: BLOK_/OIN_ ontbreekt voor de uitvraag-peer '${UITVRAAG}' in peers.env." >&2
+  exit 1
+}
+
+FOUTEN=0
+GEDAAN=0
+
+for magazijn in $MAGAZIJNEN; do
+  PROV_BLOK="$(fsc_peer_waarde BLOK "$magazijn")"
+  PROV_OIN="$(fsc_peer_waarde OIN "$magazijn")"
+
+  if [ -z "$PROV_BLOK" ] || [ -z "$PROV_OIN" ]; then
+    echo "FAIL: BLOK_/OIN_ ontbreekt voor magazijn '${magazijn}' in peers.env." >&2
+    FOUTEN=$((FOUTEN + 1))
+    continue
+  fi
+
+  if [ "$PROV_OIN" = "$CONS_OIN" ]; then
+    # Een zelfreferentieel contract is geldig FSC (zie logius' consume-service.sh voor de
+    # profiel-service), maar hier zou het betekenen dat het magazijn dezelfde identiteit draagt
+    # als de uitvraag — dan klopt peers.env niet.
+    echo "FAIL: magazijn '${magazijn}' heeft dezelfde OIN als de uitvraag-peer (${PROV_OIN})." >&2
+    FOUTEN=$((FOUTEN + 1))
+    continue
+  fi
+
+  echo "== contract ${UITVRAAG} -> ${magazijn} (${MAGAZIJN_DIENST}) =="
+
+  # De interne manager-API zit op blok+01; de outway van de consumer op blok+40. Die offsets staan
+  # in federatie/README.md en gelden voor elke peer gelijk.
+  if FSC_CONSUMER_OIN="$CONS_OIN" \
+     FSC_PROVIDER_OIN="$PROV_OIN" \
+     FSC_SERVICE_NAME="$MAGAZIJN_DIENST" \
+     FSC_OUTWAY_CERT="${ENVDIR}/${UITVRAAG}/pki/out/${UITVRAAG}/outway/cert.pem" \
+     FSC_CONSUMER_MANAGER="https://manager.${UITVRAAG}.fsc-test.local:$((CONS_BLOK + 1))" \
+     FSC_CONSUMER_CERT="${ENVDIR}/${UITVRAAG}/pki/internal/${UITVRAAG}/manager/cert.pem" \
+     FSC_CONSUMER_KEY="${ENVDIR}/${UITVRAAG}/pki/internal/${UITVRAAG}/manager/key.pem" \
+     FSC_CONSUMER_CA="${ENVDIR}/${UITVRAAG}/pki/internal/${UITVRAAG}/ca/root.pem" \
+     FSC_PROVIDER_MANAGER="https://manager.${magazijn}.fsc-test.local:$((PROV_BLOK + 1))" \
+     FSC_PROVIDER_CERT="${ENVDIR}/${magazijn}/pki/internal/${magazijn}/manager/cert.pem" \
+     FSC_PROVIDER_KEY="${ENVDIR}/${magazijn}/pki/internal/${magazijn}/manager/key.pem" \
+     FSC_PROVIDER_CA="${ENVDIR}/${magazijn}/pki/internal/${magazijn}/ca/root.pem" \
+       "${HERE}/bootstrap.sh"; then
+    GEDAAN=$((GEDAAN + 1))
+  else
+    echo "FAIL: contract ${UITVRAAG} -> ${magazijn} niet opgezet." >&2
+    FOUTEN=$((FOUTEN + 1))
+  fi
+
+  echo
+done
+
+# Nul magazijnen is geen succes maar een lege configuratie.
+if [ "$GEDAAN" -eq 0 ] && [ "$FOUTEN" -eq 0 ]; then
+  echo "FAIL: MAGAZIJNEN is leeg; er is geen enkel contract opgezet." >&2
+  exit 1
+fi
+
+if [ "$FOUTEN" -eq 0 ]; then
+  echo "FBS-CONTRACTEN OK (${GEDAAN} magazijn(en))."
+else
+  echo "FBS-CONTRACTEN ROOD: ${FOUTEN} van $((GEDAAN + FOUTEN)) mislukt." >&2
+  exit 1
+fi

--- a/demo/environment/federatie/contracts/zad-lus.sh
+++ b/demo/environment/federatie/contracts/zad-lus.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Entrypoint van het contract-bootstrap-component op ZAD: draai één helft van de bootstrap, herhaald.
+#
+# ZAD kent alleen langlopende componenten — er is geen job-vorm en geen manier om args mee te geven.
+# Vandaar een lus die zijn rol uit `FSC_ROL` leest en blijft draaien. Dat is hier geen omweg maar
+# precies wat de gesplitste opzet nodig heeft: de twee helften coördineren niet met elkaar, ze
+# convergeren. Wie van de twee als eerste start, doet er daardoor niet toe.
+#
+# Blijven draaien na succes is ook de herstelweg: wordt een contract ingetrokken of raakt een peer
+# zijn state kwijt, dan zet de volgende ronde het opnieuw op. Daarom een lang interval na succes in
+# plaats van slapend blijven hangen.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LIBDIR="${FSC_LIBDIR:-$(cd "${HERE}/../../lib" && pwd)}"
+
+# shellcheck source=../../lib/fsc-harness.sh
+. "${LIBDIR}/fsc-harness.sh"
+# shellcheck source=../../lib/fsc-contract.sh
+. "${LIBDIR}/fsc-contract.sh"
+
+# Via de helper en niet via `${FSC_ROL:?}`: die eindigt op 1, en 1 is hier "probeer opnieuw".
+ROL="$(fsc_env_vereist FSC_ROL "'consumer' of 'provider'")"
+
+# Kort interval zolang er nog iets moet gebeuren, lang interval als alles staat.
+#
+# Het lange interval bewaakt een gebeurtenis die zelden voorkomt — een ingetrokken contract of een
+# peer die zijn state kwijt is — terwijl het contract zelf tien jaar geldig is. Een uur is daarvoor
+# ruim genoeg; korter pollen kost per peer honderdduizenden calls per jaar om iets te vinden dat er
+# een paar keer is.
+WACHT="$(fsc_getal_vereist FSC_LUS_WACHT "${FSC_LUS_WACHT:-15}")"
+HERHAAL="$(fsc_getal_vereist FSC_LUS_HERHAAL "${FSC_LUS_HERHAAL:-3600}")"
+
+# Na dit aantal opeenvolgende mislukkingen stopt de lus. Een blijvende fout — verlopen cert, manager
+# die de client weigert — wordt door opnieuw proberen nooit beter, en een component dat eeuwig
+# doordraait ziet er op het platform gezond uit. Afbreken maakt er een zichtbare crashloop van.
+#
+# Acht en niet twintig: met de ladder hieronder is acht pogingen ongeveer 32 minuten, en twintig
+# zou ruim twaalf uur zijn. Een container die eens per twaalf uur afsluit, is voor het platform geen
+# crashloop maar een herstart — precies het signaal dat deze grens moet opleveren.
+MAX_MISLUKT="$(fsc_getal_vereist FSC_LUS_MAX_MISLUKT "${FSC_LUS_MAX_MISLUKT:-8}")"
+
+# Idem voor "ik wacht al heel lang op de overkant": geen fout, maar wel iets om te melden in plaats
+# van eindeloos dezelfde regel te herhalen.
+MELD_WACHT_NA="$(fsc_getal_vereist FSC_LUS_MELD_WACHT_NA "${FSC_LUS_MELD_WACHT_NA:-20}")"
+
+# En een bovengrens op het wachten zelf. Een consumer die eeuwig op de provider wacht, is de enige
+# permanente blokkade die geen crashloop oplevert — terwijl de oorzaak (onze OIN staat niet in de
+# allowlist van de overkant) juist een van de waarschijnlijkste is. Zonder grens blijft het component
+# "Running" en ziet het platform niets.
+MAX_WACHT="$(fsc_getal_vereist FSC_LUS_MAX_WACHT "${FSC_LUS_MAX_WACHT:-200}")"
+
+case "$ROL" in
+  consumer) HELFT="${FSC_HELFT_CONSUMER:-${HERE}/bootstrap-consumer.sh}" ;;
+  provider) HELFT="${FSC_HELFT_PROVIDER:-${HERE}/bootstrap-provider.sh}" ;;
+  *) echo "FAIL: FSC_ROL moet 'consumer' of 'provider' zijn, niet '${ROL}'." >&2; exit 2 ;;
+esac
+
+echo "zad-lus: rol=${ROL}, interval ${WACHT}s tot het staat, daarna ${HERHAAL}s."
+
+# Stoppen moet zonder de stop-timeout uit te zitten. De trap zet alleen een vlag: bash voert een
+# handler pas uit als het lopende voorgrondcommando klaar is, dus komt het signaal binnen tijdens de
+# helft, dan gebeurt er hier niets tot die terug is. `pauzeer` toetst de vlag daarom zelf ook — zonder
+# dat zou de lus na een TERM alsnog het volle interval afwachten voordat de conditie weer aan bod komt.
+STOPPEN=0
+trap 'STOPPEN=1' TERM INT
+
+pauzeer() {
+  [ "$STOPPEN" -eq 0 ] || return 0
+
+  # Een kale `sleep` vangt het signaal pas als hij klaar is; naar de achtergrond en `wait` erop
+  # breekt wél af op het signaal.
+  sleep "$1" &
+  wait $! 2>/dev/null || true
+}
+
+MISLUKT=0
+GEWACHT=0
+
+while [ "$STOPPEN" -eq 0 ]; do
+  rc=0
+  "$HELFT" || rc=$?
+
+  case "$rc" in
+    0)
+      MISLUKT=0
+      GEWACHT=0
+      pauzeer "$HERHAAL"
+      ;;
+    3)
+      # Wachten op de overkant: de consumer heeft ingediend en de provider moet nog tekenen, of de
+      # provider heeft nog niets binnen. Geen fout — maar wel iets dat blijvend kan zijn, bijvoorbeeld
+      # als de OIN niet in de allowlist van de overkant staat. Dan hoort het te gaan opvallen in
+      # plaats van elke ronde dezelfde regel te herhalen.
+      MISLUKT=0
+      GEWACHT=$((GEWACHT + 1))
+
+      if [ "$GEWACHT" -ge "$MAX_WACHT" ]; then
+        echo "FAIL: ${GEWACHT} rondes gewacht zonder dat het contract geldig werd; de lus stopt." >&2
+        echo "  Kijk aan providerkant naar de WEIGER-regels en naar FSC_DIENSTEN/FSC_CONSUMERS." >&2
+        exit 1
+      fi
+
+      if [ "$GEWACHT" -eq "$MELD_WACHT_NA" ]; then
+        echo "WARN: al ${GEWACHT} rondes (~$((GEWACHT * WACHT))s) wachten op de andere helft." >&2
+        echo "  Controleer daar FSC_DIENSTEN/FSC_CONSUMERS en de WEIGER-regels in de log." >&2
+      fi
+
+      # Na de melding op het lange interval verder: blijven pollen verandert er niets aan.
+      [ "$GEWACHT" -lt "$MELD_WACHT_NA" ] && pauzeer "$WACHT" || pauzeer "$HERHAAL"
+      ;;
+    2)
+      echo "FAIL: configuratiefout in de ${ROL}-helft; de lus stopt." >&2
+      exit 2
+      ;;
+    4)
+      # Provider-helft: er lagen contracten die de toets niet haalden en niets mocht getekend worden.
+      # Geen storing, dus niet opnieuw proberen op het korte interval — de allowlist verandert alleen
+      # doordat iemand hem aanpast. Maar het telt wél mee als wachten: anders is dit de enige
+      # permanente blokkade waarop de lus nooit escaleert, en blijft het component uren gezond ogen
+      # terwijl er niets gebeurt.
+      MISLUKT=0
+      GEWACHT=$((GEWACHT + 1))
+
+      if [ "$GEWACHT" -ge "$MAX_WACHT" ]; then
+        echo "FAIL: ${GEWACHT} rondes zonder dat er iets getekend kon worden; de lus stopt." >&2
+        echo "  Kijk naar de WEIGER-regels hierboven en naar FSC_DIENSTEN/FSC_CONSUMERS." >&2
+        exit 1
+      fi
+
+      pauzeer "$HERHAAL"
+      ;;
+    *)
+      MISLUKT=$((MISLUKT + 1))
+
+      if [ "$MISLUKT" -ge "$MAX_MISLUKT" ]; then
+        echo "FAIL: de ${ROL}-helft faalde ${MISLUKT} keer op rij; de lus stopt." >&2
+        exit 1
+      fi
+
+      # Exponentieel terug, afgetopt op het lange interval: een manager die weg is, wordt niet
+      # sneller bereikbaar door hem elke 15 seconden opnieuw te bevragen.
+      pauze="$WACHT"
+      for _ in $(seq 2 "$MISLUKT"); do
+        pauze=$((pauze * 2))
+        [ "$pauze" -lt "$HERHAAL" ] || { pauze="$HERHAAL"; break; }
+      done
+
+      echo "WARN: de ${ROL}-helft faalde (exit ${rc}), poging ${MISLUKT}; opnieuw over ${pauze}s." >&2
+      pauzeer "$pauze"
+      ;;
+  esac
+done
+
+# De lus verlaat zijn conditie alleen als STOPPEN gezet is; valt hij er om een andere reden uit, dan
+# doet `set -e` dat met een non-zero status. Een nulafsluiting hier betekent dus altijd een
+# stopverzoek.
+echo "zad-lus: gestopt op verzoek."

--- a/demo/environment/federatie/contracts/zad-runbook.md
+++ b/demo/environment/federatie/contracts/zad-runbook.md
@@ -1,0 +1,215 @@
+# Contract-bootstrap op ZAD — runbook
+
+Draaiboek voor de operator: de contract-bootstrap als component per peer neerzetten. Eén keer per
+peer; daarna houdt `deploy.yml` alleen de image-tag bij.
+
+## Waarom een component en geen CI-stap
+
+Elk ZAD-deployment krijgt een `<deployment>-tenant-baseline-network-policy` met
+`podSelector: {deployment: <naam>}`. Ingress komt alleen van pods met hetzelfde `deployment`-label,
+de `rig`-ingresscontroller, `rig-prd-operations` en `rig-prd-backup`; egress gaat alleen naar
+kube-dns, hetzelfde deployment, die twee namespaces, `<project>-infrastructure`, en `0.0.0.0/0`
+beperkt tot TCP 443/80. De isolatie loopt dus per **deployment**, niet per project.
+
+Daar komt bij dat de manager-internal-API (`:9443` authenticated, `:9444` unauthenticated) geen
+route heeft — de ingress publiceert alleen backend-poort `:8443`, de mesh-poort. Alleen een pod
+binnen hetzelfde deployment kan de contract-API dus bereiken, en een CI-runner of een pod uit een
+ander project nooit.
+
+Vandaar: elke peer bootstrapt zijn eigen kant tegen zijn eigen manager, en het contract kruist via
+de FSC-mesh. Dat is geen omweg — het is dezelfde weg die de managers onderling toch al gebruiken,
+en het houdt de contract-API van elke peer onbereikbaar van buiten.
+
+## De twee componenten
+
+| Deployment | Component | `FSC_ROL` | Doet |
+|------------|-----------|-----------|------|
+| `fsc-logius` (`mpfb-8wh`) | `logius-fscbootstrap` | `consumer` | dient het contract in bij de eigen manager en stelt vast dat het geldig wordt |
+| `fsc-magazijna` (`mpfm-w3h`) | `magazijna-fscbootstrap` | `provider` | tekent binnengekomen contracten die de autorisatietoets halen |
+
+Beide draaien hetzelfde image (`ghcr.io/minbzk/fbs-fsc-contract-bootstrap`). ZAD staat geen
+component-args toe, dus de rol komt uit env.
+
+De componenten hebben **geen ingress en geen inbound poort**: ze bellen alleen uit, naar de manager
+van hun eigen deployment. Geef ze dus geen `ports.inbound` — dat zou een Service opleveren die
+niemand gebruikt.
+
+## Env per component
+
+Gemeenschappelijk (beide componenten):
+
+| Variabele | Waarde |
+|-----------|--------|
+| `FSC_ROL` | `consumer` respectievelijk `provider` |
+| `FSC_LUS_WACHT` | optioneel, standaard `15` — interval zolang er nog iets moet gebeuren |
+| `FSC_LUS_HERHAAL` | optioneel, standaard `3600` — interval als alles staat |
+| `FSC_LUS_MAX_MISLUKT` | optioneel, standaard `8` — na zoveel mislukkingen op rij stopt de lus (met de backoff-ladder ongeveer 32 minuten) |
+| `FSC_LUS_MELD_WACHT_NA` | optioneel, standaard `20` — na zoveel rondes wachten volgt een waarschuwing |
+| `FSC_LUS_MAX_WACHT` | optioneel, standaard `200` — na zoveel rondes wachten op de overkant stopt de lus |
+| `FSC_GROUP_ID` | optioneel, standaard `moza-fbs-test` |
+| `FSC_CONTRACT_LIMIET` | optioneel, standaard `1000` — paginalimiet op het ophalen van de contracten; de manager staat maximaal 1000 toe en weigert meer met een 400 |
+
+`logius-fscbootstrap` (consumer):
+
+| Variabele | Waarde |
+|-----------|--------|
+| `FSC_CONSUMER_OIN` | `00000000000000001000` |
+| `FSC_PROVIDER_OIN` | `00000000000000100000` |
+| `FSC_SERVICE_NAME` | `berichtenmagazijn` |
+| `FSC_OUTWAY_THUMBPRINT` | zie hieronder |
+| `FSC_CONSUMER_MANAGER` | `https://fsc-logius-logius-fscmgr:9443` |
+| `FSC_CONSUMER_CERT` | `/etc/fsc/internal/logius/bootstrap/cert.pem` |
+| `FSC_CONSUMER_KEY` | `/etc/fsc/internal/logius/bootstrap/key.pem` |
+| `FSC_CONSUMER_CA` | `/etc/fsc/internal/logius/ca/root.pem` |
+
+`magazijna-fscbootstrap` (provider):
+
+| Variabele | Waarde |
+|-----------|--------|
+| `FSC_PROVIDER_OIN` | `00000000000000100000` |
+| `FSC_DIENSTEN` | `berichtenmagazijn` — door witruimte gescheiden lijst |
+| `FSC_CONSUMERS` | `00000000000000001000` — door witruimte gescheiden lijst |
+| `FSC_MAX_GELDIGHEID_SECONDEN` | optioneel, standaard `316224000` (ruim tien jaar) — bovengrens op de RESTERENDE geldigheid (`not_after` min nu), niet op de vensterlengte |
+| `FSC_PROVIDER_MANAGER` | `https://fsc-magazijna-magazijna-fscmgr:9443` |
+| `FSC_PROVIDER_CERT` | `/etc/fsc/internal/magazijn-a/bootstrap/cert.pem` |
+| `FSC_PROVIDER_KEY` | `/etc/fsc/internal/magazijn-a/bootstrap/key.pem` |
+| `FSC_PROVIDER_CA` | `/etc/fsc/internal/magazijn-a/ca/root.pem` |
+
+> `FSC_DIENSTEN` en `FSC_CONSUMERS` samen zijn de autorisatiegrens van de provider: alles wat er
+> niet in staat, wordt niet getekend. Een contract dat de toets niet haalt blijft ongetekend en
+> werkt daarmee niet — dat is de bedoelde uitkomst, geen storing. Zet er dus niet ruimhartig extra
+> waarden in "voor later"; een OIN erbij is een peer die van ons mag afnemen.
+
+### De outway-thumbprint bepalen
+
+De consumer-helft heeft de SPKI-SHA256-thumbprint van het **group**-cert van de eigen outway nodig.
+Op ZAD komt die uit env in plaats van uit een bestand: het group-cert hangt aan het
+outway-component, en het aan een tweede component koppelen zou die identiteit verspreiden.
+
+```bash
+openssl x509 -in demo/environment/logius/pki/out/logius/outway/cert.pem -pubkey -noout \
+  | openssl pkey -pubin -outform DER \
+  | openssl dgst -sha256 -r | cut -d' ' -f1
+```
+
+64 lowercase hex-tekens; het component weigert elke andere vorm.
+
+De waarde is stabiel zolang het sleutelpaar dat is — een cert-rotatie binnen hetzelfde sleutelpaar
+verandert hem niet. **Rouleer je het sleutelpaar wél, dan blijft het oude contract staan.** De
+thumbprint is onderdeel van de identiteit waarop de consumer-helft matcht, dus na een rotatie valt
+het oude contract buiten die match: er komt een nieuw contract bij en het oude wordt niet
+opgeruimd. Trek het met de hand in (`PUT /v1/contracts/<hash>/revoke` op de eigen manager), anders
+blijft een grant voor een outway die niet meer bestaat geldig tot zijn einddatum.
+
+## Cert-attachments
+
+Het component gebruikt het **internal**-cert van het `bootstrap`-endpoint als client naar de
+manager-API. Dat is een eigen cert en niet dat van een andere component: wie een cert deelt, deelt
+een identiteit, en dan is in het auditlog van de manager niet meer te zien welk component welke
+contract-call deed. (Niet in het FSC-txlog — dat legt data-plane-transacties vast, gelogd door
+inway en outway; een call op de interne contract-API verschijnt daar niet.)
+
+`pki/issue.sh` geeft dit endpoint bewust **geen group-cert** — het bedient zelf geen TLS en hoort
+zich niet in de mesh als de peer te kunnen voordoen.
+
+Attachments per bootstrap-component (UI-only; de v2-API kloont ze niet):
+
+| Bestand uit `pki/zad-upload/<peer>/` | Pod-pad |
+|--------------------------------------|---------|
+| `internal/<peer>/bootstrap/cert.pem` | `/etc/fsc/internal/<peer>/bootstrap/cert.pem` |
+| `internal/<peer>/bootstrap/key.pem` | `/etc/fsc/internal/<peer>/bootstrap/key.pem` |
+| `internal/<peer>/ca/root.pem` | `/etc/fsc/internal/<peer>/ca/root.pem` |
+
+Zie `deploy/zad/cert-manifest.md` bij de peer voor de algemene valkuilen (internal-pad krijgt het
+internal-cert, group-pad het group-cert inclusief intermediate).
+
+## Voorwaarden
+
+Beide peers zijn in de group geannounced — daaruit kent de mesh elkaars manageradres — en de
+provider heeft zijn dienst gepubliceerd (ServicePublicationGrant). Dat laatste is niet nodig om het
+contract te synchroniseren maar wel om het te mogen tekenen: de provider toetst dat de dienst uit de
+grant ook echt door hem wordt aangeboden, en zonder publicatie geeft hij later ook geen token uit.
+
+## Volgorde
+
+1. `pki/issue.sh` bij beide peers — geeft het nieuwe `bootstrap`-endpoint uit. **Zonder `-f`**:
+   die vlag hergenereert de internal-CA per peer en daarmee álle bestaande certificaten, zodat
+   elke attachment op ZAD opnieuw geüpload moet worden. Het bootstrap-endpoint heeft nog geen
+   certificaat, dus een kale run geeft het al uit.
+2. `pki/zad-bundle.sh <peer>` — zet de upload-set klaar.
+3. Component éénmalig aanmaken in de ZAD-UI, in de deployment van díé peer, met de env hierboven
+   en zonder inbound poort.
+4. De drie attachments koppelen.
+5. Component starten en de log volgen.
+
+Doe dit **vóór** de merge naar main: de `deploy-test-*`-job werkt daarna bij elke push de image-tag
+van dit component bij, en dat werkt alleen als het component al bestaat.
+
+> `upsert-peer.sh` noemt het bootstrap-component wel in zijn deployment-lijst — anders haalt een
+> upsert het eruit — maar zet zijn env en attachments niet. Draai je dat script na een herstel, dan
+> zijn die twee dus opnieuw handwerk.
+
+Geef het component het kleinste CPU-/geheugenprofiel dat het project toestaat. Het rekent een paar
+tientallen CPU-seconden per dag en slaapt de rest van de tijd; een standaardprofiel reserveert
+24/7 capaciteit die leeg blijft.
+
+## Verifiëren
+
+De consumer-log meldt `CONSUMER OK`, de provider-log `PROVIDER OK (1 contract(en) getekend)` en
+daarna elke ronde `PROVIDER OK (niets te tekenen)`. Dat laatste is het idempotentie-signaal: draait
+het component opnieuw of herstart de pod, dan komt er geen tweede contract bij.
+
+Een `PROVIDER GEWEIGERD`-regel (uitgang 4) betekent dat er wél iets lag maar dat niets ervan de
+toets haalde. `PROVIDER WACHT` betekent dat er nog niets van een toegelaten consumer binnen is —
+normaal bij een koude start, en de lus komt daar dan snel op terug in plaats van een uur te wachten. Werd er in dezelfde ronde ook iets getekend, dan meldt de log `PROVIDER OK (… , N
+geweigerd)` — dan is er iets aan de hand met één contract, niet met de ronde. Blijft de consumer `CONSUMER WACHT` melden, kijk dan in deze volgorde:
+
+1. **De WEIGER-regels in de log van de provider.** Meldt die `PROVIDER GEWEIGERD`, dan lag het
+   contract er wél maar haalde het de autorisatietoets niet — bij een verse opstelling bijna altijd
+   een typefout in `FSC_DIENSTEN` of een OIN die niet in `FSC_CONSUMERS` staat. De regel noemt de
+   eerste eis die faalde.
+2. **Meldt de provider `niets te tekenen`**, dan is het contract daar niet aangekomen: controleer
+   de announce en de dienstpublicatie uit de voorwaarden hierboven.
+3. **Meldt de consumer `de provider heeft minstens één van onze contracten AFGEWEZEN`**, dan heeft
+   de overkant actief geweigerd. Opnieuw indienen heeft pas zin na een fix aan die kant; trek het
+   afgewezen contract daarna bij de consumer in — zolang het in de lijst staat, dient de consumer
+   niet opnieuw in.
+4. **Heeft de provider wél getekend** en blijft de consumer toch wachten, dan is de
+   accept-handtekening onderweg blijven steken — zie hieronder. Dat kan ook de andere kant op: is de
+   handtekening van de consumer nooit bij de provider aangekomen, dan weigert die met "draagt de
+   handtekening van de consumer nog niet" en is er aan consumerkant geen knop om hem opnieuw te
+   sturen. Dien in dat geval opnieuw in door het contract bij de consumer in te trekken.
+
+Na twintig rondes wachten meldt de lus dat zelf ook, met een verwijzing naar deze punten; na
+`FSC_LUS_MAX_WACHT` rondes stopt hij, zodat het platform de blokkade als crashloop laat zien in
+plaats van als een gezond component.
+
+> Alle numerieke knoppen hierboven worden bij het opstarten op vorm gecontroleerd. Een waarde als
+> `15s` zou anders `sleep` laten falen, en dan keert het wachten meteen terug: een lus die de
+> manager zo snel mogelijk bevraagt terwijl hij elke ronde OK meldt.
+
+## Als beide kanten groen melden en het datapad tóch stuk is
+
+Kijk dan naar de provider-log op `PROVIDER GEWEIGERD (… eerder getekend …)`. Dat betekent dat de
+allowlist of de geldigheidsgrens ná de eerste tekenronde is aangepast: het contract ligt er nog,
+de consumer ziet het als geldig, maar de provider rekent het niet meer mee.
+
+Dit is het enige geval waarin de consumer-log geen enkel signaal geeft — hij heeft een geldig
+contract en meldt terecht `CONSUMER OK`. Zet de allowlist terug of trek het contract aan beide
+kanten in en laat het opnieuw opzetten.
+
+## Bekende beperking: een gestrande accept-push
+
+De manager pusht de accept-handtekening na het tekenen naar de consumer, maar best-effort: met
+begrensde backoff en zonder cron-retry. Strandt die push, dan blijft het contract bij de consumer
+`proposed` en ziet de outway de grant nooit, terwijl het bij de provider geldig heet.
+
+De provider-helft stuurt daarom na elke accept één keer na. Strandt de push daarná alsnog, dan kan
+geen van beide helften dat waarnemen: de consumer ziet het probleem maar kan de her-distributie niet
+aanroepen (dat is een provider-endpoint), en de provider kan de her-distributie aanroepen maar het
+probleem niet zien. Lokaal loste één script dat op door bij beide managers te kijken; op ZAD kan dat
+niet.
+
+De uitweg is een handmatige duw: zet op het provider-component tijdelijk
+`FSC_FORCEER_DISTRIBUTIE=1`, laat één ronde lopen, en zet hem weer uit. Aan laten staan kost een
+extra API-call per contract per ronde zonder dat er iets mis is.

--- a/demo/environment/federatie/federatie.sh
+++ b/demo/environment/federatie/federatie.sh
@@ -351,7 +351,10 @@ case "${1:-}" in
     echo
     echo "listeners in de gedeelde netns:"
     # Stderr apart houden: gevouwen in de lijst zou een foutregel hieronder als wildcard-bind lezen.
-    ALLE="$(ss -ltnH 2>"$ERRLOG" | awk '{print $4}' | sort -u -t: -k2 -n || true)"
+    # Eerst ontdubbelen, dán op poort ordenen. `sort -u -t: -k2 -n` vergelijkt alléén de sleutel,
+    # dus alle listeners op dezelfde poort vallen samen tot één regel — en laat je juist de
+    # wildcard-bind verdwijnen die de controle hieronder moet tonen.
+    ALLE="$(ss -ltnH 2>"$ERRLOG" | awk '{print $4}' | sort -u | sort -t: -k2 -n || true)"
     fsc_warn_errlog "ss faalde"
     if [ -n "$ALLE" ]; then
       printf '%s\n' "$ALLE" | sed 's/^/  /'

--- a/demo/environment/federatie/peers.env
+++ b/demo/environment/federatie/peers.env
@@ -40,3 +40,11 @@ NET_logius=127.20.1
 
 OIN_magazijn_a=00000000000000100000
 NET_magazijn_a=127.20.2
+
+# --- FBS-rollen -----------------------------------------------------------------------------
+# Welke peer het uitvraag-systeem draagt en welke peers `berichtenmagazijn` aanbieden. Hierop
+# loopt contracts/fbs-contracten.sh: één contract per magazijn. Een magazijn toevoegen aan de
+# federatie is daarmee één naam erbij, niet een gekopieerd adresblok.
+UITVRAAG=logius
+MAGAZIJNEN="magazijn-a"
+MAGAZIJN_DIENST=berichtenmagazijn

--- a/demo/environment/federatie/smoke-contract-split.sh
+++ b/demo/environment/federatie/smoke-contract-split.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# Smoke: bewijst dat de twee helften van de contract-bootstrap los van elkaar werken en samen
+# convergeren. Draai na `./federatie.sh up` en nadat elk magazijn zijn dienst gepubliceerd heeft.
+#
+# Waarom naast smoke-contract.sh. Die toetst de UITKOMST: er ligt een geldig contract en het
+# data-pad werkt. Deze toetst de WEG ernaartoe, en dat is precies wat op ZAD anders is — daar
+# draaien de helften in verschillende deployments die elkaars manager niet kunnen bereiken. Zonder
+# deze smoke zou die opzet alleen op ZAD zelf blijken te werken of niet.
+#
+#   1. de consumer-helft dient in en meldt dat hij wacht (exit 3), zónder de provider aan te raken;
+#   2. de provider-helft tekent wat er ligt, zónder de consumer aan te raken;
+#   3. de consumer-helft ziet het contract daarna geldig worden (exit 0);
+#   4. een tweede ronde levert geen tweede contract op en niets meer te tekenen.
+#
+# Linux + podman: gebruikt `podman`, `curl` en `jq`.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ENVDIR="$(cd "${HERE}/.." && pwd)"
+
+# shellcheck source=../lib/fsc-harness.sh
+. "${ENVDIR}/lib/fsc-harness.sh"
+# shellcheck source=../lib/fsc-contract.sh
+. "${ENVDIR}/lib/fsc-contract.sh"
+# shellcheck source=peers.env
+. "${HERE}/peers.env"
+
+fsc_errlog_init
+fsc_have_jq
+
+command -v curl >/dev/null 2>&1 || { echo "FAIL: 'curl' is vereist." >&2; exit 1; }
+[ "$HAVE_JQ" -eq 1 ] || { echo "FAIL: 'jq' is vereist — elke assert hieronder leest contract-JSON." >&2; exit 1; }
+
+FOUTEN=0
+fout() { echo "FAIL: $*" >&2; FOUTEN=$((FOUTEN + 1)); }
+ok()   { echo "OK: $*"; }
+
+: "${UITVRAAG:?geen UITVRAAG in peers.env}"
+: "${MAGAZIJNEN:?geen MAGAZIJNEN in peers.env}"
+: "${MAGAZIJN_DIENST:?geen MAGAZIJN_DIENST in peers.env}"
+
+CONS_NET="$(fsc_peer_waarde NET "$UITVRAAG")"
+CONS_OIN="$(fsc_peer_waarde OIN "$UITVRAAG")"
+[ -n "$CONS_NET" ] && [ -n "$CONS_OIN" ] || { echo "FAIL: NET_/OIN_ ontbreekt voor '${UITVRAAG}'." >&2; exit 1; }
+
+CONS_OUTWAY_CERT="${ENVDIR}/${UITVRAAG}/pki/out/${UITVRAAG}/outway/cert.pem"
+CONS_THUMB="$(fsc_outway_thumbprint "$CONS_OUTWAY_CERT")" \
+  || { echo "FAIL: kon de outway-thumbprint niet berekenen uit ${CONS_OUTWAY_CERT}: $(fsc_last_error)" >&2; exit 1; }
+
+CONTRACTS="${ENVDIR}/federatie/contracts"
+
+# consumer_helft <provider-oin>: de consumer-helft met UITSLUITEND zijn eigen adres en certificaten.
+#
+# `env -i` en niet alleen "de andere variabelen weglaten": deze smoke moet kunnen aantonen dat de
+# helft het zonder de overkant redt, en dat bewijst hij alleen als die overkant er echt niet is. Een
+# geërfde FSC_PROVIDER_MANAGER uit de shell van de aanroeper zou dat stil ondergraven.
+consumer_helft() {
+  env -i PATH="$PATH" HOME="$HOME" \
+    FSC_CONSUMER_OIN="$CONS_OIN" \
+    FSC_PROVIDER_OIN="$1" \
+    FSC_SERVICE_NAME="$MAGAZIJN_DIENST" \
+    FSC_OUTWAY_CERT="$CONS_OUTWAY_CERT" \
+    FSC_CONSUMER_MANAGER="https://manager.${UITVRAAG}.fsc-test.local:9443" \
+    FSC_CONSUMER_ADRES="$(fsc_component_adres "$CONS_NET" manager)" \
+    FSC_CONSUMER_CERT="${ENVDIR}/${UITVRAAG}/pki/internal/${UITVRAAG}/manager/cert.pem" \
+    FSC_CONSUMER_KEY="${ENVDIR}/${UITVRAAG}/pki/internal/${UITVRAAG}/manager/key.pem" \
+    FSC_CONSUMER_CA="${ENVDIR}/${UITVRAAG}/pki/internal/${UITVRAAG}/ca/root.pem" \
+    "${CONTRACTS}/bootstrap-consumer.sh"
+}
+
+# provider_helft <magazijn> <net> <oin>: idem voor de provider-kant.
+provider_helft() {
+  env -i PATH="$PATH" HOME="$HOME" \
+    FSC_PROVIDER_OIN="$3" \
+    FSC_DIENSTEN="$MAGAZIJN_DIENST" \
+    FSC_CONSUMERS="$CONS_OIN" \
+    FSC_PROVIDER_MANAGER="https://manager.${1}.fsc-test.local:9443" \
+    FSC_PROVIDER_ADRES="$(fsc_component_adres "$2" manager)" \
+    FSC_PROVIDER_CERT="${ENVDIR}/${1}/pki/internal/${1}/manager/cert.pem" \
+    FSC_PROVIDER_KEY="${ENVDIR}/${1}/pki/internal/${1}/manager/key.pem" \
+    FSC_PROVIDER_CA="${ENVDIR}/${1}/pki/internal/${1}/ca/root.pem" \
+    "${CONTRACTS}/bootstrap-provider.sh"
+}
+
+# geldige_contracten <peer> <net> <provider-oin>: hashes van geldige contracten voor deze combinatie.
+geldige_contracten() {
+  local json
+  json="$(fsc_manager_contracts "$ENVDIR" "$1" "$(fsc_component_adres "$2" manager)")" || return 1
+  fsc_grant_actief "$json" "$MAGAZIJN_DIENST" "$3" "$CONS_OIN" "$CONS_THUMB" | sort
+}
+
+# aantal_regels <tekst>: 0 voor leeg, anders het aantal niet-lege regels.
+aantal_regels() { printf '%s' "${1:-}" | grep -c . || true; }
+
+# tel_geldige <peer> <net> <provider-oin>: aantal geldige contracten op stdout, non-zero bij een
+# leesfout.
+#
+# Zonder deze tak zou een mislukte managerbevraging als "0 contracten" doorgaan. Twee mislukte
+# metingen op rij zijn dan gelijk aan elkaar, en de vergelijking "aantal ongewijzigd" wordt groen
+# op grond van twee fouten.
+#
+# De functie meldt zelf NIET: hij wordt in een commando-substitutie aangeroepen, dus een `fout`
+# hier zou `FOUTEN` in een subshell ophogen en bij terugkeer verdwenen zijn — waarna de smoke
+# alsnog groen eindigt. De aanroeper doet de melding.
+tel_geldige() {
+  local regels
+  regels="$(geldige_contracten "$1" "$2" "$3")" || return 1
+
+  aantal_regels "$regels"
+}
+
+# meet <naam> <peer> <net> <provider-oin>: tel_geldige met de melding op de juiste plek.
+meet() {
+  local naam="$1"; shift
+
+  tel_geldige "$@" || {
+    fout "kon de contracten van ${1} niet ophalen (${naam}): $(fsc_last_error)"
+    return 1
+  }
+}
+
+for magazijn in $MAGAZIJNEN; do
+  PROV_NET="$(fsc_peer_waarde NET "$magazijn")"
+  PROV_OIN="$(fsc_peer_waarde OIN "$magazijn")"
+  [ -n "$PROV_NET" ] && [ -n "$PROV_OIN" ] || { fout "NET_/OIN_ ontbreekt voor '${magazijn}'"; continue; }
+
+  echo "===== ${UITVRAAG} -> ${magazijn} ====="
+
+  VOORAF="$(meet vooraf "$UITVRAAG" "$CONS_NET" "$PROV_OIN")" || { fout "meting vooraf mislukt"; continue; }
+
+  # --- 1. Consumer dient in, alleen bij zijn eigen manager ---------------------------------------
+  echo "== 1. consumer-helft =="
+  rc=0
+  consumer_helft "$PROV_OIN" || rc=$?
+
+  case "$rc" in
+    0) ok "consumer: contract was al geldig (${VOORAF} contract(en) vooraf)" ;;
+    3) ok "consumer: ingediend en wachtend op de provider" ;;
+    *) fout "consumer-helft brak af met exit ${rc}"; continue ;;
+  esac
+
+  # --- 2. Provider tekent, alleen bij zijn eigen manager -----------------------------------------
+  echo "== 2. provider-helft =="
+
+  # De helft draait onder `env -i` met uitsluitend zijn eigen adres en certificaten, dus dat hij
+  # hier klaarkomt ís het bewijs dat hij de overkant niet nodig heeft.
+  rc=0
+  provider_helft "$magazijn" "$PROV_NET" "$PROV_OIN" || rc=$?
+
+  case "$rc" in
+    0|3) ok "provider: klaar met alleen zijn eigen manager in de omgeving" ;;
+    # 4 = er lag iets dat de autorisatietoets niet haalde. Geen crash: stap 3 stelt vast of ons
+    # eigen contract er wél doorheen kwam, en dat is wat deze smoke meet.
+    4) ok "provider: klaar, met een of meer contracten buiten de allowlist" ;;
+    *) fout "provider-helft brak af met exit ${rc}"; continue ;;
+  esac
+
+  # --- 3. Consumer ziet het contract geldig worden -----------------------------------------------
+  echo "== 3. consumer-helft opnieuw =="
+  rc=0
+  POGING=0
+
+  # De accept-handtekening reist via de mesh terug; dat duurt even. Zelfde grens als de orkestrator.
+  while :; do
+    rc=0
+    consumer_helft "$PROV_OIN" || rc=$?
+    [ "$rc" -eq 3 ] || break
+    [ "$POGING" -lt "${SPLIT_POGINGEN:-10}" ] || break
+
+    POGING=$((POGING + 1))
+    sleep "${SPLIT_WACHT:-2}"
+  done
+
+  if [ "$rc" -eq 0 ]; then
+    ok "consumer: contract is geldig geworden na de provider-helft"
+  else
+    fout "consumer zag het contract niet geldig worden (exit ${rc})"
+    continue
+  fi
+
+  # --- 4. Tweede ronde: niets erbij --------------------------------------------------------------
+  echo "== 4. tweede ronde =="
+  NA_EEN="$(meet na-ronde-1 "$UITVRAAG" "$CONS_NET" "$PROV_OIN")" || { fout "meting na ronde 1 mislukt"; continue; }
+
+  rc=0
+  consumer_helft "$PROV_OIN" || rc=$?
+  [ "$rc" -eq 0 ] && ok "consumer: herhaalde run is een no-op" \
+    || fout "consumer: herhaalde run gaf exit ${rc} in plaats van 0"
+
+  PROV_UIT="$(provider_helft "$magazijn" "$PROV_NET" "$PROV_OIN" 2>&1)" || {
+    fout "provider: herhaalde run brak af — $(printf '%s' "$PROV_UIT" | tail -n1)"
+    continue
+  }
+
+  case "$PROV_UIT" in
+    *"niets te tekenen"*) ok "provider: herhaalde run heeft niets meer te tekenen" ;;
+    *) fout "provider: herhaalde run tekende opnieuw — $(printf '%s' "$PROV_UIT" | tail -n1)" ;;
+  esac
+
+  NA_TWEE="$(meet na-ronde-2 "$UITVRAAG" "$CONS_NET" "$PROV_OIN")" || { fout "meting na ronde 2 mislukt"; continue; }
+
+  if [ "$NA_TWEE" -eq "$NA_EEN" ]; then
+    ok "aantal geldige contracten ongewijzigd na de tweede ronde (${NA_TWEE})"
+  else
+    fout "tweede ronde veranderde het aantal geldige contracten: ${NA_EEN} -> ${NA_TWEE}"
+  fi
+
+  # Eén contract is de bedoeling. Meer betekent dat de idempotentie lekt; de opruiming in de
+  # consumer-helft hoort dat in de volgende ronde recht te trekken, maar dan is er iets te melden.
+  if [ "$NA_TWEE" -eq 1 ]; then
+    ok "precies één geldig contract voor ${MAGAZIJN_DIENST}"
+  else
+    fout "verwachtte precies één geldig contract, vond ${NA_TWEE}"
+  fi
+
+  echo
+done
+
+if [ "$FOUTEN" -ne 0 ]; then
+  echo "SMOKE-CONTRACT-SPLIT ROOD: ${FOUTEN} bevinding(en)." >&2
+  exit 1
+fi
+
+echo "SMOKE-CONTRACT-SPLIT OK."

--- a/demo/environment/federatie/smoke-contract.sh
+++ b/demo/environment/federatie/smoke-contract.sh
@@ -46,22 +46,20 @@ CONS_OIN="$(fsc_peer_waarde OIN "$UITVRAAG")"
 # de inway van de provider.
 OUTWAY="http://$(fsc_component_adres "$CONS_NET" outway):8443"
 
+# Ruimte voor de inway om een gewijzigde upstream op te pikken (zie de lus bij het data-pad).
+UPSTREAM_POGINGEN="${UPSTREAM_POGINGEN:-5}"
+UPSTREAM_WACHT="${UPSTREAM_WACHT:-3}"
+
 # Thumbprint van de consumer-outway — zelfde grootheid als bootstrap.sh gebruikt om een contract
 # te identificeren. Nodig om hier dezelfde matcher (fsc_grant_actief) te kunnen hergebruiken.
 CONS_OUTWAY_CERT="${ENVDIR}/${UITVRAAG}/pki/out/${UITVRAAG}/outway/cert.pem"
 CONS_THUMB="$(fsc_outway_thumbprint "$CONS_OUTWAY_CERT")" \
   || { echo "FAIL: kon de outway-thumbprint niet berekenen uit ${CONS_OUTWAY_CERT}: $(fsc_last_error)" >&2; exit 1; }
 
-# manager_json <peer> <net>: de contracten van die peer via zijn interne API. Elke manager luistert
-# op zijn eigen adres, op de standaardpoort 9443.
+# manager_json <peer> <net>: de contracten van die peer via zijn interne API, op het manager-adres
+# binnen zijn eigen /24.
 manager_json() {
-  local peer="$1" net="$2" naam="manager.$1.fsc-test.local" poort=9443
-  curl -sS --fail-with-body --noproxy '*' \
-    --resolve "${naam}:${poort}:$(fsc_component_adres "$net" manager)" \
-    --cert "${ENVDIR}/${peer}/pki/internal/${peer}/manager/cert.pem" \
-    --key  "${ENVDIR}/${peer}/pki/internal/${peer}/manager/key.pem" \
-    --cacert "${ENVDIR}/${peer}/pki/internal/${peer}/ca/root.pem" \
-    "https://${naam}:${poort}/v1/contracts" 2>"$ERRLOG"
+  fsc_manager_contracts "$ENVDIR" "$1" "$(fsc_component_adres "$2" manager)"
 }
 
 for magazijn in $MAGAZIJNEN; do
@@ -100,12 +98,35 @@ for magazijn in $MAGAZIJNEN; do
     fi
   done
 
-  if [ -z "$GRANT" ]; then
-    fout "geen grant-hash gevonden — de asserts hieronder kunnen niet draaien"
+  if ! fsc_grant_bruikbaar "$GRANT"; then
+    # Niet `[ -z "$GRANT" ]`: fsc_grant_hash levert bij een mislukking de sentinel `unknown`, en
+    # dan zou deze tak nooit vuren. De asserts hieronder draaien vervolgens met een bogus header en
+    # melden een 400 op het data-pad — wat naar het verkeerde component wijst.
+    fout "geen bruikbaar grant-hash gevonden (${GRANT:-<leeg>}) — de asserts hieronder kunnen niet draaien"
     continue
   fi
 
   # --- 2. Data-pad --------------------------------------------------------------------------------
+  # De echo-stub moet achter de inway staan: deze assert herkent het antwoord aan de tekst van die
+  # stub. smoke-keten.sh zet daar het échte magazijn neer, dus zonder deze regel hangt de uitkomst
+  # af van welke smoke er het laatst gedraaid heeft.
+  if ! fsc_zet_upstream "$ENVDIR" "$magazijn" "http://stub-upstream:8080" >/dev/null 2>"$ERRLOG"; then
+    fout "kon de stub-upstream van ${magazijn} niet zetten: $(fsc_last_error)"
+  fi
+
+  # Een gewijzigde upstream propageert asynchroon naar de inway: zonder deze lus meet de assert
+  # hieronder nog de vórige upstream. Pollen op de echo-tekst van de stub, want dát is waar de
+  # assert op matcht.
+  POGING=1
+
+  while [ "$POGING" -le "$UPSTREAM_POGINGEN" ]; do
+    curl -sS --noproxy '*' --max-time 10 "${OUTWAY}/" -H "Fsc-Grant-Hash: ${GRANT}" 2>/dev/null \
+      | grep -qF "hello from ${magazijn}" && break
+
+    [ "$POGING" -lt "$UPSTREAM_POGINGEN" ] && sleep "$UPSTREAM_WACHT"
+    POGING=$((POGING + 1))
+  done
+
   # De outway resolvet de grant-hash zelf naar dienst en inway, en haalt daarbij zijn eigen token
   # op. Dat token wordt hier dus niet nagebouwd.
   echo "== 2. data-pad =="

--- a/demo/environment/federatie/smoke-contract.sh
+++ b/demo/environment/federatie/smoke-contract.sh
@@ -38,11 +38,13 @@ ok()   { echo "OK: $*"; }
 : "${MAGAZIJNEN:?geen MAGAZIJNEN in peers.env}"
 : "${MAGAZIJN_DIENST:?geen MAGAZIJN_DIENST in peers.env}"
 
-CONS_BLOK="$(fsc_peer_waarde BLOK "$UITVRAAG")"
+CONS_NET="$(fsc_peer_waarde NET "$UITVRAAG")"
 CONS_OIN="$(fsc_peer_waarde OIN "$UITVRAAG")"
-[ -n "$CONS_BLOK" ] && [ -n "$CONS_OIN" ] || { echo "FAIL: BLOK_/OIN_ ontbreekt voor '${UITVRAAG}'." >&2; exit 1; }
+[ -n "$CONS_NET" ] && [ -n "$CONS_OIN" ] || { echo "FAIL: NET_/OIN_ ontbreekt voor '${UITVRAAG}'." >&2; exit 1; }
 
-OUTWAY="http://127.0.0.1:$((CONS_BLOK + 40))"
+# De outway spreekt plain HTTP op zijn eigen adres; de mTLS begint pas aan de andere kant, richting
+# de inway van de provider.
+OUTWAY="http://$(fsc_component_adres "$CONS_NET" outway):8443"
 
 # Thumbprint van de consumer-outway — zelfde grootheid als bootstrap.sh gebruikt om een contract
 # te identificeren. Nodig om hier dezelfde matcher (fsc_grant_actief) te kunnen hergebruiken.
@@ -50,11 +52,12 @@ CONS_OUTWAY_CERT="${ENVDIR}/${UITVRAAG}/pki/out/${UITVRAAG}/outway/cert.pem"
 CONS_THUMB="$(fsc_outway_thumbprint "$CONS_OUTWAY_CERT")" \
   || { echo "FAIL: kon de outway-thumbprint niet berekenen uit ${CONS_OUTWAY_CERT}: $(fsc_last_error)" >&2; exit 1; }
 
-# manager_json <peer> <blok>: de contracten van die peer via zijn interne API (blok+01).
+# manager_json <peer> <net>: de contracten van die peer via zijn interne API. Elke manager luistert
+# op zijn eigen adres, op de standaardpoort 9443.
 manager_json() {
-  local peer="$1" blok="$2" naam="manager.$1.fsc-test.local" poort=$(( $2 + 1 ))
+  local peer="$1" net="$2" naam="manager.$1.fsc-test.local" poort=9443
   curl -sS --fail-with-body --noproxy '*' \
-    --resolve "${naam}:${poort}:127.0.0.1" \
+    --resolve "${naam}:${poort}:$(fsc_component_adres "$net" manager)" \
     --cert "${ENVDIR}/${peer}/pki/internal/${peer}/manager/cert.pem" \
     --key  "${ENVDIR}/${peer}/pki/internal/${peer}/manager/key.pem" \
     --cacert "${ENVDIR}/${peer}/pki/internal/${peer}/ca/root.pem" \
@@ -62,19 +65,19 @@ manager_json() {
 }
 
 for magazijn in $MAGAZIJNEN; do
-  PROV_BLOK="$(fsc_peer_waarde BLOK "$magazijn")"
+  PROV_NET="$(fsc_peer_waarde NET "$magazijn")"
   PROV_OIN="$(fsc_peer_waarde OIN "$magazijn")"
-  [ -n "$PROV_BLOK" ] && [ -n "$PROV_OIN" ] || { fout "BLOK_/OIN_ ontbreekt voor '${magazijn}'"; continue; }
+  [ -n "$PROV_NET" ] && [ -n "$PROV_OIN" ] || { fout "NET_/OIN_ ontbreekt voor '${magazijn}'"; continue; }
 
   echo "===== ${UITVRAAG} -> ${magazijn} ====="
 
   # --- 1. Contract op beide managers ------------------------------------------------------------
   echo "== 1. contract wederzijds ondertekend =="
   GRANT=""
-  for kant in "$UITVRAAG:$CONS_BLOK" "$magazijn:$PROV_BLOK"; do
-    peer="${kant%%:*}"; blok="${kant##*:}"
+  for kant in "$UITVRAAG:$CONS_NET" "$magazijn:$PROV_NET"; do
+    peer="${kant%%:*}"; net="${kant##*:}"
 
-    if ! JSON="$(manager_json "$peer" "$blok")"; then
+    if ! JSON="$(manager_json "$peer" "$net")"; then
       fout "${peer}: contracten niet op te halen: $(fsc_last_error)"
       continue
     fi
@@ -116,6 +119,11 @@ for magazijn in $MAGAZIJNEN; do
   # iets anders.
   if [ "$CODE" = "200" ] && printf '%s' "$PAYLOAD" | grep -qF "hello from ${magazijn}"; then
     ok "data-pad levert 200 met de echo van ${magazijn}"
+  elif printf '%s' "$PAYLOAD" | grep -qF "service could not be found"; then
+    # Een contract geeft toegang tot een dienst die gepubliceerd MOET zijn; is dat niet gebeurd, dan
+    # faalt de token-uitgifte diep in de keten (outway -> manager -> controller) met een kale 500
+    # waarin het woord 'contract' niet voorkomt. Zonder deze tak zoek je dat in de verkeerde hoek.
+    fout "de dienst '${MAGAZIJN_DIENST}' is niet gepubliceerd op ${magazijn} — draai eerst ${magazijn}/deploy/local/publish-service.sh (of smoke-federatie.sh, die publiceert 'm)"
   else
     fout "data-pad niet geslaagd (HTTP ${CODE:-<geen>}): $(printf '%s' "$PAYLOAD" | head -n1) $(fsc_last_error)"
   fi
@@ -134,7 +142,7 @@ for magazijn in $MAGAZIJNEN; do
   # de autorisatielaag hoort je alsnog te weigeren.
   INWAY_NAAM="inway.${magazijn}.fsc-test.local"
   ZONDER_TOKEN="$(curl -sS --noproxy '*' -o /dev/null -w '%{http_code}' --max-time 15 \
-                    --resolve "${INWAY_NAAM}:443:127.0.0.1" \
+                    --resolve "${INWAY_NAAM}:443:${ADRES_ROUTER}" \
                     --cert "${ENVDIR}/${UITVRAAG}/pki/out/${UITVRAAG}/outway/cert.pem" \
                     --key  "${ENVDIR}/${UITVRAAG}/pki/out/${UITVRAAG}/outway/key.pem" \
                     --cacert "${ENVDIR}/${UITVRAAG}/pki/ca/root.pem" \
@@ -181,9 +189,9 @@ done
 # canonieke contract-hash vóór en na is de eigenlijke garantie.
 echo "===== 5. idempotentie ====="
 
-contract_hashes_per_magazijn() {  # gebruikt $UITVRAAG/$CONS_BLOK/$CONS_THUMB uit de buitenste scope
+contract_hashes_per_magazijn() {  # gebruikt $UITVRAAG/$CONS_NET/$CONS_THUMB uit de buitenste scope
   local json magazijn prov_oin hash
-  json="$(manager_json "$UITVRAAG" "$CONS_BLOK")" || json=""
+  json="$(manager_json "$UITVRAAG" "$CONS_NET")" || json=""
   for magazijn in $MAGAZIJNEN; do
     prov_oin="$(fsc_peer_waarde OIN "$magazijn")"
     hash="$(fsc_grant_actief "$json" "$MAGAZIJN_DIENST" "$prov_oin" "$CONS_OIN" "$CONS_THUMB" \

--- a/demo/environment/federatie/smoke-contract.sh
+++ b/demo/environment/federatie/smoke-contract.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# Smoke: bewijst dat de uitvraag daadwerkelijk bij een magazijn kan afnemen, en dat die toegang
+# ook echt afgedwongen én verantwoord wordt. Draai na `./federatie.sh up` en
+# `./contracts/fbs-contracten.sh`.
+#
+#   1. contract — wederzijds ondertekend en `CONTRACT_STATE_VALID` op BEIDE managers;
+#   2. data-pad — outway -> router -> inway -> upstream levert 200 met de echo van dát magazijn,
+#      niet die van de uitvraag-peer zelf;
+#   3. afdwinging — een onbekende grant-hash op de outway en een call rechtstreeks naar de inway
+#      zónder token worden geweigerd. Zonder deze twee zegt een 200 niets: dan kan het pad
+#      openstaan in plaats van geautoriseerd zijn;
+#   4. verantwoording — beide peers loggen dezelfde transactie, de een als uitgaand en de ander als
+#      inkomend, met een grant-hash erbij;
+#   5. idempotentie — de bootstrap nog eens draaien levert geen tweede contract op.
+#
+# Linux + podman: gebruikt `podman` en `jq`.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ENVDIR="$(cd "${HERE}/.." && pwd)"
+
+# shellcheck source=../lib/fsc-harness.sh
+. "${ENVDIR}/lib/fsc-harness.sh"
+# shellcheck source=peers.env
+. "${HERE}/peers.env"
+
+fsc_errlog_init
+fsc_have_jq
+
+command -v curl >/dev/null 2>&1 || { echo "FAIL: 'curl' is vereist." >&2; exit 1; }
+[ "$HAVE_JQ" -eq 1 ] || { echo "FAIL: 'jq' is vereist — elke assert hieronder leest contract-JSON." >&2; exit 1; }
+
+FOUTEN=0
+fout() { echo "FAIL: $*" >&2; FOUTEN=$((FOUTEN + 1)); }
+ok()   { echo "OK: $*"; }
+
+: "${UITVRAAG:?geen UITVRAAG in peers.env}"
+: "${MAGAZIJNEN:?geen MAGAZIJNEN in peers.env}"
+: "${MAGAZIJN_DIENST:?geen MAGAZIJN_DIENST in peers.env}"
+
+CONS_BLOK="$(fsc_peer_waarde BLOK "$UITVRAAG")"
+CONS_OIN="$(fsc_peer_waarde OIN "$UITVRAAG")"
+[ -n "$CONS_BLOK" ] && [ -n "$CONS_OIN" ] || { echo "FAIL: BLOK_/OIN_ ontbreekt voor '${UITVRAAG}'." >&2; exit 1; }
+
+OUTWAY="http://127.0.0.1:$((CONS_BLOK + 40))"
+
+# manager_json <peer> <blok>: de contracten van die peer via zijn interne API (blok+01).
+manager_json() {
+  local peer="$1" blok="$2" naam="manager.$1.fsc-test.local" poort=$(( $2 + 1 ))
+  curl -sS --fail-with-body --noproxy '*' \
+    --resolve "${naam}:${poort}:127.0.0.1" \
+    --cert "${ENVDIR}/${peer}/pki/internal/${peer}/manager/cert.pem" \
+    --key  "${ENVDIR}/${peer}/pki/internal/${peer}/manager/key.pem" \
+    --cacert "${ENVDIR}/${peer}/pki/internal/${peer}/ca/root.pem" \
+    "https://${naam}:${poort}/v1/contracts" 2>"$ERRLOG"
+}
+
+for magazijn in $MAGAZIJNEN; do
+  PROV_BLOK="$(fsc_peer_waarde BLOK "$magazijn")"
+  PROV_OIN="$(fsc_peer_waarde OIN "$magazijn")"
+  [ -n "$PROV_BLOK" ] && [ -n "$PROV_OIN" ] || { fout "BLOK_/OIN_ ontbreekt voor '${magazijn}'"; continue; }
+
+  echo "===== ${UITVRAAG} -> ${magazijn} ====="
+
+  # --- 1. Contract op beide managers ------------------------------------------------------------
+  echo "== 1. contract wederzijds ondertekend =="
+  GRANT=""
+  for kant in "$UITVRAAG:$CONS_BLOK" "$magazijn:$PROV_BLOK"; do
+    peer="${kant%%:*}"; blok="${kant##*:}"
+
+    if ! JSON="$(manager_json "$peer" "$blok")"; then
+      fout "${peer}: contracten niet op te halen: $(fsc_last_error)"
+      continue
+    fi
+
+    # Beide handtekeningen én de lifecycle-state. `signatures.accept` alleen is niet genoeg: de
+    # manager gebruikt de grant pas als het contract óók `CONTRACT_STATE_VALID` is.
+    GEVONDEN="$(printf '%s' "$JSON" | jq -r \
+      --arg svc "$MAGAZIJN_DIENST" --arg prov "$PROV_OIN" --arg cons "$CONS_OIN" '
+      [ .contracts[]?
+        | select(.state == "CONTRACT_STATE_VALID")
+        | select(any(.content.grants[]?;
+              .type == "GRANT_TYPE_SERVICE_CONNECTION"
+              and .service.name == $svc and .service.peer_id == $prov
+              and .outway.peer_id == $cons))
+        | select((.signatures.accept | has($prov)) and (.signatures.accept | has($cons)))
+        | .content.grants[] | select(.type == "GRANT_TYPE_SERVICE_CONNECTION") | .hash ]
+      | .[0] // ""' 2>/dev/null)"
+
+    if [ -n "$GEVONDEN" ]; then
+      ok "${peer}: contract geldig met handtekeningen van beide peers"
+      [ -n "$GRANT" ] || GRANT="$GEVONDEN"
+    else
+      fout "${peer}: geen geldig contract met beide handtekeningen voor ${MAGAZIJN_DIENST}"
+    fi
+  done
+
+  if [ -z "$GRANT" ]; then
+    fout "geen grant-hash gevonden — de asserts hieronder kunnen niet draaien"
+    continue
+  fi
+
+  # --- 2. Data-pad --------------------------------------------------------------------------------
+  # De outway resolvet de grant-hash zelf naar dienst en inway, en haalt daarbij zijn eigen token
+  # op. Dat token wordt hier dus niet nagebouwd.
+  echo "== 2. data-pad =="
+  BODY="$(curl -sS --noproxy '*' -o - -w '\n%{http_code}' --max-time 20 \
+            "${OUTWAY}/" -H "Fsc-Grant-Hash: ${GRANT}" 2>"$ERRLOG" || true)"
+  CODE="$(printf '%s' "$BODY" | tail -n1)"
+  PAYLOAD="$(printf '%s' "$BODY" | sed '$d')"
+
+  # De echo van elk magazijn draagt zijn eigen naam, dus dit onderscheidt "de juiste peer
+  # antwoordde" van "er kwam toevallig een 200 terug" — de stub van de uitvraag-peer zelf zegt
+  # iets anders.
+  if [ "$CODE" = "200" ] && printf '%s' "$PAYLOAD" | grep -qF "hello from ${magazijn}"; then
+    ok "data-pad levert 200 met de echo van ${magazijn}"
+  else
+    fout "data-pad niet geslaagd (HTTP ${CODE:-<geen>}): $(printf '%s' "$PAYLOAD" | head -n1) $(fsc_last_error)"
+  fi
+
+  # --- 3. Afdwinging ------------------------------------------------------------------------------
+  echo "== 3. toegang wordt afgedwongen =="
+  ONBEKEND="$(curl -sS --noproxy '*' -o /dev/null -w '%{http_code}' --max-time 15 \
+                "${OUTWAY}/" -H 'Fsc-Grant-Hash: $1$3$deze-grant-bestaat-niet' 2>/dev/null || true)"
+  if [ "$ONBEKEND" = "400" ]; then
+    ok "onbekende grant-hash op de outway wordt geweigerd (400)"
+  else
+    fout "onbekende grant-hash gaf HTTP ${ONBEKEND:-<geen>}, verwacht 400"
+  fi
+
+  # Rechtstreeks naar de inway mét geldig group-cert maar zónder token: de mTLS-laag laat je binnen,
+  # de autorisatielaag hoort je alsnog te weigeren.
+  INWAY_NAAM="inway.${magazijn}.fsc-test.local"
+  ZONDER_TOKEN="$(curl -sS --noproxy '*' -o /dev/null -w '%{http_code}' --max-time 15 \
+                    --resolve "${INWAY_NAAM}:443:127.0.0.1" \
+                    --cert "${ENVDIR}/${UITVRAAG}/pki/out/${UITVRAAG}/outway/cert.pem" \
+                    --key  "${ENVDIR}/${UITVRAAG}/pki/out/${UITVRAAG}/outway/key.pem" \
+                    --cacert "${ENVDIR}/${UITVRAAG}/pki/ca/root.pem" \
+                    "https://${INWAY_NAAM}/" 2>/dev/null || true)"
+  if [ "$ZONDER_TOKEN" = "401" ]; then
+    ok "inway weigert een call zonder token (401)"
+  else
+    fout "inway zonder token gaf HTTP ${ZONDER_TOKEN:-<geen>}, verwacht 401"
+  fi
+
+  # --- 4. Verantwoording --------------------------------------------------------------------------
+  # Beide peers horen dezelfde transactie te loggen: bij de consumer uitgaand, bij de provider
+  # inkomend. Dat is de fsc-logging-keten over de peer-grens.
+  echo "== 4. verantwoording =="
+  if ! PROJECT="$(fsc_compose_project "${ENVDIR}/${GASTHEER}/deploy/local/docker-compose.yaml")"; then
+    fout "projectnaam van de gastheer niet af te leiden"
+  else
+    txids() {  # <db> <richting>
+      podman exec "${PROJECT}-postgres-1" psql -U postgres -d "$1" -tA \
+        -c "SELECT transaction_id FROM transactionlog.records
+            WHERE direction = '$2' AND service_name = '${MAGAZIJN_DIENST}' AND grant_hash IS NOT NULL" \
+        2>"$ERRLOG" | sort -u
+    }
+
+    CONS_DB="fsc_txlog_$(fsc_peer_var "$UITVRAAG")"
+    PROV_DB="fsc_txlog_$(fsc_peer_var "$magazijn")"
+
+    UIT="$(txids "$CONS_DB" out)" || UIT=""
+    IN="$(txids "$PROV_DB" in)"   || IN=""
+    GEDEELD="$(comm -12 <(printf '%s\n' "$UIT") <(printf '%s\n' "$IN") | grep -c . || true)"
+
+    if [ "${GEDEELD:-0}" -gt 0 ]; then
+      ok "${GEDEELD} transactie(s) in beide txlogs, uitgaand bij ${UITVRAAG} en inkomend bij ${magazijn}"
+    else
+      fout "geen gedeelde transactie-id tussen ${CONS_DB} (out) en ${PROV_DB} (in): $(fsc_last_error)"
+    fi
+  fi
+done
+
+# --- 5. Idempotentie ------------------------------------------------------------------------------
+# Zonder state-file: de bootstrap moet het bestaande contract herkennen uit de contracten zelf.
+# Anders zou elke deploy er een geldig contract bij maken.
+echo "===== 5. idempotentie ====="
+VOOR="$(manager_json "$UITVRAAG" "$CONS_BLOK" | jq '[.contracts[]?|select(any(.content.grants[]?; .type=="GRANT_TYPE_SERVICE_CONNECTION"))]|length' 2>/dev/null || echo -1)"
+
+if "${HERE}/contracts/fbs-contracten.sh" >/dev/null 2>&1; then
+  NA="$(manager_json "$UITVRAAG" "$CONS_BLOK" | jq '[.contracts[]?|select(any(.content.grants[]?; .type=="GRANT_TYPE_SERVICE_CONNECTION"))]|length' 2>/dev/null || echo -2)"
+
+  if [ "$VOOR" -gt 0 ] && [ "$NA" -eq "$VOOR" ]; then
+    ok "her-draaien van de bootstrap levert geen extra contract op (${VOOR} -> ${NA})"
+  else
+    fout "aantal serviceConnection-contracten ging van ${VOOR} naar ${NA}"
+  fi
+else
+  fout "fbs-contracten.sh faalde bij de her-draai"
+fi
+
+echo
+if [ "$FOUTEN" -eq 0 ]; then
+  echo "== CONTRACT-SMOKE GROEN =="
+else
+  echo "== CONTRACT-SMOKE ROOD: ${FOUTEN} bevinding(en) ==" >&2
+  exit 1
+fi

--- a/demo/environment/federatie/smoke-contract.sh
+++ b/demo/environment/federatie/smoke-contract.sh
@@ -44,6 +44,12 @@ CONS_OIN="$(fsc_peer_waarde OIN "$UITVRAAG")"
 
 OUTWAY="http://127.0.0.1:$((CONS_BLOK + 40))"
 
+# Thumbprint van de consumer-outway — zelfde grootheid als bootstrap.sh gebruikt om een contract
+# te identificeren. Nodig om hier dezelfde matcher (fsc_grant_actief) te kunnen hergebruiken.
+CONS_OUTWAY_CERT="${ENVDIR}/${UITVRAAG}/pki/out/${UITVRAAG}/outway/cert.pem"
+CONS_THUMB="$(fsc_outway_thumbprint "$CONS_OUTWAY_CERT")" \
+  || { echo "FAIL: kon de outway-thumbprint niet berekenen uit ${CONS_OUTWAY_CERT}: $(fsc_last_error)" >&2; exit 1; }
+
 # manager_json <peer> <blok>: de contracten van die peer via zijn interne API (blok+01).
 manager_json() {
   local peer="$1" blok="$2" naam="manager.$1.fsc-test.local" poort=$(( $2 + 1 ))
@@ -73,23 +79,19 @@ for magazijn in $MAGAZIJNEN; do
       continue
     fi
 
-    # Beide handtekeningen én de lifecycle-state. `signatures.accept` alleen is niet genoeg: de
-    # manager gebruikt de grant pas als het contract óók `CONTRACT_STATE_VALID` is.
-    GEVONDEN="$(printf '%s' "$JSON" | jq -r \
-      --arg svc "$MAGAZIJN_DIENST" --arg prov "$PROV_OIN" --arg cons "$CONS_OIN" '
-      [ .contracts[]?
-        | select(.state == "CONTRACT_STATE_VALID")
-        | select(any(.content.grants[]?;
-              .type == "GRANT_TYPE_SERVICE_CONNECTION"
-              and .service.name == $svc and .service.peer_id == $prov
-              and .outway.peer_id == $cons))
-        | select((.signatures.accept | has($prov)) and (.signatures.accept | has($cons)))
-        | .content.grants[] | select(.type == "GRANT_TYPE_SERVICE_CONNECTION") | .hash ]
-      | .[0] // ""' 2>/dev/null)"
+    # Zelfde matcher als contracts/bootstrap.sh gebruikt om een bestaand contract te herkennen:
+    # lifecycle-state, niet-ingetrokken, beide handtekeningen én de outway-thumbprint. Dat laatste
+    # ontbrak hier voorheen — zonder thumbprint-check zou een contract voor een andere (bv. na
+    # certificaatrotatie verouderde) consumer-outway ook meetellen.
+    CONTRACT_HASH="$(fsc_grant_actief "$JSON" "$MAGAZIJN_DIENST" "$PROV_OIN" "$CONS_OIN" "$CONS_THUMB" \
+      | sort | head -n1)" || CONTRACT_HASH=""
 
-    if [ -n "$GEVONDEN" ]; then
+    if [ -n "$CONTRACT_HASH" ]; then
       ok "${peer}: contract geldig met handtekeningen van beide peers"
-      [ -n "$GRANT" ] || GRANT="$GEVONDEN"
+      if [ -z "$GRANT" ]; then
+        # De grant-hash (voor de Fsc-Grant-Hash-header) is niet het contract-hash zelf.
+        GRANT="$(fsc_grant_hash "$JSON" "$CONTRACT_HASH" "$MAGAZIJN_DIENST" "$CONS_THUMB")"
+      fi
     else
       fout "${peer}: geen geldig contract met beide handtekeningen voor ${MAGAZIJN_DIENST}"
     fi
@@ -174,21 +176,37 @@ done
 
 # --- 5. Idempotentie ------------------------------------------------------------------------------
 # Zonder state-file: de bootstrap moet het bestaande contract herkennen uit de contracten zelf.
-# Anders zou elke deploy er een geldig contract bij maken.
+# Anders zou elke deploy er een geldig contract bij maken. Een aggregaat-COUNT over alle magazijnen
+# zou een verschuiving (het ene magazijn erbij, het andere eraf) niet zien; per-magazijn hetzelfde
+# canonieke contract-hash vóór en na is de eigenlijke garantie.
 echo "===== 5. idempotentie ====="
-VOOR="$(manager_json "$UITVRAAG" "$CONS_BLOK" | jq '[.contracts[]?|select(any(.content.grants[]?; .type=="GRANT_TYPE_SERVICE_CONNECTION"))]|length' 2>/dev/null || echo -1)"
 
-if "${HERE}/contracts/fbs-contracten.sh" >/dev/null 2>&1; then
-  NA="$(manager_json "$UITVRAAG" "$CONS_BLOK" | jq '[.contracts[]?|select(any(.content.grants[]?; .type=="GRANT_TYPE_SERVICE_CONNECTION"))]|length' 2>/dev/null || echo -2)"
+contract_hashes_per_magazijn() {  # gebruikt $UITVRAAG/$CONS_BLOK/$CONS_THUMB uit de buitenste scope
+  local json magazijn prov_oin hash
+  json="$(manager_json "$UITVRAAG" "$CONS_BLOK")" || json=""
+  for magazijn in $MAGAZIJNEN; do
+    prov_oin="$(fsc_peer_waarde OIN "$magazijn")"
+    hash="$(fsc_grant_actief "$json" "$MAGAZIJN_DIENST" "$prov_oin" "$CONS_OIN" "$CONS_THUMB" \
+      | sort | head -n1)" || hash=""
+    printf '%s=%s\n' "$magazijn" "$hash"
+  done
+}
 
-  if [ "$VOOR" -gt 0 ] && [ "$NA" -eq "$VOOR" ]; then
-    ok "her-draaien van de bootstrap levert geen extra contract op (${VOOR} -> ${NA})"
+VOOR="$(contract_hashes_per_magazijn)"
+HERDRAAI_LOG="$(mktemp)"
+
+if "${HERE}/contracts/fbs-contracten.sh" >"$HERDRAAI_LOG" 2>&1; then
+  NA="$(contract_hashes_per_magazijn)"
+
+  if [ -n "$VOOR" ] && [ "$VOOR" = "$NA" ] && ! printf '%s\n' "$VOOR" | grep -q '=$'; then
+    ok "her-draaien van de bootstrap levert per magazijn hetzelfde contract op"
   else
-    fout "aantal serviceConnection-contracten ging van ${VOOR} naar ${NA}"
+    fout "contract-hash per magazijn verschilt (of ontbreekt) vóór/na de her-draai — vóór: [${VOOR}] na: [${NA}]"
   fi
 else
-  fout "fbs-contracten.sh faalde bij de her-draai"
+  fout "fbs-contracten.sh faalde bij de her-draai: $(tail -n 10 "$HERDRAAI_LOG")"
 fi
+rm -f "$HERDRAAI_LOG"
 
 echo
 if [ "$FOUTEN" -eq 0 ]; then

--- a/demo/environment/federatie/smoke-federatie.sh
+++ b/demo/environment/federatie/smoke-federatie.sh
@@ -226,7 +226,13 @@ done
 # De router opent zijn poort uit de gemounte haproxy-config en postgres drukt zijn bind uit als
 # `listen_addresses=` zonder poort; beide ontsnappen dus aan de extractie uit de overlays.
 VOOR_INFRA=$FOUTEN
-if ! ROUTER_BINDS="$(binds_uit "${HERE}/haproxy.federatie.cfg")" || [ -z "$ROUTER_BINDS" ]; then
+# Alleen de `bind`-regels: `binds_uit` grept élk adres in het bestand, en dat zijn ook de
+# `server s1 <adres>`-backends. Die horen bij de peers, niet bij de router — zonder dit filter zou
+# een liggende inway hier als "de router luistert niet" gemeld worden, en dubbel geteld bovenop de
+# terechte melding uit de peer-lus.
+if ! ROUTER_BINDS="$(grep -E '^[[:space:]]*bind[[:space:]]' "${HERE}/haproxy.federatie.cfg" \
+                       | grep -oE "${FED_RE#^}[0-9]+\.[0-9]+:[0-9]+" | sort -u)" \
+   || [ -z "$ROUTER_BINDS" ]; then
   fout "geen ${FED_PREFIX}-bind leesbaar uit haproxy.federatie.cfg — deze assert meet niets"
 else
   for bind in $ROUTER_BINDS; do
@@ -256,8 +262,12 @@ ok_tenzij "$VOOR_ONBEKEND" "geen onbekende luisteraar binnen ${FED_PREFIX}."
 # rood op gaan zou de assert op termijn versoepeld krijgen. TCP-only; de componenten zijn HTTP/TLS.
 VOOR_BUITEN=$FOUTEN
 # `LISTENERS` leeg is hierboven al gemeld; hier alleen de OK onderdrukken, niet dubbel tellen.
+# Regelgewijs lezen en niet `for adres in $BUITEN`: dat splitst op spaties én globt, en `ss` schrijft
+# een IPv6-wildcard als `*:8080` — bash vervangt dat dan door bestandsnamen uit de huidige map, en
+# juist deze negatieve assert zou daardoor stil verzwakken.
 BUITEN="$(printf '%s\n' "$LISTENERS" | grep -vE "$LOOPBACK_RE" || true)"
-for adres in $BUITEN; do
+while IFS= read -r adres; do
+  [ -n "$adres" ] || continue
   poort="${adres##*:}"
 
   for bind in $VERWACHT_BINDS; do
@@ -266,7 +276,10 @@ for adres in $BUITEN; do
       break
     fi
   done
-done
+done <<EOF
+$BUITEN
+EOF
+
 if [ -n "$LISTENERS" ]; then
   ok_tenzij "$VOOR_BUITEN" "geen federatie-poort luistert buiten loopback (TCP)"
 fi

--- a/demo/environment/federatie/smoke-keten.sh
+++ b/demo/environment/federatie/smoke-keten.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# Smoke: bewijst dat de FBS-keten écht door FSC loopt — berichtenuitvraag haalt een bericht op bij
+# berichtenmagazijn-a via outway -> router -> inway, in plaats van rechtstreeks.
+#
+#   1. data-pad — een bericht dat alleen in de database van magazijn-a bestaat, komt via de
+#      uitvraag terug. Een 200 op zichzelf zegt niets: de inhoud moet uniek zijn voor deze run,
+#      anders kan een oud bericht uit de cache of een stub de assert groen houden;
+#   2. verantwoording — dezelfde transactie staat in beide txlogs, uitgaand bij de uitvraag-peer en
+#      inkomend bij het magazijn. Dit onderscheidt "door de keten" van "toevallig hetzelfde
+#      antwoord": ging de call rechtstreeks, dan groeit geen van beide logboeken;
+#   3. het niet-FSC-pad blijft werken — magazijn-b loopt rechtstreeks en mag hier niet door sneuvelen.
+#
+# Voorwaarden:
+#   - de federatie draait en het contract staat  -> ./federatie.sh up && contracts/fbs-contracten.sh
+#   - magazijn-a's inway wijst naar het ECHTE magazijn, niet naar de stub:
+#       FSC_UPSTREAM_URL=http://127.0.0.1:8090 ../magazijn-a/deploy/local/publish-service.sh
+#   - de demo-stack draait met de uitvraag door de outway:
+#       MODUS=hostnet MAGAZIJN_A_URL=http://127.20.1.5:8443 demo/podman-up.sh
+#
+# Linux + podman: gebruikt `podman` en `curl`.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ENVDIR="$(cd "${HERE}/.." && pwd)"
+
+# shellcheck source=../lib/fsc-harness.sh
+. "${ENVDIR}/lib/fsc-harness.sh"
+# shellcheck source=peers.env
+. "${HERE}/peers.env"
+
+fsc_errlog_init
+
+UITVRAAG_URL="${UITVRAAG_URL:-http://127.0.0.1:8086/api/v1}"
+MAGAZIJN_A_DIRECT="${MAGAZIJN_A_DIRECT:-http://127.0.0.1:8090/api/v1}"
+MAGAZIJN_B_DIRECT="${MAGAZIJN_B_DIRECT:-http://127.0.0.1:8091/api/v1}"
+OPHAAL_TIMEOUT="${OPHAAL_TIMEOUT:-60}"
+# Ruimte voor de inway om een gewijzigde upstream op te pikken; elke poging is een volledige
+# ophaling, dus dit is geen vaste wachttijd maar een bovengrens.
+KETEN_POGINGEN="${KETEN_POGINGEN:-5}"
+KETEN_WACHT="${KETEN_WACHT:-3}"
+
+# Testgegevens. Elke run een VERSE ontvanger, en niet een vaste test-BSN: de uitvraag houdt een
+# sessiecache per ontvanger, dus bij een tweede run zou `_ophalen` uit die cache serveren zonder het
+# magazijn ooit te bellen. Assert 1 blijft dan groen terwijl de keten stuk kan zijn, en assert 2
+# ziet geen nieuwe transactie. De BSN moet door de elfproef komen, anders weigert het magazijn hem
+# en leest dat als een ketenfout.
+nieuwe_bsn() {
+  local cijfers som i c laatste
+
+  while :; do
+    cijfers=""; som=0
+
+    for i in 9 8 7 6 5 4 3 2; do
+      # Eerste cijfer nooit 0: een BSN met een voorloopnul is negen tekens lang maar wordt door
+      # sommige parsers als achtcijferig gelezen.
+      if [ "$i" -eq 9 ]; then c=$((RANDOM % 9 + 1)); else c=$((RANDOM % 10)); fi
+      cijfers="${cijfers}${c}"
+      som=$((som + c * i))
+    done
+
+    # Het negende cijfer telt met gewicht -1; bestaat er geen passend cijfer 0-9, dan opnieuw.
+    for laatste in 0 1 2 3 4 5 6 7 8 9; do
+      if [ $(( (som - laatste) % 11 )) -eq 0 ]; then
+        printf '%s%s' "$cijfers" "$laatste"
+        return 0
+      fi
+    done
+  done
+}
+
+BSN="${KETEN_BSN:-$(nieuwe_bsn)}"
+AFZENDER_OIN="$(fsc_peer_waarde OIN magazijn-a)"
+
+FOUTEN=0
+fout() { echo "FAIL: $*" >&2; FOUTEN=$((FOUTEN + 1)); }
+ok()   { echo "OK: $*"; }
+
+command -v curl >/dev/null 2>&1 || { echo "FAIL: 'curl' is vereist." >&2; exit 1; }
+
+# Uniek per run: zonder dat kan een bericht uit een eerdere run, of uit de sessiecache, deze smoke
+# groen houden terwijl de keten stuk is.
+MERK="ketensmoke-$$-$(od -An -N4 -tu4 < /dev/urandom | tr -d ' ')"
+
+aanleveren() {  # <magazijn-basis-url> <onderwerp>
+  curl -sS -o /dev/null -w '%{http_code}' --noproxy '*' --max-time 20 \
+    -X POST "$1/berichten" -H 'Content-Type: application/json' \
+    -d "{\"afzender\":\"${AFZENDER_OIN}\",\"ontvanger\":{\"type\":\"BSN\",\"waarde\":\"${BSN}\"},\"onderwerp\":\"$2\",\"inhoud\":\"$2\"}" \
+    2>"$ERRLOG"
+}
+
+# ophalen: vult de sessiecache van de uitvraag uit de magazijnen. Dit is de call die door de outway
+# gaat; `_ophalen` is een SSE-stream, dus we lezen 'm met een harde timeout leeg.
+ophalen() {
+  curl -sS -o /dev/null --noproxy '*' --max-time "$OPHAAL_TIMEOUT" \
+    -H "X-Ontvanger: BSN:${BSN}" -H 'Accept: text/event-stream' \
+    "${UITVRAAG_URL}/berichten/_ophalen" 2>"$ERRLOG"
+}
+
+berichten() {
+  curl -sS --noproxy '*' --max-time 20 -H "X-Ontvanger: BSN:${BSN}" \
+    "${UITVRAAG_URL}/berichten" 2>"$ERRLOG"
+}
+
+# De txlog-meting hieronder telt alleen transacties die DEZE run veroorzaakt. Een eerdere
+# smoke-contract-run laat namelijk ook een gedeelde transactie achter; zonder nulmeting zou deze
+# smoke groen blijven terwijl de uitvraag rechtstreeks naar het magazijn ging.
+if PROJECT="$(fsc_compose_project "${ENVDIR}/${GASTHEER}/deploy/local/docker-compose.yaml")"; then
+  txids() {  # <db> <richting>
+    podman exec "${PROJECT}-postgres-1" psql -U postgres -d "$1" -tA \
+      -c "SELECT transaction_id FROM transactionlog.records
+          WHERE direction = '$2' AND service_name = '${MAGAZIJN_DIENST}' AND grant_hash IS NOT NULL" \
+      2>"$ERRLOG" | sort -u
+  }
+
+  # Eerst opvangen in variabelen, dan pas vergelijken. In een process substitution is de exitstatus
+  # onzichtbaar: een gestopte postgres of een psql-fout levert dan lege uitvoer met exitcode 0, en
+  # de assert hieronder zou "de uitvraag ging buiten de outway om" melden terwijl het logboek
+  # simpelweg onleesbaar was.
+  gedeelde_txids() {
+    local uit in
+    uit="$(txids "fsc_txlog_$(fsc_peer_var "$UITVRAAG")" out)" || {
+      echo "WAARSCHUWING: txlog van ${UITVRAAG} niet leesbaar: $(fsc_last_error)" >&2
+      return 1
+    }
+    in="$(txids "fsc_txlog_$(fsc_peer_var magazijn-a)" in)" || {
+      echo "WAARSCHUWING: txlog van magazijn-a niet leesbaar: $(fsc_last_error)" >&2
+      return 1
+    }
+
+    comm -12 <(printf '%s\n' "$uit") <(printf '%s\n' "$in")
+  }
+
+  TXLOG_LEESBAAR=1
+else
+  TXLOG_LEESBAAR=0
+fi
+
+# De inway moet naar het ECHTE magazijn wijzen. Dat hier afdwingen en niet als voorwaarde aan de
+# gebruiker laten: `smoke-federatie.sh` publiceert de dienst met de echo-stub als upstream, dus wie
+# die smoke ná het instellen draait, zet 'm ongemerkt terug. De publicatie is idempotent.
+echo "== 0. inway wijst naar het echte magazijn =="
+if fsc_zet_upstream "$ENVDIR" magazijn-a "${MAGAZIJN_A_UPSTREAM:-http://127.0.0.1:8090}" \
+     >/dev/null 2>"$ERRLOG"; then
+  # De dienstwijziging propageert asynchroon naar de inway; de eerste calls erna komen nog bij de
+  # vórige upstream uit. Hier uitwachten en niet in assert 1: die mag maar één keer ophalen, want
+  # daarna serveert de sessiecache en meet een tweede poging niets meer.
+  #
+  # De probe gaat door de outway naar `/q/health` — een pad dat het echte magazijn met JSON
+  # beantwoordt en de echo-stub met zijn vaste tekst. Zo meten we de keten zelf en niet wat de
+  # controller denkt te weten.
+  # Via de lib-functie en niet met een kale `sed`: het bestand draagt compose-escaping, dus de
+  # dollars staan er verdubbeld in.
+  GRANT="$(fsc_compose_env_lees "$(cd "${ENVDIR}/.." && pwd)/generated/fsc-grants.env" MAGAZIJN_A_GRANT_HASH || true)"
+  OUTWAY="http://$(fsc_component_adres "$(fsc_peer_waarde NET "$UITVRAAG")" outway):8443"
+  POGING=1
+  DOOR=0
+
+  if ! fsc_grant_bruikbaar "$GRANT"; then
+    fout "geen bruikbaar grant-hash in demo/generated/fsc-grants.env — draai contracts/fbs-contracten.sh"
+  else
+    while [ "$POGING" -le "$KETEN_POGINGEN" ]; do
+      if curl -sS --noproxy '*' --max-time 10 -H "Fsc-Grant-Hash: ${GRANT}" \
+           "${OUTWAY}/q/health" 2>"$ERRLOG" | grep -q '"status"'; then
+        DOOR=1
+        break
+      fi
+
+      [ "$POGING" -lt "$KETEN_POGINGEN" ] && sleep "$KETEN_WACHT"
+      POGING=$((POGING + 1))
+    done
+
+    if [ "$DOOR" -eq 1 ]; then
+      ok "upstream van de inway staat op ${MAGAZIJN_A_UPSTREAM:-http://127.0.0.1:8090} (na ${POGING} poging(en))"
+    else
+      fout "de inway levert na ${KETEN_POGINGEN} pogingen nog niet het echte magazijn — upstream niet doorgedrongen"
+    fi
+  fi
+else
+  fout "kon de upstream van magazijn-a niet zetten: $(fsc_last_error)"
+fi
+
+# Nulmeting NA stap 0, niet ervoor: die probe gaat zelf door de outway naar de inway en schrijft
+# dus een rij in beide txlogs. Stond de nulmeting ervóór, dan telde die rij als "nieuw" en kon
+# assert 2 nooit rood worden — ook niet als de uitvraag rechtstreeks met het magazijn praat, wat
+# precies het geval is dat deze smoke moet uitsluiten.
+# En pas nemen als de txlogs tot stilstand zijn gekomen. De inway/outway schrijven hun record
+# out-of-band via de txlog-API, dus de rij van de probe hierboven kan ná de nulmeting landen en dan
+# als "nieuw" meetellen — dezelfde vals-groen, alleen via een race in plaats van via de ordening.
+VOOR_OK=0
+VOOR=""
+
+if [ "$TXLOG_LEESBAAR" -eq 1 ]; then
+  STABIEL=0
+  POGING=1
+
+  while [ "$POGING" -le "$KETEN_POGINGEN" ]; do
+    HUIDIG="$(gedeelde_txids)" || break
+
+    if [ "$POGING" -gt 1 ] && [ "$HUIDIG" = "$VORIG" ]; then
+      STABIEL=1
+      break
+    fi
+
+    VORIG="$HUIDIG"
+    sleep "$KETEN_WACHT"
+    POGING=$((POGING + 1))
+  done
+
+  if [ "$STABIEL" -eq 1 ]; then
+    VOOR="$HUIDIG"
+    VOOR_OK=1
+  else
+    echo "WAARSCHUWING: de txlogs kwamen niet tot stilstand binnen ${KETEN_POGINGEN} metingen" >&2
+  fi
+fi
+
+# --- 1. Data-pad ---------------------------------------------------------------------------------
+echo "== 1. bericht uit magazijn-a via de FSC-keten =="
+CODE="$(aanleveren "$MAGAZIJN_A_DIRECT" "$MERK")" || CODE=""
+
+if [ "$CODE" != "201" ] && [ "$CODE" != "200" ]; then
+  fout "aanleveren bij magazijn-a gaf HTTP ${CODE:-<geen>}: $(fsc_last_error) — draait de demo-stack?"
+else
+  ok "bericht '${MERK}' aangeleverd bij magazijn-a (HTTP ${CODE})"
+
+  # Eén ophaling, bewust. Herproberen kan niet: de eerste ophaling vult de sessiecache voor deze
+  # ontvanger, en elke volgende komt daaruit zonder het magazijn nog te bellen. Een tweede poging
+  # zou dus niets nieuws meten en assert 2 juist rood maken.
+  if ! ophalen; then
+    fout "ophalen bij de uitvraag mislukte: $(fsc_last_error)"
+  else
+    LIJST="$(berichten)" || LIJST=""
+
+    if printf '%s' "$LIJST" | grep -qF "$MERK"; then
+      ok "de uitvraag levert het bericht van magazijn-a terug"
+    else
+      fout "het bericht '${MERK}' zit niet in de uitvraag-lijst — kwam de keten niet rond? $(fsc_last_error)"
+    fi
+  fi
+fi
+
+# --- 2. Verantwoording ---------------------------------------------------------------------------
+# Zelfde meting als smoke-contract.sh, maar nu over verkeer dat de ÁPPLICATIE veroorzaakte in
+# plaats van een handmatige curl. Ging de uitvraag rechtstreeks naar het magazijn, dan staat er
+# niets in de txlogs en valt dat hier op.
+echo "== 2. verantwoording in beide txlogs =="
+if [ -z "${PROJECT:-}" ]; then
+  fout "projectnaam van de gastheer niet af te leiden — deze assert heeft niets gemeten"
+elif [ "$VOOR_OK" -ne 1 ]; then
+  fout "de nulmeting op de txlogs mislukte — deze assert heeft niets gemeten"
+elif ! NA="$(gedeelde_txids)"; then
+  fout "de txlogs zijn na afloop niet leesbaar — deze assert heeft niets gemeten"
+else
+  NIEUW="$(comm -13 <(printf '%s\n' "$VOOR") <(printf '%s\n' "$NA") | grep -c . || true)"
+
+  if [ "${NIEUW:-0}" -gt 0 ]; then
+    ok "${NIEUW} nieuwe transactie(s) in beide txlogs, uitgaand bij ${UITVRAAG} en inkomend bij magazijn-a"
+  else
+    fout "geen NIEUWE gedeelde transactie-id — de uitvraag ging buiten de outway om (of het ophalen leverde niets op)"
+  fi
+fi
+
+# --- 3. Het niet-FSC-pad ------------------------------------------------------------------------
+# magazijn-b loopt rechtstreeks. Zonder deze assert zou een omzetting die alle magazijnen door FSC
+# dwingt (of het rechtstreekse pad sloopt) hier ongemerkt doorheen komen.
+echo "== 3. magazijn-b blijft rechtstreeks werken =="
+CODE_B="$(aanleveren "$MAGAZIJN_B_DIRECT" "${MERK}-b")" || CODE_B=""
+
+if [ "$CODE_B" = "201" ] || [ "$CODE_B" = "200" ]; then
+  ok "magazijn-b neemt een bericht aan buiten FSC om (HTTP ${CODE_B})"
+else
+  fout "magazijn-b gaf HTTP ${CODE_B:-<geen>}: $(fsc_last_error)"
+fi
+
+echo
+if [ "$FOUTEN" -eq 0 ]; then
+  echo "== KETEN-SMOKE GROEN =="
+else
+  echo "== KETEN-SMOKE ROOD: ${FOUTEN} bevinding(en) ==" >&2
+  exit 1
+fi

--- a/demo/environment/lib/fsc-contract.sh
+++ b/demo/environment/lib/fsc-contract.sh
@@ -1,0 +1,403 @@
+#!/usr/bin/env bash
+# Bouwstenen voor de contract-bootstrap, gedeeld door de consumer- en de provider-helft.
+#
+# De twee helften praten elk met precies één manager: die van hun eigen peer. Dat is geen
+# stijlkeuze maar een eis van de omgeving — op ZAD isoleert de tenant-baseline-NetworkPolicy per
+# deployment, en de interne manager-API heeft geen route. Eén proces dat beide managers aanspreekt
+# bestaat daar dus niet. Het contract kruist in plaats daarvan via de FSC-mesh, de weg die de
+# managers onderling toch al gebruiken.
+#
+# Vereist $ERRLOG (fsc_errlog_init) en $HAVE_JQ (fsc_have_jq) uit fsc-harness.sh.
+
+# fsc_env_vereist <naam> [uitleg]: de waarde van die variabele op stdout, of afbreken met 2.
+#
+# Niet `${VAR:?melding}`: dat eindigt op 1, en 1 betekent hier "het ging mis, probeer opnieuw".
+# Een ontbrekende variabele wordt door opnieuw proberen nooit beter, en de lus op ZAD zou er
+# eindeloos op blijven herstarten met steeds dezelfde melding. Uitgang 2 is de afspraak voor
+# "configuratie deugt niet"; de lus stopt daarop, wat een zichtbare crashloop oplevert in plaats van
+# een component dat draait en niets doet.
+#
+# Leunt op `set -e` bij de aanroeper: de exit-status van de commando-substitutie is de status van de
+# toekenning, dus `X="$(fsc_env_vereist FOO)"` breekt het script af met 2.
+fsc_env_vereist() {
+  local naam="$1" waarde="${!1-}"
+
+  [ -n "$waarde" ] || {
+    echo "FAIL: zet ${naam}${2:+ — $2}" >&2
+    exit 2
+  }
+
+  printf '%s' "$waarde"
+}
+
+# fsc_getal_vereist <naam> <waarde>: de waarde op stdout als het een geheel getal is, anders exit 2.
+#
+# Intervallen en drempels komen op ZAD uit component-env. Een tikfout maakt daar geen fout van maar
+# iets ergers: `sleep "15s"` mislukt meteen, `pauzeer` keert direct terug en de lus wordt een hot
+# loop die de manager zo snel mogelijk bevraagt terwijl hij elke ronde OK meldt. En een niet-numerieke
+# drempel laat `[ ]` falen, waarna de vangrail die de lus zou stoppen niets meer doet. Beide falen
+# dus open; vandaar één controle bij het opstarten.
+# Het patroon eist een positief getal zónder voorloopnul, niet "alleen cijfers". `0` zou de guard
+# passeren en precies de hot loop opleveren waarvoor hij bestaat, en `08` wordt door bash als
+# octaal gelezen: `$((… * 08))` breekt af met "value too great for base", midden in de lus.
+fsc_getal_vereist() {
+  # Twee patronen en niet één: een case-patroon is een glob, geen reguliere expressie, dus
+  # `[1-9][0-9]*` zou ook `15s` accepteren — de `*` matcht daar willekeurige tekens.
+  case "${2:-}" in
+    ""|*[!0-9]*|0|0*)
+      echo "FAIL: ${1} moet een positief geheel getal zijn zonder voorloopnul, niet '${2:-}'." >&2
+      exit 2
+      ;;
+  esac
+
+  printf '%s' "$2"
+}
+
+# fsc_getal_hoogstens <naam> <waarde> <max>: als fsc_getal_vereist, met een bovengrens.
+fsc_getal_hoogstens() {
+  local waarde
+  waarde="$(fsc_getal_vereist "$1" "$2")"
+
+  [ "$waarde" -le "$3" ] || {
+    echo "FAIL: ${1} mag hoogstens ${3} zijn, niet '${waarde}'." >&2
+    exit 2
+  }
+
+  printf '%s' "$waarde"
+}
+
+# fsc_hex64 <waarde>: is dit precies 64 lowercase hex-tekens?
+#
+# `[0-9a-f]*` in een case-patroon toetst alléén het eerste teken — de overige 63 komen er dan
+# ongezien doorheen, inclusief een uppercase SHA-256 (de vorm die veel tooling teruggeeft). Vandaar
+# het negatieve patroon: één teken buiten de verzameling en de waarde valt af.
+fsc_hex64() {
+  case "${1:-}" in
+    ""|*[!0-9a-f]*) return 1 ;;
+    *) [ "${#1}" -eq 64 ] ;;
+  esac
+}
+
+# fsc_hash_ok <waarde>: heeft dit contract-hash een vorm die veilig in een URL-pad past?
+#
+# FSC-hashes hebben de vorm `$1$4$<base64url>`. Een waarde met een schuine streep of witruimte zou
+# het pad verleggen — curl normaliseert `..`-segmenten — dus die valt af.
+fsc_hash_ok() {
+  case "${1:-}" in
+    # Puur punten apart: `.` en `..` bestaan volledig uit toegestane tekens, en curl normaliseert ze
+    # weg — `/v1/contracts/../revoke` komt aan als `/v1/revoke`.
+    ""|.|..|*[!A-Za-z0-9._~$+-]*) return 1 ;;
+  esac
+}
+
+# fsc_contract_manager_ok <url...>: elk adres moet met https:// beginnen.
+#
+# De adressen worden geconcateneerd tot curl's URL-argument; een waarde die met `-` begint zou curl
+# als optie lezen (`-K/pad` maakt er een config-file-lees van).
+fsc_contract_manager_ok() {
+  local url
+  for url in "$@"; do
+    case "$url" in
+      https://*) ;;
+      *) echo "FAIL: manager-adres moet met https:// beginnen: '${url}'" >&2; return 1 ;;
+    esac
+  done
+}
+
+# fsc_contract_api <url> <cert> <key> <ca> <adres> <curl-args...>: één call naar een manager.
+#
+# <adres> is het IP waar de hostnaam heen moet wijzen, of leeg. Leeg = gewone DNS-resolutie, wat op
+# ZAD het geval is: daar is de manager een ClusterIP-service met een echte naam. Lokaal staan de
+# federatie-namen in geen enkele resolver (`extra_hosts` geldt alleen binnen containers), vandaar
+# --resolve met het loopback-adres van die component.
+fsc_contract_api() {
+  local url="$1" cert="$2" key="$3" ca="$4" adres="$5"; shift 5
+  local args=() hostnaam poort
+
+  if [ -n "$adres" ]; then
+    hostnaam="${url#https://}"; hostnaam="${hostnaam%%/*}"
+    poort="${hostnaam##*:}"; hostnaam="${hostnaam%%:*}"
+    args=(--resolve "${hostnaam}:${poort}:${adres}")
+  fi
+
+  # `${args[@]+…}`: bash < 4.4 (de macOS-default 3.2) ziet "${args[@]}" op een lege array onder
+  # `set -u` als unbound. Leeg is hier de normale toestand — op ZAD resolveert DNS gewoon.
+  curl -sS --fail-with-body --noproxy '*' ${args[@]+"${args[@]}"} \
+    --cert "$cert" --key "$key" --cacert "$ca" "$@" 2>"$ERRLOG"
+}
+
+# fsc_lijst_naar_json <naam> <waarde>: een spaties-gescheiden lijst uit env als JSON-array.
+#
+# `read -r -a` leest maar één REGEL: `$'a\nb'` levert één element op. Een allowlist komt op ZAD uit
+# component-env (YAML), waar een waarde over meerdere regels schrijven voor de hand ligt — en dan
+# zou alles na de eerste regel geruisloos buiten de autorisatiegrens vallen. Vandaar splitsen op
+# elke witruimte, en een lege uitkomst als fout behandelen in plaats van als "niemand mag iets".
+fsc_lijst_naar_json() {
+  local naam="$1" woord woorden=()
+
+  # `|| [ -n "$woord" ]`: de invoer eindigt niet op een newline, en een kale `read` laat het laatste
+  # stuk dan vallen — dat zou stilletjes de laatste dienst of consumer uit de allowlist halen.
+  while IFS= read -r woord || [ -n "$woord" ]; do
+    [ -n "$woord" ] && woorden+=("$woord")
+  done < <(printf '%s' "${2:-}" | tr -s '[:space:]' '\n')
+
+  [ "${#woorden[@]}" -gt 0 ] || {
+    echo "FAIL: ${naam} bevat geen enkele waarde." >&2
+    return 1
+  }
+
+  fsc_json_lijst "${woorden[@]}"
+}
+
+# fsc_json_lijst <woord...>: de woorden als JSON-array op stdout, voor jq's --argjson.
+fsc_json_lijst() {
+  local eerste=1 woord
+  printf '['
+  for woord in "$@"; do
+    [ "$eerste" -eq 1 ] || printf ','
+    eerste=0
+    printf '%s' "$woord" | jq -R .
+  done
+  printf ']'
+}
+
+# --- De contractenlijst binnenhalen -------------------------------------------------------------
+
+# _FSC_CONTRACTEN_JQ: jq-prelude die `.contracts` als array oplevert of afbreekt.
+#
+# `.contracts[]?` leek de veilige vorm, maar doet precies het verkeerde: de `?` onderdrukt juist de
+# fout die hier het signaal is. Een 200 met een ander lijstveld, met `null`, of met een lege body
+# levert dan 0 regels op — niet te onderscheiden van "er zijn geen contracten". Aan consumer-kant
+# betekent dat elke ronde een nieuw contract indienen, en op ZAD draait die ronde elke 15 seconden.
+_FSC_CONTRACTEN_JQ='
+  def contracten:
+    if type != "object" then error("respons is geen JSON-object")
+    elif has("contracts") | not then error("respons heeft geen veld \"contracts\"")
+    elif (.contracts | type) != "array" then error("veld \"contracts\" is \(.contracts | type), geen array")
+    elif ((.pagination.next_cursor? // .next_cursor? // "") | tostring) != "" then
+      # De lijst is cursor-gepagineerd. Alleen pagina 1 lezen zou betekenen dat de consumer zijn
+      # eigen contract niet meer ziet zodra de manager er genoeg heeft — en dan dient hij elke ronde
+      # een nieuw contract in. Afbreken tot iemand de cursor volgt; stil doorgaan is hier de
+      # gevaarlijke keuze.
+      #
+      # Twee plekken, want het veld staat genest onder `pagination` en niet op topniveau; alleen de
+      # topniveau-vorm toetsen zou een guard opleveren die nooit vuurt, en dat is slechter dan geen
+      # guard. De aanroepers vragen daarnaast expliciet een ruime `limit` op, zodat dit een vangrail
+      # blijft in plaats van een dagelijkse blokkade.
+      error("de contractenlijst is gepagineerd (next_cursor gezet) en dat volgen we nog niet")
+    else .contracts end;
+'
+
+# _fsc_respons_ok <body>: een lege body is geen lege lijst.
+#
+# Aparte controle, want jq draait bij lege invoer helemaal niet: het programma komt nooit aan bod,
+# er komt niets uit en de exit-status is 0. De prelude hierboven zou dat dus nooit zien, en een
+# HTTP 200 met lege body zou als "geen contracten" gelezen worden.
+_fsc_respons_ok() {
+  # Niet `[ -n ]`: jq draait óók niet op invoer die alleen witruimte is — het programma komt dan
+  # nooit aan bod, er komt niets uit en de status is 0. Vandaar toetsen op minstens één teken dat
+  # géén witruimte is.
+  case "${1:-}" in
+    *[![:space:]]*) return 0 ;;
+  esac
+
+  echo 'lege respons van de manager (HTTP 200 zonder body?)' >>"$ERRLOG"
+  return 1
+}
+
+# --- Wat de provider mag tekenen ----------------------------------------------------------------
+# Vóór de splitsing was de accept een gerichte handeling: het script kende het hash dat het zelf
+# net had laten indienen. De provider-helft kent dat hash niet — hij vindt een contract in zijn
+# lijst en moet zélf besluiten of hij tekent. Dat is een autorisatiebesluit, en de inhoud van het
+# contract komt van de tegenpartij.
+#
+# Een contract draagt een LIJST grants. Toetsen of er een grant in zit die ons bevalt is daarom
+# niet genoeg: wie een tweede grant meestuurt, krijgt die anders mee-ondertekend. Het contract moet
+# als geheel kloppen, dus de eis is "precies één grant, en die klopt" — niet "er is er één die
+# klopt".
+#
+# Buiten de grant tellen ook de eigenschappen van het contract zelf mee. De allowlist bepaalt WIE er
+# mag afnemen; zonder deze vier bepaalt de tegenpartij in zijn eentje HOE LANG en onder welke
+# voorwaarden: `group_id` (anders tekenen we iets dat de inway later afwijst op
+# WRONG_GROUP_ID_IN_TOKEN — geldig en toch stuk), `hash_algorithm` (dat bindt de content aan de
+# handtekening), de aanwezigheid van een geldigheidsduur, en een bovengrens daarop.
+#
+# De WAARDE van de thumbprint wordt bewust niet getoetst, het TYPE wel. Het type moet
+# PUBLIC_KEY_THUMBPRINT zijn: fsc-core kent daarnaast DOMAIN_NAME, een zwakkere binding die een
+# provider niet hoort te accepteren. De waarde zelf kan de provider niet onafhankelijk verifiëren en
+# hoeft hij ook niet — die wordt aan zijn eigen kant cryptografisch afgedwongen op een later moment:
+# de outway haalt zijn token bij ONZE manager, die de presentatie tegen de thumbprint in de grant
+# houdt, en onze inway verifieert `cnf.x5t#S256` tegen het verbindingscertificaat.
+
+# fsc_contract_beoordeling <json> <provider_oin> <diensten-json> <consumers-json> <group_id>
+# <max-geldigheid-seconden>: één regel per niet-ingetrokken contract dat nog een besluit vraagt.
+# Ook contracten die ons NIET aangaan komen langs — juist die leveren een WEIGER-regel op.
+#
+#   TEKEN    <hash> <consumer_oin>   mag getekend worden, is dat nog niet
+#   GETEKEND <hash> <consumer_oin>   voldoet en draagt onze handtekening al
+#   WEIGER   <hash> <reden>          nog niet getekend en haalt de toets niet
+#
+# Alle drie komen uit hetzelfde jq-programma en dus uit dezelfde toets. Twee programma's zouden
+# uiteen kunnen lopen, en een diagnose die andere contracten bekijkt dan de matcher tekent wijst de
+# operator juist de verkeerde kant op. De reden noemt de eerste eis die faalt.
+#
+# Elke waarde uit het contract komt van de tegenpartij en gaat hier een regelgebaseerde stroom in.
+# De `veilig`-filter vervangt daarom álle witruimte en niet alleen newlines: elke lezer van deze
+# regels telt kolommen, dus een spatie in een hash verschuift de rest en laat een controle op de
+# verkeerde kolom kijken. Zonder dat schrijft
+# `jq -r` een newline in een dienstnaam letterlijk weg, en leest de aanroeper de tweede helft als
+# een eigen record. Een peer die zijn dienst "x<newline>TEKEN <hash> <oin>" noemt, laat zich zo een
+# contract naar keuze tekenen — de allowlist wordt dan volledig omzeild.
+#
+# Een contract dat de toets niet haalt én al getekend is levert niets op: dat is andermans zaak.
+# Het servicePublication-contract voor onze eigen dienst staat op dezelfde manager en draagt onze
+# eigen handtekening al — die zet de manager er server-side op bij het publiceren. Zou dat een
+# WEIGER-regel opleveren, dan stond de log elke ronde vol met contracten waar niets mee mis is.
+fsc_contract_beoordeling() {
+  [ "$HAVE_JQ" -eq 1 ] || return 0
+  _fsc_respons_ok "${1:-}" || return 1
+  printf '%s' "$1" | jq -r \
+    --arg prov "$2" --argjson diensten "$3" --argjson consumers "$4" \
+    --arg groep "${5:-}" --argjson maxgeldig "${6:-0}" --argjson nu "${7:-0}" "${_FSC_CONTRACTEN_JQ}"'
+    def veilig: (. // "ontbreekt") | tostring | gsub("[[:cntrl:]]"; "\u00b7");
+    # Een contract dat de toets niet haalt en al onze handtekening draagt, is meestal andermans zaak
+    # (het publicatiecontract voor onze eigen dienst staat op dezelfde manager). Máár als het een
+    # serviceConnection voor onze eigen dienst is, was het ooit van ons en is het nu afgekeurd — door
+    # een gecorrigeerde allowlist, een verlopen looptijd of een verlaagde bovengrens. Dat stil laten
+    # zou de provider "nog niets binnen" laten melden terwijl het contract er wel degelijk ligt.
+    def weiger($ondertekend; $tekst):
+      if $ondertekend then
+        if (((.content.grants // [])[0].type? // "") == "GRANT_TYPE_SERVICE_CONNECTION"
+            and ((.content.grants // [])[0].service?.peer_id? // "") == $prov)
+        then "AANDACHT \($tekst)" else empty end
+      else "WEIGER \($tekst)" end;
+
+    contracten[]
+    # Eerst het type: een rij die geen object is, laat élke veldtoets hieronder afbreken en daarmee
+    # het hele programma — dan wordt in die ronde geen enkel legitiem contract meer getekend. De
+    # `try` verderop begint pas ná deze regels en zou dat niet vangen.
+    | if type != "object" then "WEIGER <geen object> een rij in de contractenlijst is \(type), geen object"
+      else
+        # Ook `has_rejected`: een contract dat wij eerder hebben afgewezen draagt onze
+        # accept-handtekening niet, dus zonder deze regel komt het elke ronde terug als kandidaat en
+        # tekenen we alsnog wat we bewust hebben geweigerd.
+        select((.has_revoked // false) == false and (.has_rejected // false) == false)
+    | . as $c
+    | ($c.hash | veilig) as $h
+
+    # Per contract afvangen. Zonder deze try sloopt één misvormde rij — `content` een string,
+    # `validity` een datumtekst, een grant die geen object is — het hele programma, en dan wordt in
+    # die ronde geen enkel legitiem contract meer getekend. Een rij die we niet kunnen lezen, tekenen
+    # we niet: dat is dezelfde veilige uitkomst als elke andere weigering.
+    | try (
+        (.content.grants // []) as $g
+        | (((.signatures.accept // {}) | has($prov))) as $ondertekend
+        | if $groep != "" and .content.group_id != $groep then
+            weiger($ondertekend; "\($h) hoort bij group \(.content.group_id | veilig), niet bij de onze")
+          elif .content.hash_algorithm != "HASH_ALGORITHM_SHA3_512" then
+            weiger($ondertekend; "\($h) hash-algoritme \(.content.hash_algorithm | veilig) wijkt af")
+          elif (.content.validity | type) != "object" then
+            weiger($ondertekend; "\($h) draagt geen geldigheidsduur")
+          elif (.content.validity.not_before | type) != "number"
+               or (.content.validity.not_after | type) != "number" then
+            # Alleen op "is een object" toetsen zou te weinig zijn: een `validity` zonder `not_after`
+            # levert een contract zonder einddatum op, en dat is juist wat de bovengrens moet vangen.
+            weiger($ondertekend; "\($h) geldigheidsduur is onvolledig (not_before/not_after ontbreekt of is geen getal)")
+          elif .content.validity.not_after <= .content.validity.not_before then
+            weiger($ondertekend; "\($h) einddatum ligt niet ná de begindatum")
+          elif $nu > 0 and .content.validity.not_after <= $nu then
+            # fsc-core eist dat not_after in de toekomst ligt. Een verlopen contract tekenen is
+            # bovendien zinloos werk dat elke ronde terugkomt.
+            weiger($ondertekend; "\($h) is al verlopen")
+          elif $nu > 0 and $maxgeldig > 0 and (.content.validity.not_after - $nu) > $maxgeldig then
+            # Gemeten vanaf NU en niet als vensterlengte: de vraag is hoe lang deze tegenpartij een
+            # claim op ons kan houden. Een venster van tien jaar dat over vijf jaar begint, is een
+            # claim tot over vijftien jaar terwijl de lengte binnen de grens valt.
+            weiger($ondertekend; "\($h) loopt nog \(.content.validity.not_after - $nu)s, meer dan het maximum van \($maxgeldig)s")
+          elif ($g | length) != 1 then
+            weiger($ondertekend; "\($h) draagt \($g | length) grants in plaats van precies 1")
+          elif $g[0].type != "GRANT_TYPE_SERVICE_CONNECTION" then
+            weiger($ondertekend; "\($h) grant-type \($g[0].type | veilig) is geen serviceConnection")
+          elif $g[0].service.peer_id != $prov then
+            weiger($ondertekend; "\($h) dienst hoort bij peer \($g[0].service.peer_id | veilig), niet bij ons")
+          elif ($diensten | index($g[0].service.name)) == null then
+            weiger($ondertekend; "\($h) dienst \($g[0].service.name | veilig) bieden wij niet aan")
+          elif $g[0].service.type != "SERVICE_TYPE_SERVICE" then
+            # Dezelfde klasse discriminator als het identificatietype hieronder: een
+            # DELEGATED_SERVICE zet een delegator-claim in het token en verandert welke
+            # handtekeningen vereist zijn. Wij bieden geen gedelegeerde diensten aan.
+            weiger($ondertekend; "\($h) dienst-type \($g[0].service.type | veilig) is geen gewone dienst")
+          elif (($g[0].properties // {}) | length) != 0 then
+            # `properties` schrijft claims die onze eigen manager in het access token zet en die onze
+            # inway en de dienst erachter te zien krijgen — ongesanitiseerd, door de tegenpartij
+            # opgesteld. Dat is dezelfde soort blinde ondertekening als een tweede grant.
+            weiger($ondertekend; "\($h) draagt grant-properties die wij niet ondertekenen")
+          elif $g[0].outway.identification.type != "OUTWAY_IDENTIFICATION_TYPE_PUBLIC_KEY_THUMBPRINT" then
+            weiger($ondertekend; "\($h) outway-identificatie \($g[0].outway.identification.type | veilig) is geen thumbprint")
+          elif ($consumers | index($g[0].outway.peer_id)) == null then
+            weiger($ondertekend; "\($h) consumer \($g[0].outway.peer_id | veilig) staat niet op de lijst")
+          elif ((.signatures.accept // {}) | has($g[0].outway.peer_id)) | not then
+            # fsc-core wil onder een serviceConnection de handtekening van beide kanten. Tekenen
+            # vóór de tegenpartij zich gecommitteerd heeft, is een verplichting aangaan die de ander
+            # nog niet is aangegaan.
+            weiger($ondertekend; "\($h) draagt de handtekening van de consumer nog niet")
+          elif $ondertekend then "GETEKEND \($c.hash) \($g[0].outway.peer_id)"
+          else "TEKEN \($c.hash) \($g[0].outway.peer_id)" end
+      ) catch "WEIGER \($h) is niet te beoordelen: \(. | tostring | gsub("[[:cntrl:]]"; "·"))"
+      end' 2>>"$ERRLOG"
+}
+
+# --- Wat de consumer al heeft uitstaan ----------------------------------------------------------
+
+# fsc_contract_voor_combinatie <json> <service> <provider_oin> <consumer_oin> <thumbprint>:
+# `<hash> <state> <provider-getekend ja|nee> <afgewezen|->` per regel, voor elk niet-ingetrokken
+# contract dat
+# precies deze serviceConnection draagt. De state komt lowercase terug (`contract_state_valid`), en
+# `ontbreekt` als de manager het veld niet meestuurt — dat laatste is geen synoniem voor ongeldig,
+# maar een toestand die de aanroeper hoort te melden in plaats van als "nog niet klaar" te lezen.
+#
+# De consumer-helft heeft dit nodig om te weten of hij nog moet indienen. Alleen kijken naar
+# volledig geldige contracten (fsc_grant_actief) zou niet volstaan: in de gesplitste opzet zit er
+# tijd tussen indienen en tekenen, en in dat gat zou elke ronde er nóg een contract bij posten.
+#
+# De "precies één grant"-eis staat er ook hier, zodat consumer en provider dezelfde contracten als
+# "van deze combinatie" zien. Zouden ze daarin verschillen, dan wacht de consumer op een contract
+# dat de provider nooit gaat tekenen.
+fsc_contract_voor_combinatie() {
+  [ "$HAVE_JQ" -eq 1 ] || return 0
+  _fsc_respons_ok "${1:-}" || return 1
+  printf '%s' "$1" | jq -r \
+    --arg svc "$2" --arg prov "$3" --arg cons "$4" --arg thumb "$5" "${_FSC_CONTRACTEN_JQ}"'
+    def veilig: (. // "ontbreekt") | tostring | gsub("[[:cntrl:]]"; "\u00b7");
+
+    contracten[]
+    | select(type == "object")
+    # Hier bewust WÉL de afgewezen contracten erbij, anders dan in de beoordeling hiernaast. Daar is
+    # "afgewezen" een besluit van onszelf dat we niet moeten overdoen; hier is het het antwoord van
+    # de overkant op ónze aanvraag. Wegfilteren zou de consumer zijn eigen afgewezen contract niet
+    # meer laten zien, waarna hij elke ronde een nieuwe indient en de afwijzing nergens blijkt.
+    | select((.has_revoked // false) == false)
+    # Zelfde reden als in de beoordeling hiernaast: één misvormde rij mag de rest niet meenemen.
+    # Hier zonder melding — deze matcher zoekt ons eigen contract, en een rij van iemand anders die
+    # we niet kunnen lezen is simpelweg niet de onze. De provider-kant maakt er wél een WEIGER van,
+    # want daar is het een besluit.
+    | try (
+        select((.content.grants // []) | length == 1)
+    | select(.content.grants[0]
+        | .type == "GRANT_TYPE_SERVICE_CONNECTION"
+          and .service.name == $svc
+          and .service.peer_id == $prov
+          and .outway.peer_id == $cons
+          and .outway.identification.public_key_thumbprint == $thumb)
+    # `veilig` ook op het hash: dit is net zo goed een regelgebaseerde stroom als de beoordeling
+    # hiernaast, dus een hash met een newline erin zou hier een tweede record schrijven dat de
+    # consumer-helft als eigen contract leest — en vervolgens intrekt, op een pad naar keuze.
+        | "\(.hash | veilig) \((.state // "ontbreekt") | tostring | ascii_downcase) \(if ((.signatures.accept // {}) | has($prov)) then "ja" else "nee" end) \(if (.has_rejected // false) then "afgewezen" else "-" end)"
+      ) catch empty
+    ' 2>>"$ERRLOG"
+}
+
+# fsc_contract_regels <beoordeling> <soort>: de regels van één soort, zonder het soort-woord.
+fsc_contract_regels() {
+  printf '%s' "${1:-}" | sed -n "s/^$2 //p"
+}

--- a/demo/environment/lib/fsc-harness.sh
+++ b/demo/environment/lib/fsc-harness.sh
@@ -126,6 +126,49 @@ fsc_grant_hash() {
     | ($g[0] // "unknown")' 2>/dev/null || echo unknown
 }
 
+# --- contract-matching (gedeeld door contracts/bootstrap.sh en federatie/smoke-contract.sh) ----
+# Eén matcher voor "is dit contract geldig en van toepassing op deze serviceConnection", zodat
+# beide scripts niet elk hun eigen (en dus potentieel afwijkende) criteria hanteren.
+
+# fsc_outway_thumbprint <cert-pad>: SPKI-SHA256-thumbprint (64 lowercase hex) van een outway-
+# groepscert op stdout; leeg + non-zero exit bij een ontbrekend/onleesbaar/corrupt certificaat.
+# Vereist $ERRLOG (fsc_errlog_init).
+fsc_outway_thumbprint() {
+  local cert="$1" thumb
+  [ -r "$cert" ] || return 1
+  thumb="$(openssl x509 -in "$cert" -pubkey -noout 2>>"$ERRLOG" \
+             | openssl pkey -pubin -outform DER 2>>"$ERRLOG" \
+             | openssl dgst -sha256 -r 2>>"$ERRLOG" | cut -d' ' -f1)" || return 1
+  case "$thumb" in
+    [0-9a-f]*) [ "${#thumb}" -eq 64 ] || return 1 ;;
+    *) return 1 ;;
+  esac
+  printf '%s' "$thumb"
+}
+
+# fsc_grant_actief <json> <service> <provider_oin> <consumer_oin> <outway_thumbprint>: hashes
+# (één per regel) van niet-ingetrokken CONTRACT_STATE_VALID-contracten die de accept-handtekening
+# van zowel provider als consumer dragen, voor precies deze serviceConnection-combinatie. Leeg bij
+# geen match. De identiteit van een serviceConnection is service + provider + consumer-outway +
+# thumbprint samen: op servicenaam alleen matchen zou ook het servicePublication-contract voor
+# dezelfde dienst meetellen, dat op dezelfde manager staat en altijd aanwezig is.
+fsc_grant_actief() {
+  [ "$HAVE_JQ" -eq 1 ] || return 0
+  printf '%s' "$1" | jq -r \
+    --arg svc "$2" --arg prov "$3" --arg cons "$4" --arg thumb "$5" '
+    [ .contracts[]?
+      | select(.state == "CONTRACT_STATE_VALID" and (.has_revoked // false) == false)
+      | select( ((.signatures.accept // {}) | has($prov))
+                and ((.signatures.accept // {}) | has($cons)) )
+      | select(any(.content.grants[]?;
+            .type == "GRANT_TYPE_SERVICE_CONNECTION"
+            and .service.name == $svc
+            and .service.peer_id == $prov
+            and .outway.peer_id == $cons
+            and .outway.identification.public_key_thumbprint == $thumb))
+      | .hash ] | .[]' 2>/dev/null
+}
+
 # --- federatie-helpers ------------------------------------------------------------------------
 # Gebruikt door demo/environment/federatie/. Staan hier en niet in die map omdat ze door meerdere
 # scripts én door de bash-unittests gedeeld worden.

--- a/demo/environment/lib/fsc-harness.sh
+++ b/demo/environment/lib/fsc-harness.sh
@@ -126,6 +126,56 @@ fsc_grant_hash() {
     | ($g[0] // "unknown")' 2>/dev/null || echo unknown
 }
 
+# fsc_zet_upstream <envdir> <peer> <upstream-url>: publiceer de dienst van die peer (opnieuw) met
+# deze upstream achter de inway. Idempotent — bestaat de dienst al met dezelfde upstream, dan doet
+# publish-service.sh niets.
+#
+# Elke smoke die over het data-pad iets beweert, hoort dit zelf te zetten in plaats van het als
+# voorwaarde op te schrijven: smoke-contract.sh toetst de echo van de stub, smoke-keten.sh het
+# échte magazijn, en wie ze na elkaar draait zou anders de ene de andere zien omgooien.
+fsc_zet_upstream() {
+  FSC_CONTROLLER="https://controller.$2.fsc-test.local:9444" \
+  FSC_MANAGER="https://manager.$2.fsc-test.local:9443" \
+  FSC_UPSTREAM_URL="$3" \
+    "$1/$2/deploy/local/publish-service.sh"
+}
+
+# fsc_compose_env_waarde <waarde>: waarde zoals hij in een `env_file` van docker compose moet staan.
+#
+# Compose interpoleert een env_file: `$NAAM` wordt vervangen door een variabele uit de omgeving, en
+# een onbekende naam door niets. FSC-grant-hashes hebben de vorm `$1$<n>$<base64url>`, dus het deel
+# ná de derde `$` wordt opgeslokt zodra het met een letter of underscore begint — 53 van de 64
+# base64url-tekens. Gemeten in een container: `$1$4$k4rwlWTsCM_j89Fc3nrbnQa9-KB43` komt aan als
+# `$1$4-KB43`, en de outway antwoordt dan 400 UNKNOWN_GRANT_HASH_IN_HEADER.
+#
+# Verdubbelen is compose' eigen escape voor een letterlijke `$`. Dat maakt het bestand
+# compose-specifiek: lees het niet met `set -a; . bestand`, want dan houd je de dubbele tekens.
+fsc_compose_env_waarde() {
+  printf '%s' "${1//\$/\$\$}"
+}
+
+# fsc_compose_env_lees <bestand> <naam>: de ONGE-escapete waarde van `naam` uit een compose-env_file.
+#
+# Tegenhanger van fsc_compose_env_waarde. Wie zo'n bestand met `sed`/`grep` uitleest krijgt de
+# verdubbelde dollars mee en stuurt die door — bij een grant-hash levert dat een 400 op de outway,
+# terwijl het bestand er goed uitziet. Altijd via deze functie lezen.
+fsc_compose_env_lees() {
+  local waarde
+  waarde="$(sed -n "s/^$2=//p" "$1" 2>/dev/null | head -n1)" || return 1
+  printf '%s' "${waarde//\$\$/\$}"
+}
+
+# fsc_grant_bruikbaar <hash>: is dit een echt grant-hash?
+#
+# fsc_grant_hash levert bij een mislukking de string `unknown` in plaats van een lege waarde, zodat
+# een aanroeper die 'm alleen toont iets leesbaars afdrukt. Een kale `[ -n "$hash" ]` is daardoor
+# geen geldige controle: die slaagt óók op de sentinel, en dan reist `Fsc-Grant-Hash: unknown` mee
+# naar de outway, die er een 400 op geeft. Vandaar één predicaat in plaats van de vergelijking op
+# elke plek los over te typen.
+fsc_grant_bruikbaar() {
+  [ -n "${1:-}" ] && [ "$1" != unknown ]
+}
+
 # --- contract-matching (gedeeld door contracts/bootstrap.sh en federatie/smoke-contract.sh) ----
 # Eén matcher voor "is dit contract geldig en van toepassing op deze serviceConnection", zodat
 # beide scripts niet elk hun eigen (en dus potentieel afwijkende) criteria hanteren.
@@ -187,6 +237,24 @@ fsc_peer_waarde() {
 
 # fsc_alle_peers: gastheer + gasten uit peers.env, in opstartvolgorde.
 fsc_alle_peers() { printf '%s %s' "$GASTHEER" "$GASTEN"; }
+
+# fsc_manager_contracts <envdir> <peer> <adres>: de contracten van een peer via zijn INTERNE
+# manager-API, met het internal-cert van diezelfde peer. De naam staat niet in /etc/hosts
+# (`extra_hosts` geldt alleen binnen containers), vandaar `--resolve` op het meegegeven adres.
+#
+# Hier en niet in één van de aanroepers, omdat zowel de contract-bootstrap als de smokes deze
+# lijst nodig hebben: twee kopieën zouden uiteen kunnen lopen in cert-pad of poort, en dan meet de
+# smoke iets anders dan de bootstrap doet.
+fsc_manager_contracts() {
+  local envdir="$1" peer="$2" adres="$3" naam="manager.$2.fsc-test.local"
+
+  curl -sS --fail-with-body --noproxy '*' \
+    --resolve "${naam}:9443:${adres}" \
+    --cert "${envdir}/${peer}/pki/internal/${peer}/manager/cert.pem" \
+    --key  "${envdir}/${peer}/pki/internal/${peer}/manager/key.pem" \
+    --cacert "${envdir}/${peer}/pki/internal/${peer}/ca/root.pem" \
+    "https://${naam}:9443/v1/contracts" 2>"$ERRLOG"
+}
 
 # fsc_component_adres <net> <component>: het adres van een component binnen het /24 van een peer,
 # bv. `fsc_component_adres 127.20.2 inway` -> `127.20.2.4`. De octetten liggen vast en zijn voor

--- a/demo/environment/lib/test-bootstrap-uitgangen.sh
+++ b/demo/environment/lib/test-bootstrap-uitgangen.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Fixture-tests voor de uitgangen van de twee bootstrap-helften.
+#
+# Deze bestaan omdat de exit-codes de coördinatie ZIJN: `zad-lus.sh` vertakt erop, en `bootstrap.sh`
+# ook. Twee opeenvolgende reviewrondes introduceerden allebei een regressie in precies deze ladder —
+# een kapotte toestand die als 0 naar buiten kwam — en geen enkele test merkte dat, omdat alle
+# andere tests op bibliotheekniveau zitten en de smokes alleen het gelukkige pad tegen een draaiende
+# federatie lopen.
+#
+# De helften worden hier zonder netwerk gedraaid: een `curl` vooraan op PATH levert een vaste
+# contractenlijst, zodat elke combinatie van getekend/geweigerd/aandacht afdwingbaar is.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CONTRACTS="$(cd "${HERE}/../federatie/contracts" && pwd)"
+
+fails=0
+
+assert_uitgang() {
+  local desc="$1" verwacht="$2" kregen="$3"
+  if [ "$kregen" = "$verwacht" ]; then
+    echo "OK: $desc (exit $kregen)"
+  else
+    echo "FAIL: $desc — verwacht exit $verwacht, kreeg $kregen" >&2
+    fails=$((fails + 1))
+  fi
+}
+
+PROV=00000000000000100000
+CONS=00000000000000001000
+THUMB="$(printf 'a%.0s' $(seq 1 64))"
+NU="$(date -u +%s)"
+
+# contract <hash> <dienst> <getekend-door-provider> <not_after-offset>
+contract() {
+  jq -nc --arg h "$1" --arg svc "$2" --argjson sig "$3" --argjson na "$4" \
+         --arg prov "$PROV" --arg cons "$CONS" --arg thumb "$THUMB" --argjson nu "$NU" '
+    { hash: $h, state: "CONTRACT_STATE_PROPOSED", has_revoked: false, has_rejected: false,
+      signatures: { accept: ({($cons): true} + (if $sig then {($prov): true} else {} end)) },
+      content: { group_id: "moza-fbs-test", hash_algorithm: "HASH_ALGORITHM_SHA3_512",
+                 validity: { not_before: ($nu - 60), not_after: ($nu + $na) },
+                 grants: [ { type: "GRANT_TYPE_SERVICE_CONNECTION",
+                   service: { type: "SERVICE_TYPE_SERVICE", name: $svc, peer_id: $prov },
+                   outway: { peer_id: $cons,
+                     identification: { type: "OUTWAY_IDENTIFICATION_TYPE_PUBLIC_KEY_THUMBPRINT",
+                                       public_key_thumbprint: $thumb } } } ] } }'
+}
+
+# draai_provider <contract-json...>: de provider-helft tegen een gestubde manager; echoot de exit-code.
+draai_provider() {
+  local tmp lijst rc=0
+  tmp="$(mktemp -d)"
+  lijst="$(printf '%s\n' "$@" | jq -sc '{ contracts: . }')"
+
+  # De stub antwoordt op de lijst-call en zegt op alles wat muteert simpelweg ja. Meer is hier niet
+  # nodig: getoetst wordt de uitgang, niet de manager.
+  printf '%s' "$lijst" > "${tmp}/lijst.json"
+  cat > "${tmp}/curl" <<'STUB'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  case "$arg" in
+    *"/v1/contracts?"*) cat "$(dirname "$0")/lijst.json"; exit 0 ;;
+  esac
+done
+exit 0
+STUB
+  chmod +x "${tmp}/curl"
+
+  PATH="${tmp}:$PATH" \
+  FSC_LIBDIR="$HERE" \
+  FSC_PROVIDER_OIN="$PROV" FSC_DIENSTEN=berichtenmagazijn FSC_CONSUMERS="$CONS" \
+  FSC_PROVIDER_MANAGER=https://manager:9443 \
+  FSC_PROVIDER_CERT=/dev/null FSC_PROVIDER_KEY=/dev/null FSC_PROVIDER_CA=/dev/null \
+    "${CONTRACTS}/bootstrap-provider.sh" >/dev/null 2>&1 || rc=$?
+
+  rm -rf "$tmp"
+  printf '%s' "$rc"
+}
+
+command -v jq >/dev/null 2>&1 || { echo "FAIL: jq is vereist." >&2; exit 1; }
+
+echo "== provider-helft: de uitgangen per combinatie =="
+
+TEKENBAAR="$(contract h1 berichtenmagazijn false 315360000)"
+GEWEIGERD="$(contract h2 andere-dienst false 315360000)"
+AANDACHT="$(contract h3 berichtenmagazijn true -1)"
+
+assert_uitgang "lege lijst: wachten op de overkant" 3 "$(draai_provider)"
+assert_uitgang "alleen iets tekenbaars" 0 "$(draai_provider "$TEKENBAAR")"
+assert_uitgang "alleen iets geweigerds" 4 "$(draai_provider "$GEWEIGERD")"
+
+# De regressie uit reviewronde 3: dit gaf exit 0, waarna de lus de wachtteller op nul zette en het
+# component eeuwig groen bleef terwijl het datapad stuk was.
+assert_uitgang "alleen een eerder getekend contract dat nu afvalt" 4 "$(draai_provider "$AANDACHT")"
+
+assert_uitgang "geweigerd én aandacht, niets getekend" 4 "$(draai_provider "$GEWEIGERD" "$AANDACHT")"
+assert_uitgang "getekend naast geweigerd" 0 "$(draai_provider "$TEKENBAAR" "$GEWEIGERD")"
+assert_uitgang "getekend naast aandacht" 0 "$(draai_provider "$TEKENBAAR" "$AANDACHT")"
+
+echo
+echo "== provider-helft: configuratie eindigt op 2, niet op 1 =="
+
+assert_config() {
+  local desc="$1" rc=0; shift
+  env -i PATH="$PATH" FSC_LIBDIR="$HERE" "$@" "${CONTRACTS}/bootstrap-provider.sh" >/dev/null 2>&1 || rc=$?
+  assert_uitgang "$desc" 2 "$rc"
+}
+
+assert_config "ontbrekende OIN" FSC_DIENSTEN=d FSC_CONSUMERS=1 FSC_PROVIDER_MANAGER=https://m:9443 \
+  FSC_PROVIDER_CERT=/dev/null FSC_PROVIDER_KEY=/dev/null FSC_PROVIDER_CA=/dev/null
+assert_config "lege dienstenlijst" FSC_PROVIDER_OIN=1 FSC_DIENSTEN=" " FSC_CONSUMERS=1 \
+  FSC_PROVIDER_MANAGER=https://m:9443 \
+  FSC_PROVIDER_CERT=/dev/null FSC_PROVIDER_KEY=/dev/null FSC_PROVIDER_CA=/dev/null
+assert_config "manager-adres als curl-optie" FSC_PROVIDER_OIN=1 FSC_DIENSTEN=d FSC_CONSUMERS=1 \
+  FSC_PROVIDER_MANAGER=-K/etc/passwd \
+  FSC_PROVIDER_CERT=/dev/null FSC_PROVIDER_KEY=/dev/null FSC_PROVIDER_CA=/dev/null
+assert_config "limiet boven het maximum" FSC_PROVIDER_OIN=1 FSC_DIENSTEN=d FSC_CONSUMERS=1 \
+  FSC_CONTRACT_LIMIET=5000 FSC_PROVIDER_MANAGER=https://m:9443 \
+  FSC_PROVIDER_CERT=/dev/null FSC_PROVIDER_KEY=/dev/null FSC_PROVIDER_CA=/dev/null
+
+echo
+if [ "$fails" -ne 0 ]; then
+  echo "ROOD: ${fails} test(s) gefaald." >&2
+  exit 1
+fi
+
+echo "GROEN: alle uitgang-tests geslaagd."

--- a/demo/environment/lib/test-federatie-helpers.sh
+++ b/demo/environment/lib/test-federatie-helpers.sh
@@ -66,6 +66,56 @@ else
   ok "component_adres faalt hard op een leeg net"
 fi
 
+# --- fsc_grant_bruikbaar ------------------------------------------------------------------------
+# De sentinel is het hele punt: fsc_grant_hash geeft `unknown` terug in plaats van leeg, en een
+# aanroeper die op leegte toetst schrijft die string door naar de Fsc-Grant-Hash-header.
+fsc_grant_bruikbaar '$1$3$abc' \
+  && ok "grant_bruikbaar accepteert een echt hash" || fout "grant_bruikbaar verwerpt een echt hash"
+
+if fsc_grant_bruikbaar unknown; then
+  fout "grant_bruikbaar accepteert de sentinel 'unknown' (die belandt dan op de header)"
+else
+  ok "grant_bruikbaar verwerpt de sentinel 'unknown'"
+fi
+
+if fsc_grant_bruikbaar ""; then
+  fout "grant_bruikbaar accepteert een lege waarde"
+else
+  ok "grant_bruikbaar verwerpt een lege waarde"
+fi
+
+if fsc_grant_bruikbaar; then
+  fout "grant_bruikbaar accepteert een ontbrekend argument"
+else
+  ok "grant_bruikbaar verwerpt een ontbrekend argument"
+fi
+
+# --- fsc_compose_env_waarde ---------------------------------------------------------------------
+# Een kale `$` in een env_file wordt door compose als variabele-verwijzing gelezen; bij een
+# grant-hash (`$1$<n>$<base64url>`) verdwijnt daardoor het hele middenstuk en antwoordt de outway
+# 400. Gemeten in een container: `$1$4$k4rw…` kwam aan als `$1$4-KB43`.
+[ "$(fsc_compose_env_waarde '$1$4$k4rwlWTsCM_j89Fc3nrbnQa9-KB43')" = '$$1$$4$$k4rwlWTsCM_j89Fc3nrbnQa9-KB43' ] \
+  && ok "compose_env_waarde verdubbelt elke dollar in een grant-hash" \
+  || fout "compose_env_waarde verdubbelt de dollars niet (compose vreet dan het hash op)"
+
+[ "$(fsc_compose_env_waarde 'geen-dollars-hier')" = 'geen-dollars-hier' ] \
+  && ok "compose_env_waarde laat een waarde zonder dollars ongemoeid" \
+  || fout "compose_env_waarde muteert een waarde zonder dollars"
+
+[ "$(fsc_compose_env_waarde '')" = '' ] \
+  && ok "compose_env_waarde levert leeg op leeg" || fout "compose_env_waarde muteert een lege waarde"
+
+# Heen en terug: wat de schrijffunctie erin zet, moet de leesfunctie er ongeschonden uit halen.
+# Zonder die symmetrie stuurt een lezer de verdubbelde dollars door en krijgt hij een 400.
+printf 'MAGAZIJN_A_GRANT_HASH=%s\n' "$(fsc_compose_env_waarde '$1$3$_AKXojkq-Nn07')" > "$WERK/grants.env"
+[ "$(fsc_compose_env_lees "$WERK/grants.env" MAGAZIJN_A_GRANT_HASH)" = '$1$3$_AKXojkq-Nn07' ] \
+  && ok "compose_env_lees haalt eruit wat compose_env_waarde erin zette" \
+  || fout "compose_env_waarde/-lees zijn niet symmetrisch (de lezer stuurt dan dubbele dollars door)"
+
+[ -z "$(fsc_compose_env_lees "$WERK/grants.env" BESTAAT_NIET)" ] \
+  && ok "compose_env_lees levert leeg voor een onbekende naam" \
+  || fout "compose_env_lees levert niet-leeg voor een onbekende naam"
+
 # --- fsc_compose_project ------------------------------------------------------------------------
 printf 'name: fsc-magazijna\nservices:\n  x: {}\n' > "$WERK/goed.yaml"
 [ "$(fsc_compose_project "$WERK/goed.yaml")" = "fsc-magazijna" ] \

--- a/demo/environment/lib/test-fsc-contract.sh
+++ b/demo/environment/lib/test-fsc-contract.sh
@@ -1,0 +1,578 @@
+#!/usr/bin/env bash
+# Fixture-tests voor de matchers in fsc-contract.sh.
+#
+# Het zwaartepunt ligt op fsc_contract_beoordeling: dat is de autorisatiegrens van de provider-helft.
+# Waar de accept vóór de splitsing een gerichte handeling was (het script kende het hash dat het zelf
+# net had ingediend), besluit de provider nu per binnengekomen contract of hij tekent — en de inhoud
+# van dat contract komt van de tegenpartij. Elke eis heeft daarom zijn eigen weiger-test, inclusief
+# het geval waar het contract een tweede grant meesmokkelt.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=fsc-harness.sh
+source "$HERE/fsc-harness.sh"
+# shellcheck source=fsc-contract.sh
+source "$HERE/fsc-contract.sh"
+
+fsc_errlog_init
+fsc_have_jq
+[ "$HAVE_JQ" -eq 1 ] || { echo "FAIL: jq is vereist voor deze fixture-tests." >&2; exit 1; }
+
+fails=0
+
+# Vaste testidentiteiten. De waarden zelf doen er niet toe, alleen dat ze van elkaar verschillen.
+SVC=berichtenmagazijn
+SVC2=berichtenarchief
+PROV=00000000000000100000
+CONS=00000000000000001000
+CONS2=00000000000000002000
+VREEMDE=00000000000000009999
+THUMB="$(printf 'a%.0s' $(seq 1 64))"
+
+DIENSTEN="$(fsc_json_lijst "$SVC")"
+CONSUMERS="$(fsc_json_lijst "$CONS")"
+GROEP=moza-fbs-test
+MAXGELDIG=316224000
+# Vaste "nu": de geldigheidstoets meet vanaf het heden, dus zonder een gepinde klok zou de suite
+# afhangen van wanneer hij draait.
+NU=1000000000
+
+# --- fixtures ------------------------------------------------------------------------------------
+
+# grant <service> <service-peer> <consumer-peer> [grant-type] [identificatie-type]: één grant-object,
+# in de vorm die de consumer-helft daadwerkelijk indient.
+grant() {
+  jq -nc --arg svc "$1" --arg sp "$2" --arg cp "$3" --arg t "${4:-GRANT_TYPE_SERVICE_CONNECTION}" \
+         --arg it "${5:-OUTWAY_IDENTIFICATION_TYPE_PUBLIC_KEY_THUMBPRINT}" --arg thumb "$THUMB" '
+    { type: $t,
+      service: { type: "SERVICE_TYPE_SERVICE", name: $svc, peer_id: $sp },
+      outway: { peer_id: $cp, identification: { type: $it, public_key_thumbprint: $thumb } } }'
+}
+
+# contract <hash> <state> <has_revoked> <getekend-door-provider> <grant-json...>
+#
+# `signatures.accept` draagt ALTIJD de consumer, want zo ziet een echt ingediend contract eruit: de
+# manager van de consumer tekent server-side bij de POST. Een fixture met een lege `accept` zou het
+# verschil verbergen tussen "heeft ONZE handtekening" en "heeft een handtekening" — precies de
+# vergissing die de provider elk contract als al-getekend zou laten zien, waardoor hij nooit tekent.
+#
+# Ook group_id, hash_algorithm en validity horen erbij: die wegen sinds de uitbreiding mee in de
+# toets, en een fixture zonder die velden zou een andere weiger-grond raken dan de test bedoelt.
+contract() {
+  local h="$1" st="$2" rv="$3" ondertekend="$4"; shift 4
+  printf '%s\n' "$@" | jq -sc --arg h "$h" --arg st "$st" --argjson rv "$rv" \
+        --argjson sig "$ondertekend" --arg prov "$PROV" --arg cons "$CONS" --arg groep "$GROEP" \
+        --argjson nu "$NU" '
+    { hash: $h, state: $st, has_revoked: $rv,
+      signatures: { accept: ({($cons): true} + (if $sig then {($prov): true} else {} end)) },
+      content: { group_id: $groep, hash_algorithm: "HASH_ALGORITHM_SHA3_512",
+                 validity: { not_before: ($nu - 60), not_after: ($nu + 315360000) },
+                 grants: . } }'
+}
+
+# contract_ruw <json-patch>: een contract met een afwijkende content, voor de eisen buiten de grant.
+contract_ruw() {
+  contract hx CONTRACT_STATE_PROPOSED false false "$(grant "$SVC" "$PROV" "$CONS")" \
+    | jq -c "$1"
+}
+
+bundel() { printf '%s\n' "$@" | jq -sc '{ contracts: . }'; }
+
+# --- assert-helpers ------------------------------------------------------------------------------
+
+assert_gelijk() {
+  local desc="$1" verwacht="$2" kregen="$3"
+  if [ "$kregen" = "$verwacht" ]; then
+    echo "OK: $desc"
+  else
+    echo "FAIL: $desc — verwacht [$verwacht], kreeg [$kregen]" >&2
+    fails=$((fails + 1))
+  fi
+}
+
+beoordeel() {
+  fsc_contract_beoordeling "$1" "$PROV" "${2:-$DIENSTEN}" "${3:-$CONSUMERS}" "$GROEP" "$MAXGELDIG" "$NU"
+}
+
+# assert_beoordeling <desc> <json> <soort> <verwacht> [diensten-json] [consumers-json]
+assert_beoordeling() {
+  local desc="$1" json="$2" soort="$3" verwacht="$4" d="${5:-$DIENSTEN}" c="${6:-$CONSUMERS}"
+  assert_gelijk "$desc" "$verwacht" "$(fsc_contract_regels "$(beoordeel "$json" "$d" "$c")" "$soort")"
+}
+
+# assert_weiger_regel <desc> <json> <verwachte volledige regel>: strikter dan op een fragment
+# matchen, want zo is "juiste reden, verkeerd contract" wél te onderscheiden.
+assert_weiger_regel() {
+  assert_gelijk "$1" "$3" "$(fsc_contract_regels "$(beoordeel "$2")" WEIGER)"
+}
+
+# assert_weigerreden <desc> <json> <fragment>: de weigering noemt deze grond.
+assert_weigerreden() {
+  local desc="$1" json="$2" fragment="$3" reden
+  reden="$(fsc_contract_regels "$(beoordeel "$json")" WEIGER)"
+
+  case "$reden" in
+    *"$fragment"*) echo "OK: $desc" ;;
+    *) echo "FAIL: $desc — verwachtte een reden met '$fragment', kreeg [$reden]" >&2
+       fails=$((fails + 1)) ;;
+  esac
+}
+
+echo "== fsc_contract_beoordeling: cardinaliteit =="
+
+assert_beoordeling "lege contractenlijst levert niets op" '{"contracts":[]}' TEKEN ""
+assert_beoordeling "lege contractenlijst weigert ook niets" '{"contracts":[]}' WEIGER ""
+
+GOED="$(contract h1 CONTRACT_STATE_PROPOSED false false "$(grant "$SVC" "$PROV" "$CONS")")"
+assert_beoordeling "één passend contract wordt getekend" "$(bundel "$GOED")" TEKEN "h1 ${CONS}"
+
+# Twee passende contracten: een matcher die alleen het eerste teruggeeft zou hier de helft laten
+# liggen, en dat is precies het geval dat op ZAD ontstaat zodra een tweede consumer aanhaakt.
+GOED2="$(contract h2 CONTRACT_STATE_PROPOSED false false "$(grant "$SVC" "$PROV" "$CONS")")"
+assert_beoordeling "twee passende contracten worden allebei getekend" \
+  "$(bundel "$GOED" "$GOED2")" TEKEN "h1 ${CONS}
+h2 ${CONS}"
+
+echo
+echo "== fsc_contract_beoordeling: de autorisatie-eisen, elk apart =="
+
+# De kern van de invariant. Een contract draagt een LIJST grants; wie alleen toetst of er één
+# passende grant in zit, tekent de tweede mee.
+SMOKKEL="$(contract hs CONTRACT_STATE_PROPOSED false false \
+  "$(grant "$SVC" "$PROV" "$CONS")" "$(grant "$SVC2" "$PROV" "$VREEMDE")")"
+assert_beoordeling "een tweede grant erbij: niet tekenen" "$(bundel "$SMOKKEL")" TEKEN ""
+assert_weigerreden "en de reden noemt het aantal grants" "$(bundel "$SMOKKEL")" "draagt 2 grants"
+
+GEEN_GRANTS="$(contract hg CONTRACT_STATE_PROPOSED false false)"
+assert_beoordeling "nul grants: niet tekenen" "$(bundel "$GEEN_GRANTS")" TEKEN ""
+
+VERKEERD_TYPE="$(contract ht CONTRACT_STATE_PROPOSED false false \
+  "$(grant "$SVC" "$PROV" "$CONS" GRANT_TYPE_SERVICE_PUBLICATION)")"
+assert_beoordeling "ander grant-type: niet tekenen" "$(bundel "$VERKEERD_TYPE")" TEKEN ""
+assert_weigerreden "en de reden noemt het type" "$(bundel "$VERKEERD_TYPE")" "geen serviceConnection"
+
+ANDERE_PEER="$(contract hp CONTRACT_STATE_PROPOSED false false "$(grant "$SVC" "$VREEMDE" "$CONS")")"
+assert_beoordeling "dienst van een andere peer: niet tekenen" "$(bundel "$ANDERE_PEER")" TEKEN ""
+assert_weigerreden "en de reden noemt de vreemde peer" "$(bundel "$ANDERE_PEER")" "niet bij ons"
+
+ANDERE_DIENST="$(contract hd CONTRACT_STATE_PROPOSED false false "$(grant "$SVC2" "$PROV" "$CONS")")"
+assert_beoordeling "dienst die wij niet aanbieden: niet tekenen" "$(bundel "$ANDERE_DIENST")" TEKEN ""
+assert_weigerreden "en de reden noemt de dienst" "$(bundel "$ANDERE_DIENST")" "bieden wij niet aan"
+
+VREEMDE_CONS="$(contract hc CONTRACT_STATE_PROPOSED false false "$(grant "$SVC" "$PROV" "$VREEMDE")")"
+assert_beoordeling "onbekende consumer: niet tekenen" "$(bundel "$VREEMDE_CONS")" TEKEN ""
+assert_weigerreden "en de reden noemt de consumer" "$(bundel "$VREEMDE_CONS")" "staat niet op de lijst"
+
+# Een gedelegeerde dienst zet een delegator-claim in het token en verandert welke handtekeningen
+# vereist zijn. Wij bieden die niet aan.
+assert_weiger_regel "gedelegeerde dienst: niet tekenen" \
+  "$(bundel "$(contract_ruw '.content.grants[0].service.type = "SERVICE_TYPE_DELEGATED_SERVICE"')")" \
+  "hx dienst-type SERVICE_TYPE_DELEGATED_SERVICE is geen gewone dienst"
+# De discriminator is verplicht in de spec; een ontbrekende waarde als "gewone dienst" lezen zou
+# precies de blinde ondertekening zijn die deze check moet voorkomen.
+assert_weiger_regel "ontbrekend dienst-type: niet tekenen" \
+  "$(bundel "$(contract_ruw 'del(.content.grants[0].service.type)')")" \
+  "hx dienst-type ontbreekt is geen gewone dienst"
+
+# `properties` schrijft claims die onze eigen manager in het token zet en die onze inway en de dienst
+# erachter te zien krijgen — door de tegenpartij opgesteld. Blind mee-ondertekenen is dezelfde fout
+# als een tweede grant mee-ondertekenen.
+assert_weiger_regel "grant met properties: niet tekenen" \
+  "$(bundel "$(contract_ruw '.content.grants[0].properties = {"rol": "beheerder"}')")" \
+  "hx draagt grant-properties die wij niet ondertekenen"
+assert_beoordeling "een leeg properties-object is onschadelijk" \
+  "$(bundel "$(contract_ruw '.content.grants[0].properties = {}')")" TEKEN "hx ${CONS}"
+
+# Een contract dat wij eerder afwezen draagt onze accept-handtekening niet, dus zonder filter komt
+# het elke ronde terug als kandidaat en tekenen we alsnog wat we bewust weigerden.
+assert_beoordeling "een eerder afgewezen contract komt niet terug" \
+  "$(bundel "$(contract_ruw '.has_rejected = true')")" TEKEN ""
+assert_beoordeling "en levert ook geen weigering op" \
+  "$(bundel "$(contract_ruw '.has_rejected = true')")" WEIGER ""
+
+echo
+echo "== fsc_contract_beoordeling: allowlists met meer dan één waarde =="
+
+# Een allowlist van één verbergt het verschil tussen "geeft de enige terug" en "kiest per sleutel".
+BREED_D="$(fsc_json_lijst "$SVC2" "$SVC")"
+BREED_C="$(fsc_json_lijst "$CONS2" "$CONS")"
+
+assert_beoordeling "tweede dienst uit een bredere lijst telt mee" \
+  "$(bundel "$ANDERE_DIENST")" TEKEN "hd ${CONS}" "$BREED_D" "$CONSUMERS"
+# Let op de handtekening: een contract van CONS2 draagt de accept van CONS2, niet die van CONS.
+assert_beoordeling "tweede consumer uit een bredere lijst telt mee" \
+  "$(bundel "$(contract hb CONTRACT_STATE_PROPOSED false false "$(grant "$SVC" "$PROV" "$CONS2")" \
+      | jq -c --arg c "$CONS2" '.signatures.accept = {($c): true}')")" \
+  TEKEN "hb ${CONS2}" "$DIENSTEN" "$BREED_C"
+assert_beoordeling "een waarde buiten de bredere lijst blijft geweigerd" \
+  "$(bundel "$VREEMDE_CONS")" TEKEN "" "$BREED_D" "$BREED_C"
+
+echo
+echo "== fsc_contract_beoordeling: al getekend en ingetrokken =="
+
+AL_GETEKEND="$(contract hq CONTRACT_STATE_VALID false true "$(grant "$SVC" "$PROV" "$CONS")")"
+assert_beoordeling "al getekend contract komt niet opnieuw langs" "$(bundel "$AL_GETEKEND")" TEKEN ""
+assert_beoordeling "maar is wel als GETEKEND zichtbaar" "$(bundel "$AL_GETEKEND")" GETEKEND "hq ${CONS}"
+
+# Het servicePublication-contract voor onze eigen dienst staat op dezelfde manager en wordt door
+# AUTO_SIGN_GRANTS vanzelf getekend. Zou dat elke ronde een weigering opleveren, dan stond de log vol
+# met contracten waar niets mee mis is.
+PUBLICATIE="$(contract hpub CONTRACT_STATE_VALID false true \
+  "$(grant "$SVC" "$PROV" "$CONS" GRANT_TYPE_SERVICE_PUBLICATION)")"
+assert_beoordeling "een getekend contract dat de toets niet haalt zwijgt" "$(bundel "$PUBLICATIE")" WEIGER ""
+assert_beoordeling "en verschijnt ook niet als GETEKEND" "$(bundel "$PUBLICATIE")" GETEKEND ""
+
+INGETROKKEN="$(contract hr CONTRACT_STATE_PROPOSED true false "$(grant "$SVC" "$PROV" "$CONS")")"
+assert_beoordeling "ingetrokken contract wordt niet getekend" "$(bundel "$INGETROKKEN")" TEKEN ""
+assert_beoordeling "en levert geen weigering op" "$(bundel "$INGETROKKEN")" WEIGER ""
+
+echo
+echo "== fsc_contract_beoordeling: gemengde lijst =="
+
+GEMENGD="$(bundel "$GOED" "$SMOKKEL" "$AL_GETEKEND" "$INGETROKKEN" "$VREEMDE_CONS")"
+assert_beoordeling "uit een gemengde lijst alleen het juiste contract" "$GEMENGD" TEKEN "h1 ${CONS}"
+assert_beoordeling "de getekende komt als GETEKEND terug" "$GEMENGD" GETEKEND "hq ${CONS}"
+assert_gelijk "twee weigeringen met hun eigen grond" "hs
+hc" \
+  "$(fsc_contract_regels "$(fsc_contract_beoordeling "$GEMENGD" "$PROV" "$DIENSTEN" "$CONSUMERS")" WEIGER \
+     | cut -d' ' -f1)"
+
+echo
+echo "== fsc_contract_voor_combinatie =="
+
+assert_combinatie() {
+  local desc="$1" json="$2" verwacht="$3"
+  assert_gelijk "$desc" "$verwacht" "$(fsc_contract_voor_combinatie "$json" "$SVC" "$PROV" "$CONS" "$THUMB")"
+}
+
+assert_combinatie "lege lijst levert niets op" '{"contracts":[]}' ""
+assert_combinatie "ingediend maar niet getekend telt mee als uitstaand" \
+  "$(bundel "$GOED")" "h1 contract_state_proposed nee -"
+assert_combinatie "getekend en geldig komt met beide kenmerken terug" \
+  "$(bundel "$AL_GETEKEND")" "hq contract_state_valid ja -"
+
+# Zonder deze regel zou de consumer een contract van een andere outway voor "het onze" aanzien en
+# nooit meer indienen, terwijl zíjn outway de grant nooit krijgt.
+ANDERE_THUMB_C="$(contract hz CONTRACT_STATE_VALID false true "$(
+  jq -nc --arg svc "$SVC" --arg sp "$PROV" --arg cp "$CONS" '
+    { type: "GRANT_TYPE_SERVICE_CONNECTION",
+      service: { name: $svc, peer_id: $sp },
+      outway: { peer_id: $cp, identification: { public_key_thumbprint: "ffff" } } }')")"
+assert_combinatie "een andere outway-thumbprint is een ander contract" "$(bundel "$ANDERE_THUMB_C")" ""
+
+assert_combinatie "een contract met twee grants hoort niet bij deze combinatie" "$(bundel "$SMOKKEL")" ""
+assert_combinatie "ingetrokken telt niet mee" "$(bundel "$INGETROKKEN")" ""
+
+# Anders dan bij de beoordeling blijft een AFGEWEZEN contract hier zichtbaar. Zou het wegvallen, dan
+# ziet de consumer zijn eigen aanvraag niet meer en dient hij elke ronde een nieuwe in, terwijl de
+# afwijzing nergens blijkt.
+assert_combinatie "een afgewezen contract blijft zichtbaar, met vlag" \
+  "$(bundel "$(contract hr2 CONTRACT_STATE_REJECTED false false "$(grant "$SVC" "$PROV" "$CONS")" \
+      | jq -c '.has_rejected = true')")" \
+  "hr2 contract_state_rejected nee afgewezen"
+# Ook hier mag één misvormde rij de rest niet meenemen: de consumer zou zijn eigen contract dan niet
+# meer zien en elke ronde een nieuw indienen.
+#
+# De exit-status hoort er expliciet bij. jq streamt, dus de goede regel is al uitgestuurd vóór de
+# fout op de rotte rij — alleen op de uitvoer toetsen zou dus slagen terwijl de aanroeper
+# (`eigen_contracten`, onder `pipefail`) de run juist als mislukt afbreekt.
+for rot in '{"hash":"rot","content":"x"}' \
+           '{"hash":"rot","content":{"grants":[42]}}' \
+           '{"hash":"rot","content":{"grants":42}}'; do
+  gemengd="$(printf '%s\n' "$GOED" "$rot" | jq -sc '{contracts: .}')"
+  uitkomst="$(fsc_contract_voor_combinatie "$gemengd" "$SVC" "$PROV" "$CONS" "$THUMB")" && rc=0 || rc=$?
+
+  assert_gelijk "naast $(printf '%s' "$rot" | cut -c1-34)… blijft het uitstaande contract zichtbaar" \
+    "h1 contract_state_proposed nee -" "$uitkomst"
+  assert_gelijk "  en de matcher zelf slaagt (exit 0)" "0" "$rc"
+done
+
+assert_combinatie "twee uitstaande contracten komen allebei terug" \
+  "$(bundel "$GOED" "$GOED2")" "h1 contract_state_proposed nee -
+h2 contract_state_proposed nee -"
+
+echo
+echo "== fsc_contract_beoordeling: de eisen buiten de grant =="
+
+# Zonder deze vier bepaalt de tegenpartij in zijn eentje hoe lang en onder welke voorwaarden het
+# contract geldt; de allowlist zegt daar niets over.
+assert_weiger_regel "vreemde group_id: niet tekenen" \
+  "$(bundel "$(contract_ruw '.content.group_id = "andere-groep"')")" \
+  "hx hoort bij group andere-groep, niet bij de onze"
+assert_weiger_regel "afwijkend hash-algoritme: niet tekenen" \
+  "$(bundel "$(contract_ruw '.content.hash_algorithm = "HASH_ALGORITHM_SHA1"')")" \
+  "hx hash-algoritme HASH_ALGORITHM_SHA1 wijkt af"
+assert_weiger_regel "geen geldigheidsduur: niet tekenen" \
+  "$(bundel "$(contract_ruw 'del(.content.validity)')")" \
+  "hx draagt geen geldigheidsduur"
+# Precies op de grens hoort het nog wél te mogen: een off-by-one hier zou de normale
+# tienjaars-aanvraag van de consumer-helft weigeren.
+assert_beoordeling "looptijd precies op het maximum mag" \
+  "$(bundel "$(contract_ruw ".content.validity.not_after = ${NU} + ${MAXGELDIG}")")" TEKEN "hx ${CONS}"
+
+# Gemeten vanaf nu, niet als vensterlengte: een venster van tien jaar dat pas over jaren begint, is
+# een claim die veel verder reikt dan de grens die de lengte suggereert.
+assert_weiger_regel "venster dat ver in de toekomst begint: niet tekenen" \
+  "$(bundel "$(contract_ruw ".content.validity = {not_before: (${NU} + 200000000), not_after: (${NU} + 200000000 + 315360000)}")")" \
+  "hx loopt nog 515360000s, meer dan het maximum van ${MAXGELDIG}s"
+
+assert_weiger_regel "al verlopen contract: niet tekenen" \
+  "$(bundel "$(contract_ruw ".content.validity.not_after = ${NU} - 1")")" \
+  "hx is al verlopen"
+
+assert_weiger_regel "einddatum vóór begindatum: niet tekenen" \
+  "$(bundel "$(contract_ruw ".content.validity = {not_before: (${NU} + 100), not_after: (${NU} + 50)}")")" \
+  "hx einddatum ligt niet ná de begindatum"
+
+assert_weiger_regel "lege validity: niet tekenen" \
+  "$(bundel "$(contract_ruw '.content.validity = {}')")" \
+  "hx geldigheidsduur is onvolledig (not_before/not_after ontbreekt of is geen getal)"
+
+assert_weiger_regel "validity zonder not_after: niet tekenen" \
+  "$(bundel "$(contract_ruw 'del(.content.validity.not_after)')")" \
+  "hx geldigheidsduur is onvolledig (not_before/not_after ontbreekt of is geen getal)"
+
+# fsc-core wil onder een serviceConnection de handtekening van beide kanten; tekenen vóór de
+# tegenpartij dat deed, is een verplichting aangaan die de ander nog niet is aangegaan.
+assert_weiger_regel "consumer heeft nog niet getekend: wij ook niet" \
+  "$(bundel "$(contract_ruw '.signatures.accept = {}')")" \
+  "hx draagt de handtekening van de consumer nog niet"
+
+# DOMAIN_NAME is een zwakkere binding dan een thumbprint; die hoort een provider niet te tekenen.
+assert_weiger_regel "andere outway-identificatie: niet tekenen" \
+  "$(bundel "$(contract hi CONTRACT_STATE_PROPOSED false false \
+      "$(grant "$SVC" "$PROV" "$CONS" GRANT_TYPE_SERVICE_CONNECTION OUTWAY_IDENTIFICATION_TYPE_DOMAIN_NAME)")")" \
+  "hi outway-identificatie OUTWAY_IDENTIFICATION_TYPE_DOMAIN_NAME is geen thumbprint"
+
+echo
+echo "== fsc_contract_beoordeling: volgorde en samenloop =="
+
+# De gesmokkelde grant vooraan: een implementatie die "de eerste grant" toetst in plaats van "de
+# enige" zou hier iets anders beslissen dan bij de omgekeerde volgorde.
+OMGEKEERD="$(contract ho CONTRACT_STATE_PROPOSED false false \
+  "$(grant "$SVC2" "$PROV" "$VREEMDE")" "$(grant "$SVC" "$PROV" "$CONS")")"
+assert_weiger_regel "gesmokkelde grant vooraan geeft dezelfde uitkomst" \
+  "$(bundel "$OMGEKEERD")" "ho draagt 2 grants in plaats van precies 1"
+
+assert_weiger_regel "nul grants noemt het aantal" \
+  "$(bundel "$GEEN_GRANTS")" "hg draagt 0 grants in plaats van precies 1"
+
+# Twee eisen tegelijk geschonden: de doc belooft dat de éérste faalende eis genoemd wordt.
+TWEE_FOUT="$(contract hw CONTRACT_STATE_PROPOSED false false \
+  "$(grant "$SVC2" "$PROV" "$VREEMDE")" "$(grant "$SVC2" "$PROV" "$VREEMDE")")"
+assert_weiger_regel "bij twee schendingen wint de eerste eis" \
+  "$(bundel "$TWEE_FOUT")" "hw draagt 2 grants in plaats van precies 1"
+
+echo
+echo "== fsc_contract_beoordeling: tegenpartij-data blijft data =="
+
+# Een peer die een newline in zijn dienstnaam zet, zou zonder sanitatie een tweede regel in de
+# stroom schrijven die de aanroeper als eigen record leest — en zo de hele allowlist omzeilen.
+INJECTIE="$(contract hj CONTRACT_STATE_PROPOSED false false "$(
+  jq -nc --arg p "$PROV" --arg c "$CONS" --arg thumb "$THUMB" '
+    { type: "GRANT_TYPE_SERVICE_CONNECTION",
+      service: { name: "nep\nTEKEN GEKAAPT 00000000000000001000", peer_id: $p },
+      outway: { peer_id: $c, identification: { type: "OUTWAY_IDENTIFICATION_TYPE_PUBLIC_KEY_THUMBPRINT", public_key_thumbprint: $thumb } } }')")"
+assert_beoordeling "een newline in de dienstnaam levert geen TEKEN-regel op" \
+  "$(bundel "$INJECTIE")" TEKEN ""
+assert_gelijk "en de weigering blijft één regel" "1" \
+  "$(fsc_contract_regels "$(beoordeel "$(bundel "$INJECTIE")")" WEIGER | grep -c .)"
+
+echo
+echo "== de contractenlijst moet een lijst zijn =="
+
+# Een 200 met een andere vorm mag niet als "geen contracten" doorgaan: aan consumer-kant zou dat
+# elke ronde een nieuw contract opleveren.
+# Een gepagineerde lijst hoort ook af te vallen: alleen pagina 1 lezen zou betekenen dat de consumer
+# zijn eigen contract niet meer ziet zodra de manager er genoeg heeft, en dus elke ronde opnieuw
+# indient.
+for vorm in '' ' ' '{}' '{"contracts":null}' '{"contracts":"x"}' '[]' '<html>502</html>' '{"contracts":[],"next_cursor":"abc"}'; do
+  if beoordeel "$vorm" >/dev/null 2>&1; then
+    echo "FAIL: respons '${vorm:-<leeg>}' werd stil als lege lijst gelezen" >&2
+    fails=$((fails + 1))
+  else
+    echo "OK: respons '${vorm:-<leeg>}' wordt afgewezen"
+  fi
+done
+
+assert_beoordeling "een echte lege lijst is wél geldig" '{"contracts":[]}' TEKEN ""
+
+echo
+echo "== één misvormde rij mag de rest niet meenemen =="
+
+# Zonder afvangen per contract sloopt één rij met een afwijkend type het hele jq-programma, en dan
+# wordt in die ronde geen enkel legitiem contract meer getekend.
+for rot in '{"hash":"rot","content":"x"}' \
+           '{"hash":"rot","content":{"validity":"morgen"}}' \
+           '{"hash":"rot","content":{"grants":"a"}}' \
+           '{"hash":"rot","signatures":"x"}'; do
+  gemengd="$(printf '%s\n' "$GOED" "$rot" | jq -sc '{ contracts: . }')"
+  assert_gelijk "naast $(printf '%s' "$rot" | cut -c1-38)… blijft het goede contract over" \
+    "h1 ${CONS}" "$(fsc_contract_regels "$(beoordeel "$gemengd")" TEKEN)"
+done
+
+echo
+echo "== fsc_hex64 =="
+
+GELDIGE_THUMB="$(printf 'a%.0s' $(seq 1 64))"
+assert_hex() {
+  local desc="$1" waarde="$2" verwacht="$3" kregen=nee
+  fsc_hex64 "$waarde" && kregen=ja
+  assert_gelijk "$desc" "$verwacht" "$kregen"
+}
+
+assert_hex "64 lowercase hex is geldig" "$GELDIGE_THUMB" ja
+assert_hex "leeg is ongeldig" "" nee
+assert_hex "63 tekens is ongeldig" "${GELDIGE_THUMB%?}" nee
+assert_hex "65 tekens is ongeldig" "${GELDIGE_THUMB}a" nee
+assert_hex "hoofdletters zijn ongeldig" "$(printf 'A%.0s' $(seq 1 64))" nee
+# De oude glob toetste alleen teken 1; deze twee kwamen er toen doorheen.
+assert_hex "niet-hex ná het eerste teken is ongeldig" "a$(printf 'z%.0s' $(seq 1 63))" nee
+assert_hex "een aanhalingsteken erin is ongeldig" "a\",\"x\":\"$(printf 'a%.0s' $(seq 1 56))" nee
+
+echo
+echo "== fsc_lijst_naar_json en fsc_json_lijst =="
+
+assert_gelijk "één dienst" '["a"]' "$(fsc_lijst_naar_json T a | tr -d '\n')"
+assert_gelijk "meerdere op spaties" '["a","b"]' "$(fsc_lijst_naar_json T "a  b" | tr -d '\n')"
+# Een allowlist over meerdere regels: `read -r -a` zou hier alles na regel 1 laten vallen, en dat
+# versmalt de autorisatiegrens zonder dat iemand het merkt.
+assert_gelijk "meerdere over regels" '["a","b","c"]' "$(fsc_lijst_naar_json T "$(printf 'a\nb c')" | tr -d '\n')"
+assert_gelijk "tabs tellen ook als scheiding" '["a","b"]' "$(fsc_lijst_naar_json T "$(printf 'a\tb')" | tr -d '\n')"
+
+for leeg in "" " " "$(printf '\n\n')"; do
+  if fsc_lijst_naar_json T "$leeg" >/dev/null 2>&1; then
+    echo "FAIL: lege lijst '${leeg}' werd geaccepteerd" >&2
+    fails=$((fails + 1))
+  else
+    echo "OK: lege lijst wordt afgewezen"
+  fi
+done
+
+# De grens waar operator-env een jq-argument wordt.
+assert_gelijk "aanhalingstekens worden ge-escaped" '["a\"b"]' "$(fsc_json_lijst 'a"b' | tr -d '\n')"
+assert_gelijk "geen argumenten geeft een lege array" '[]' "$(fsc_json_lijst)"
+
+echo
+echo "== een rij die geen object is =="
+
+# Zonder aparte typecheck laat élke veldtoets zo'n rij het hele programma afbreken, en dan wordt in
+# die ronde geen enkel legitiem contract getekend.
+for rot in '"oeps"' '42' '[]' 'null'; do
+  gemengd="$(printf '%s\n' "$GOED" "$rot" | jq -sc '{contracts: .}')"
+  uitkomst="$(beoordeel "$gemengd")" && rc=0 || rc=$?
+
+  assert_gelijk "rij ${rot}: het goede contract blijft over" "h1 ${CONS}" \
+    "$(fsc_contract_regels "$uitkomst" TEKEN)"
+  assert_gelijk "  en de beoordeling zelf slaagt" "0" "$rc"
+done
+
+echo
+echo "== eerder getekend, nu afgekeurd: niet stil =="
+
+# Wordt een typefout in FSC_DIENSTEN gecorrigeerd ná de eerste tekenronde, of daalt de bovengrens,
+# dan valt een contract dat wij al tekenden buiten de toets. Dat is geen besluit meer, maar wel iets
+# waarvan de operator moet weten — anders meldt de provider "nog niets binnen" terwijl het er ligt.
+GETEKEND_VERLOPEN="$(contract hv CONTRACT_STATE_VALID false true "$(grant "$SVC" "$PROV" "$CONS")" \
+  | jq -c ".content.validity.not_after = ${NU} - 1")"
+assert_beoordeling "een verlopen eigen contract levert een AANDACHT-regel op" \
+  "$(bundel "$GETEKEND_VERLOPEN")" AANDACHT "hv is al verlopen"
+assert_beoordeling "en geen WEIGER" "$(bundel "$GETEKEND_VERLOPEN")" WEIGER ""
+
+# Het publicatiecontract voor onze eigen dienst draagt onze handtekening en haalt de toets ook niet;
+# dát hoort wél stil te blijven, anders staat de log elke ronde vol.
+assert_beoordeling "een getekend publicatiecontract blijft stil" "$(bundel "$PUBLICATIE")" AANDACHT ""
+
+echo
+echo "== fsc_getal_vereist =="
+
+assert_getal() {
+  local desc="$1" waarde="$2" verwacht="$3" kregen
+  kregen="$(fsc_getal_vereist T "$waarde" 2>/dev/null)" || kregen="(afgewezen)"
+  assert_gelijk "$desc" "$verwacht" "$kregen"
+}
+
+assert_getal "gewoon getal" 15 15
+assert_getal "meercijferig" 3600 3600
+# Nul zou de lus zonder pauze laten draaien — precies de hot loop waar de controle voor bestaat.
+assert_getal "nul wordt afgewezen" 0 "(afgewezen)"
+# Bash leest een voorloopnul als octaal; `$((x * 08))` breekt af midden in de lus.
+assert_getal "voorloopnul wordt afgewezen" 08 "(afgewezen)"
+assert_getal "eenheden erachter worden afgewezen" 15s "(afgewezen)"
+assert_getal "negatief wordt afgewezen" -1 "(afgewezen)"
+assert_getal "leeg wordt afgewezen" "" "(afgewezen)"
+
+echo
+echo "== fsc_hash_ok =="
+
+assert_hash() {
+  local desc="$1" waarde="$2" verwacht="$3" kregen=nee
+  fsc_hash_ok "$waarde" && kregen=ja
+  assert_gelijk "$desc" "$verwacht" "$kregen"
+}
+
+assert_hash "een echte FSC-hash" '$1$4$k4rwlWTsCM_j89Fc3nrbnQa9-KB43' ja
+assert_hash "leeg" "" nee
+# `.` en `..` bestaan uit toegestane tekens maar verleggen het pad: curl normaliseert ze weg.
+assert_hash "een punt" "." nee
+assert_hash "twee punten" ".." nee
+assert_hash "een schuine streep" "a/b" nee
+assert_hash "witruimte" "a b" nee
+assert_hash "een newline" "$(printf 'a\nb')" nee
+
+echo
+echo "== fsc_contract_manager_ok =="
+
+assert_manager() {
+  local desc="$1" verwacht="$2"; shift 2
+  local kregen=nee
+  fsc_contract_manager_ok "$@" 2>/dev/null && kregen=ja
+  assert_gelijk "$desc" "$verwacht" "$kregen"
+}
+
+assert_manager "https wordt geaccepteerd" ja https://manager:9443
+assert_manager "http wordt geweigerd" nee http://manager:9443
+assert_manager "leeg wordt geweigerd" nee ""
+# De reden dat deze functie bestaat: curl leest een argument dat met `-` begint als optie, en
+# `-K/pad` maakt er een lees-je-config-uit-dit-bestand van.
+assert_manager "een curl-optie wordt geweigerd" nee -K/tmp/kwaadaardig
+# Met twee argumenten: een implementatie die na de eerste stopt, zou de tweede missen.
+assert_manager "een ongeldig tweede adres wordt ook geweigerd" nee https://manager:9443 http://andere:9443
+
+echo
+echo "== de helften kennen elkaars manager niet =="
+
+# Statisch, en daarom hier en niet in de smoke: dit is de eigenschap waar de hele ZAD-opzet op
+# rust, en hij moet ook toetsbaar zijn zonder draaiende federatie. Een half dat de adres- of
+# certificaat-variabelen van de overkant leest, werkt lokaal prima en faalt pas op ZAD — precies de
+# terugkoppeling die we niet willen.
+#
+# De OIN's staan er bewust niet bij: dat zijn publieke organisatienummers, geen adressen, en beide
+# helften hebben ze nodig om te weten waar het contract over gaat.
+CONTRACTS_DIR="$(cd "$HERE/../federatie/contracts" && pwd)"
+
+assert_geen_verwijzing() {
+  local desc="$1" bestand="$2" patroon="$3" treffers
+  treffers="$(grep -nE "$patroon" "$bestand" || true)"
+
+  if [ -z "$treffers" ]; then
+    echo "OK: $desc"
+  else
+    echo "FAIL: $desc — gevonden in $(basename "$bestand"):" >&2
+    printf '%s\n' "$treffers" | sed 's/^/  /' >&2
+    fails=$((fails + 1))
+  fi
+}
+
+assert_geen_verwijzing "de consumer-helft noemt de provider-manager nergens" \
+  "${CONTRACTS_DIR}/bootstrap-consumer.sh" 'FSC_PROVIDER_(MANAGER|CERT|KEY|CA|ADRES)'
+assert_geen_verwijzing "de provider-helft noemt de consumer-manager nergens" \
+  "${CONTRACTS_DIR}/bootstrap-provider.sh" 'FSC_CONSUMER_(MANAGER|CERT|KEY|CA|ADRES)'
+
+echo
+if [ "$fails" -ne 0 ]; then
+  echo "ROOD: ${fails} test(s) gefaald." >&2
+  exit 1
+fi
+
+echo "GROEN: alle fsc-contract-tests geslaagd."

--- a/demo/environment/lib/test-fsc-harness.sh
+++ b/demo/environment/lib/test-fsc-harness.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Fixture-test voor fsc_scrub_errlog: toetst tegen de exacte ANSI-bytes uit de PR-166-bug-report
-# (ericwout-overheid, 2026-08-12) — reproductie van de podman-external-compose-provider-banner.
+# Fixture-tests voor de pure-logica-helpers in fsc-harness.sh: fsc_scrub_errlog (tegen de exacte
+# ANSI-bytes uit de PR-166-bug-report, ericwout-overheid, 2026-08-12), en de contract-matcher/
+# thumbprint-helpers die bootstrap.sh en smoke-contract.sh delen.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
@@ -45,6 +46,104 @@ assert_empty_after_scrub "banner-only wordt leeg (geen vals alarm)" "$BANNER"
 REAL_ERROR="${BANNER}curl: (7) Failed to connect to manager.logius.fsc-test.local port 9443: Connection refused
 "
 assert_survives_scrub "echte curl-fout blijft zichtbaar na scrub" "$REAL_ERROR" "Connection refused"
+
+fsc_have_jq
+[ "$HAVE_JQ" -eq 1 ] || { echo "FAIL: jq is vereist voor deze fixture-tests." >&2; exit 1; }
+
+# --- fsc_grant_actief -------------------------------------------------------------------------
+# Vaste testidentiteit; de waarden zelf doen er niet toe, alleen dat thumbprint 1 != thumbprint 2.
+SVC=berichtenmagazijn
+PROV=00000000000000100000
+CONS=00000000000000001000
+THUMB="$(printf 'a%.0s' $(seq 1 64))"
+ANDERE_THUMB="$(printf 'b%.0s' $(seq 1 64))"
+
+# contract_json <hash> <state> <has_revoked> <heeft-provider-sig> <heeft-consumer-sig> <thumb>
+contract_json() {
+  jq -n --arg h "$1" --arg st "$2" --argjson rv "$3" --argjson hp "$4" --argjson hc "$5" \
+        --arg svc "$SVC" --arg prov "$PROV" --arg cons "$CONS" --arg thumb "$6" '
+    { hash: $h, state: $st, has_revoked: $rv,
+      signatures: { accept: ( {}
+        + (if $hp then {($prov): true} else {} end)
+        + (if $hc then {($cons): true} else {} end) ) },
+      content: { grants: [ {
+        type: "GRANT_TYPE_SERVICE_CONNECTION",
+        service: { name: $svc, peer_id: $prov },
+        outway: { peer_id: $cons, identification: { public_key_thumbprint: $thumb } }
+      } ] } }'
+}
+
+# contracts_json <contract-json...>: bundelt losse contract-objecten tot { "contracts": [...] }.
+contracts_json() { printf '%s\n' "$@" | jq -s '{ contracts: . }'; }
+
+assert_grant_hashes() {
+  local desc="$1" json="$2" verwacht="$3" thumb="${4:-$THUMB}" kregen
+  kregen="$(fsc_grant_actief "$json" "$SVC" "$PROV" "$CONS" "$thumb")"
+  if [ "$kregen" = "$verwacht" ]; then
+    echo "OK: $desc"
+  else
+    echo "FAIL: $desc — verwacht [$verwacht], kreeg [$kregen]" >&2
+    fails=$((fails + 1))
+  fi
+}
+
+VALID_VOLLEDIG="$(contract_json h1 CONTRACT_STATE_VALID false true true "$THUMB")"
+assert_grant_hashes "geldig + niet-ingetrokken + beide handtekeningen -> gevonden" \
+  "$(contracts_json "$VALID_VOLLEDIG")" "h1"
+
+GEREVOKED="$(contract_json h2 CONTRACT_STATE_VALID true true true "$THUMB")"
+assert_grant_hashes "ingetrokken contract telt niet mee" \
+  "$(contracts_json "$GEREVOKED")" ""
+
+ZONDER_CONSUMER_SIG="$(contract_json h3 CONTRACT_STATE_VALID false true false "$THUMB")"
+assert_grant_hashes "ontbrekende consumer-handtekening telt niet mee" \
+  "$(contracts_json "$ZONDER_CONSUMER_SIG")" ""
+
+ANDERE_STATE="$(contract_json h4 CONTRACT_STATE_PROPOSED false true true "$THUMB")"
+assert_grant_hashes "niet-VALID state telt niet mee" \
+  "$(contracts_json "$ANDERE_STATE")" ""
+
+ANDER_THUMB_CONTRACT="$(contract_json h5 CONTRACT_STATE_VALID false true true "$ANDERE_THUMB")"
+assert_grant_hashes "afwijkende outway-thumbprint telt niet mee" \
+  "$(contracts_json "$ANDER_THUMB_CONTRACT")" ""
+
+assert_grant_hashes "twee geldige contracten voor dezelfde combinatie komen beide terug" \
+  "$(contracts_json "$VALID_VOLLEDIG" "$(contract_json h1b CONTRACT_STATE_VALID false true true "$THUMB")")" \
+  "$(printf 'h1\nh1b')"
+
+assert_grant_hashes "lege contractenlijst geeft niets terug" \
+  "$(contracts_json)" ""
+
+# --- fsc_outway_thumbprint ---------------------------------------------------------------------
+CERTDIR="$(mktemp -d)"
+trap 'rm -rf "$CERTDIR"' EXIT
+openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -nodes -days 1 \
+  -subj "/CN=test-outway" -keyout "$CERTDIR/key.pem" -out "$CERTDIR/cert.pem" >/dev/null 2>&1
+
+ERRLOG="$(mktemp)"
+GEVONDEN="$(fsc_outway_thumbprint "$CERTDIR/cert.pem")" && THUMB_OK=1 || THUMB_OK=0
+if [ "$THUMB_OK" -eq 1 ] && printf '%s' "$GEVONDEN" | grep -qE '^[0-9a-f]{64}$'; then
+  echo "OK: fsc_outway_thumbprint geeft 64 lowercase hex-tekens voor een geldig cert"
+else
+  echo "FAIL: fsc_outway_thumbprint op een geldig cert gaf '$GEVONDEN' (ok=$THUMB_OK)" >&2
+  fails=$((fails + 1))
+fi
+
+if GEVONDEN="$(fsc_outway_thumbprint "$CERTDIR/niet-bestaand.pem" 2>/dev/null)"; then
+  echo "FAIL: fsc_outway_thumbprint had moeten falen op een ontbrekend bestand, gaf '$GEVONDEN'" >&2
+  fails=$((fails + 1))
+else
+  echo "OK: fsc_outway_thumbprint faalt op een ontbrekend certificaatbestand"
+fi
+
+printf 'dit is geen certificaat' > "$CERTDIR/rommel.pem"
+if GEVONDEN="$(fsc_outway_thumbprint "$CERTDIR/rommel.pem" 2>/dev/null)"; then
+  echo "FAIL: fsc_outway_thumbprint had moeten falen op een corrupt bestand, gaf '$GEVONDEN'" >&2
+  fails=$((fails + 1))
+else
+  echo "OK: fsc_outway_thumbprint faalt op een corrupt certificaatbestand"
+fi
+rm -f "$ERRLOG"
 
 if [ "$fails" -eq 0 ]; then
   echo "ALLE ASSERTS GROEN"

--- a/demo/environment/logius/deploy/local/publish-service.sh
+++ b/demo/environment/logius/deploy/local/publish-service.sh
@@ -9,6 +9,17 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=../../../lib/fsc-harness.sh
 source "$HERE/../../../lib/fsc-harness.sh"
 
+# Zet $HAVE_JQ; de vergelijking van de bestaande upstream leest de controller-JSON met jq.
+#
+# Meteen hard falen en niet pas bij de vergelijking: die tak wordt alleen geraakt als de dienst al
+# bestaat, dus zonder deze controle slaagt de eerste run op een machine zonder jq en faalt elke
+# volgende — een verschil dat je aan het script niet ziet.
+fsc_have_jq
+[ "$HAVE_JQ" -eq 1 ] || {
+  echo "FAIL: jq is vereist; dit script vergelijkt de bestaande upstream met de controller-JSON." >&2
+  exit 1
+}
+
 # shellcheck disable=SC2034  # gelezen door fsc_tb() uit de caller-scope (lib/fsc-harness.sh).
 COMPOSE=(docker compose -f "$HERE/docker-compose.yaml")
 SERVICE_NAME="profiel-service"
@@ -19,7 +30,10 @@ GROUP_ID="moza-fbs-test"
 # overrulebaar, met de standalone-waarde als default. Geprefixt met FSC_ omdat een kale `MANAGER=`
 # in iemands shell anders stilzwijgend een mTLS-call mét het internal-cert van deze peer naar een
 # vreemd endpoint zou sturen.
-STUB_URL="${FSC_STUB_URL:-http://stub-upstream:8080}"
+# De dienst wijst naar de upstream die de inway fronter. In de kale harness is dat de
+# http-echo-stub; zodra de echte applicatie erachter hangt, is het die. FSC_STUB_URL blijft als
+# oude naam werken zodat bestaande aanroepen niet stilvallen.
+UPSTREAM_URL="${FSC_UPSTREAM_URL:-${FSC_STUB_URL:-http://stub-upstream:8080}}"
 
 # shellcheck disable=SC2034  # gelezen door fsc_tb() uit de caller-scope (lib/fsc-harness.sh).
 CERT=/pki/internal/logius/manager/cert.pem
@@ -41,14 +55,14 @@ case "$MANAGER" in
   *) echo "FAIL: FSC_MANAGER moet met https:// beginnen: '${MANAGER}'" >&2; exit 2 ;;
 esac
 
-# STUB_URL gaat ongeëscaped een handgebouwde JSON-body in (CreateService, hieronder). Een
+# UPSTREAM_URL gaat ongeëscaped een handgebouwde JSON-body in (CreateService, hieronder). Een
 # aanhalingsteken zou daar uit de string breken en velden kunnen toevoegen.
-case "$STUB_URL" in
+case "$UPSTREAM_URL" in
   http://*|https://*) ;;
-  *) echo "FAIL: FSC_STUB_URL moet met http:// of https:// beginnen: '${STUB_URL}'" >&2; exit 2 ;;
+  *) echo "FAIL: FSC_UPSTREAM_URL moet met http:// of https:// beginnen: '${UPSTREAM_URL}'" >&2; exit 2 ;;
 esac
-case "$STUB_URL" in
-  *'"'*|*'\'*) echo "FAIL: FSC_STUB_URL bevat een aanhalingsteken of backslash." >&2; exit 2 ;;
+case "$UPSTREAM_URL" in
+  *'"'*|*'\'*) echo "FAIL: FSC_UPSTREAM_URL bevat een aanhalingsteken of backslash." >&2; exit 2 ;;
 esac
 
 # Vang curl-/toolbox-stderr op i.p.v. weg te gooien: een mTLS-/netwerk-/dode-container-fout
@@ -73,11 +87,28 @@ done
 echo "  inway_address=$INWAY_ADDR"
 
 echo "publish: $SERVICE_NAME aanmaken (idempotent)..."
-if fsc_tb "$CONTROLLER/v1/services" | grep -q "\"$SERVICE_NAME\""; then
-  echo "  bestaat al, skip create."
+BESTAAND="$(fsc_tb "$CONTROLLER/v1/services" || true)"
+if printf '%s' "$BESTAAND" | grep -q "\"$SERVICE_NAME\""; then
+  # Bestaat al — maar met wélke upstream? Zonder deze controle wisselt een run met een andere
+  # FSC_UPSTREAM_URL stilzwijgend niets, en blijft de inway naar de oude upstream wijzen terwijl
+  # het script "klaar" meldt. Dat kost je een half uur zoeken in de verkeerde hoek.
+  #
+  # Met jq en niet met grep: een grep-patroon over JSON breekt zodra het antwoord met spaties wordt
+  # opgemaakt, en de URL zou als regex worden gelezen (een punt matcht dan elk teken).
+  HUIDIGE_URL="$(printf '%s' "$BESTAAND" \
+    | jq -r --arg n "$SERVICE_NAME" '.services[]? | select(.name == $n) | .endpoint_url' 2>/dev/null || true)"
+
+  if [ "$HUIDIGE_URL" = "$UPSTREAM_URL" ]; then
+    echo "  bestaat al met dezelfde upstream, skip create."
+  else
+    echo "  bestaat al met upstream ${HUIDIGE_URL:-<onbekend>}; bijwerken naar ${UPSTREAM_URL}..."
+    fsc_tb -X PUT "$CONTROLLER/v1/services/$SERVICE_NAME" -H 'Content-Type: application/json' \
+       -d "{\"name\":\"$SERVICE_NAME\",\"endpoint_url\":\"$UPSTREAM_URL\",\"inway_address\":\"$INWAY_ADDR\"}"
+    echo "  bijgewerkt."
+  fi
 else
   fsc_tb -X POST "$CONTROLLER/v1/services" -H 'Content-Type: application/json' \
-     -d "{\"name\":\"$SERVICE_NAME\",\"endpoint_url\":\"$STUB_URL\",\"inway_address\":\"$INWAY_ADDR\"}"
+     -d "{\"name\":\"$SERVICE_NAME\",\"endpoint_url\":\"$UPSTREAM_URL\",\"inway_address\":\"$INWAY_ADDR\"}"
   echo "  aangemaakt."
 fi
 

--- a/demo/environment/logius/deploy/zad/README.md
+++ b/demo/environment/logius/deploy/zad/README.md
@@ -41,7 +41,8 @@ De peer staat daarom in een eigen deployment `fsc-logius`: **wat niet in `test` 
 | `upsert-peer.sh` | `validate`/`plan`/`apply` tegen de ZAD v2 Operations Manager API — lokaal/handmatig hulpmiddel voor de eenmalige component-creatie (env/ports/certs) en voor debugging. |
 | `cert-manifest.md` | Runbook: welk cert-bestand op welk `/etc/fsc/...`-pad, per component (UI-only bijlagen). |
 | `verify-zad.md` | Runbook: announce/publiceren/discover ná een geslaagde apply, + de acceptatiecriteria. |
-| `../../../../../.github/workflows/deploy.yml` (root) | `deploy-test-uitvraag`-job: de DOORLOPENDE image-tag-updates (elke push naar main) — de `uitvraag`-componenten op deployment `test`, de zes `logius-fsc*`-componenten op `fsc-logius`. Niet de eenmalige creatie (die doet `upsert-peer.sh`). |
+| `../../../federatie/contracts/zad-runbook.md` | Runbook: het contract-bootstrap-component (`logius-fscbootstrap`, rol consumer) neerzetten — env, cert-attachments, verificatie. |
+| `../../../../../.github/workflows/deploy.yml` (root) | `deploy-test-uitvraag`-job: de DOORLOPENDE image-tag-updates (elke push naar main) — de `uitvraag`-componenten op deployment `test`, de zeven `logius-fsc*`-componenten op `fsc-logius`. Niet de eenmalige creatie (die doet `upsert-peer.sh`). |
 
 ## Volgorde
 

--- a/demo/environment/logius/deploy/zad/upsert-peer.sh
+++ b/demo/environment/logius/deploy/zad/upsert-peer.sh
@@ -14,6 +14,10 @@
 # Twee valkuilen die het gedrag van dit script bepalen:
 # - ZAD past component-config (env_vars/aliases) alleen bij COMPONENT-CREATIE toe, niet bij een
 #   re-POST op een bestaande component. Config wijzigen betekent de component eerst in de UI
+# LET OP: `logius-fscbootstrap` staat wel in de deployment-lijst hieronder (anders haalt een upsert hem
+# eruit) maar krijgt hier geen env en geen poorten: zijn env (FSC_ROL=consumer, allowlist) en zijn
+# cert-attachments zijn UI-werk, zie federatie/contracts/zad-runbook.md.
+#
 #   verwijderen en opnieuw applyen — de cert-attachments raak je daarmee kwijt en moeten opnieuw
 #   gemount worden.
 # - `:upsert-deployment` maakt géén NIEUW deployment aan (geeft wel HTTP 202, maar het deployment
@@ -84,6 +88,12 @@ OUTWAY_IMAGE="docker.io/federatedserviceconnectivity/outway:${IMAGE_TAG}"
 INWAY_IMAGE="docker.io/federatedserviceconnectivity/inway:${IMAGE_TAG}"
 TXLOG_IMAGE="${ZAD_TXLOG_IMAGE:-ghcr.io/minbzk/moza-fsc-testnet-txlog-migrate:${TXLOG_TAG}}"
 POSTGRES_IMAGE="${ZAD_POSTGRES_IMAGE:-docker.io/library/postgres:17}"   # self-hosted DB (spiegelt deploy/local)
+# De contract-bootstrap komt uit DEZE repo (build-contract-bootstrap in deploy.yml), niet uit
+# repo A, en volgt dus niet de FSC-versietag.
+# Geen kale `:main`-default: de deploy-workflow pusht uitsluitend `main-<sha7>` en `pr-<n>-<sha7>`,
+# dus `:main` bestaat niet en zou een ImagePullBackOff opleveren tot de eerstvolgende deploy hem
+# overschrijft. Zet de tag expliciet, of laat het component met rust — `deploy.yml` houdt hem bij.
+BOOTSTRAP_IMAGE="${ZAD_BOOTSTRAP_IMAGE:-__ZET_ZAD_BOOTSTRAP_IMAGE__}"
 
 # Concrete hostnamen voor déze (vaste) deployment — zowel voor de plan-/apply-output als, direct,
 # voor de inter-component-adressen in de env_vars-blobs. Geen $DEPLOYMENT_NAME-substitutie: de
@@ -265,9 +275,9 @@ component_body() {  # $1=name $2=image $3=ports_json $4=env  [$5=services_json=[
 
 DEPLOY_BODY="$(jq -n --arg d "${DEPLOYMENT}" --arg cf "${CLONE_FROM}" \
   --arg mgr "${MANAGER_IMAGE}" --arg ctl "${CONTROLLER_IMAGE}" --arg outway "${OUTWAY_IMAGE}" \
-  --arg inway "${INWAY_IMAGE}" --arg txlog "${TXLOG_IMAGE}" --arg pg "${POSTGRES_IMAGE}" \
+  --arg inway "${INWAY_IMAGE}" --arg txlog "${TXLOG_IMAGE}" --arg pg "${POSTGRES_IMAGE}" --arg boot "${BOOTSTRAP_IMAGE}" \
   '{deploymentName:$d, domain_format:"component-deployment-project",
-    components:[{reference:"logius-fscpg", image:$pg}, {reference:"logius-fscmgr", image:$mgr}, {reference:"logius-fscctl", image:$ctl}, {reference:"logius-fscoutway", image:$outway}, {reference:"logius-fscinway", image:$inway}, {reference:"logius-fsctxlog", image:$txlog}]}
+    components:[{reference:"logius-fscpg", image:$pg}, {reference:"logius-fscmgr", image:$mgr}, {reference:"logius-fscctl", image:$ctl}, {reference:"logius-fscoutway", image:$outway}, {reference:"logius-fscinway", image:$inway}, {reference:"logius-fsctxlog", image:$txlog}, {reference:"logius-fscbootstrap", image:$boot}]}
    + (if $cf=="" then {} else {cloneFrom:$cf, forceClone:false} end)')"
 
 # Poorten per component (ports[0] = ingress). manager/controller exposen naast de ingress hun interne

--- a/demo/environment/logius/pki/gen-csr.sh
+++ b/demo/environment/logius/pki/gen-csr.sh
@@ -38,7 +38,7 @@ ORG="Logius"
 OIN="00000000000000001000"                                # = subject.serialNumber = Peer ID
 # endpoint:component-korte-naam (de ZAD-component + Service heet `<deployment>-<short>`). Volgorde
 # bepaalt de uitvoer-volgorde; spiegelt de LOG*_SVC-namen in upsert-peer.sh.
-ENDPOINTS=( "manager:logius-fscmgr" "outway:logius-fscoutway" "inway:logius-fscinway" "controller:logius-fscctl" "txlog:logius-fsctxlog" )
+ENDPOINTS=( "manager:logius-fscmgr" "outway:logius-fscoutway" "inway:logius-fscinway" "controller:logius-fscctl" "txlog:logius-fsctxlog" "bootstrap:logius-fscbootstrap" )
 
 # Genereer per endpoint de csr.json. SAN-volgorde: peer-identiteit (alleen manager) ->
 # <endpoint>.<peer>.fsc-test.local -> externe mesh-host -> Service-kortnaam -> Service-FQDN.

--- a/demo/environment/logius/pki/issue.sh
+++ b/demo/environment/logius/pki/issue.sh
@@ -44,12 +44,20 @@ done
 find "${BASE_DIR}/peers" -name csr.json -print0 | while IFS= read -r -d '' CSR; do
   REL="$(dirname "${CSR#"${BASE_DIR}/peers/"}")"   # <peer>/<endpoint>
   PEER="${REL%%/*}"
+  ENDPOINT="${REL##*/}"
   GROUP_OUT="${BASE_DIR}/out/${REL}"
   INT_OUT="${BASE_DIR}/internal/${REL}"
   ICA_DIR="${BASE_DIR}/internal/${PEER}/ca"
 
   # GROUP (extern, group-intermediate). Hecht intermediate aan voor de keten.
-  if [ -s "${GROUP_OUT}/cert.pem" ] && [ -s "${GROUP_OUT}/key.pem" ] && [ "${FORCE}" -eq 0 ]; then
+  #
+  # Niet voor client-only endpoints. Een group-cert is de identiteit waarmee een component zich in
+  # de mesh als deze peer voordoet; wie hem niet nodig heeft, hoort hem ook niet te krijgen. De
+  # contract-bootstrap praat alleen met de interne manager-API van zijn eigen peer en bedient zelf
+  # geen TLS, dus hij komt met het internal-cert hieronder toe.
+  if [ "${ENDPOINT}" = bootstrap ]; then
+    echo "skip group ${REL} (client-only endpoint)"
+  elif [ -s "${GROUP_OUT}/cert.pem" ] && [ -s "${GROUP_OUT}/key.pem" ] && [ "${FORCE}" -eq 0 ]; then
     echo "skip group ${REL} (geen -f)"
   else
     mkdir -p "${GROUP_OUT}"

--- a/demo/environment/logius/pki/peers/logius/bootstrap/csr.json
+++ b/demo/environment/logius/pki/peers/logius/bootstrap/csr.json
@@ -1,0 +1,20 @@
+{
+  "CN": "bootstrap.logius.fsc-test.local",
+  "key": {
+    "algo": "rsa",
+    "size": 4096
+  },
+  "hosts": [
+    "bootstrap.logius.fsc-test.local",
+    "logius-fscbootstrap-fsc-logius-mpfb-8wh.rig.prd1.gn2.quattro.rijksapps.nl",
+    "fsc-logius-logius-fscbootstrap",
+    "fsc-logius-logius-fscbootstrap.rig-prd-mpfb-8wh.svc.cluster.local"
+  ],
+  "serialnumber": "00000000000000001000",
+  "names": [
+    {
+      "O": "Logius",
+      "C": "NL"
+    }
+  ]
+}

--- a/demo/environment/logius/pki/zad-bundle.sh
+++ b/demo/environment/logius/pki/zad-bundle.sh
@@ -22,6 +22,10 @@ env_for() {
     out/*/cert.pem)         echo "TLS_GROUP_CERT (+ TLS_GROUP_TOKEN_CERT, TLS_GROUP_CONTRACT_CERT)" ;;
     out/*/key.pem)          echo "TLS_GROUP_KEY (+ TLS_GROUP_TOKEN_KEY, TLS_GROUP_CONTRACT_KEY)" ;;
     internal/*/ca/root.pem) echo "TLS_ROOT_CERT (+ TLS_INTERNAL_UNAUTHENTICATED_ROOT_CERT)" ;;
+    # Vóór de algemene internal-regels: het bootstrap-component is geen FSC-binary en leest geen
+    # TLS_*-variabelen, maar gebruikt hetzelfde internal-cert als client naar de manager-API.
+    internal/*/bootstrap/cert.pem) echo "FSC_{CONSUMER,PROVIDER}_CERT (client-cert contract-bootstrap)" ;;
+    internal/*/bootstrap/key.pem)  echo "FSC_{CONSUMER,PROVIDER}_KEY" ;;
     internal/*/cert.pem)    echo "TLS_CERT (+ TLS_INTERNAL_UNAUTHENTICATED_CERT)" ;;
     internal/*/key.pem)     echo "TLS_KEY (+ TLS_INTERNAL_UNAUTHENTICATED_KEY)" ;;
     *)                      echo "?" ;;

--- a/demo/environment/magazijn-a/deploy/local/publish-service.sh
+++ b/demo/environment/magazijn-a/deploy/local/publish-service.sh
@@ -9,6 +9,17 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=../../../lib/fsc-harness.sh
 source "$HERE/../../../lib/fsc-harness.sh"
 
+# Zet $HAVE_JQ; de vergelijking van de bestaande upstream leest de controller-JSON met jq.
+#
+# Meteen hard falen en niet pas bij de vergelijking: die tak wordt alleen geraakt als de dienst al
+# bestaat, dus zonder deze controle slaagt de eerste run op een machine zonder jq en faalt elke
+# volgende — een verschil dat je aan het script niet ziet.
+fsc_have_jq
+[ "$HAVE_JQ" -eq 1 ] || {
+  echo "FAIL: jq is vereist; dit script vergelijkt de bestaande upstream met de controller-JSON." >&2
+  exit 1
+}
+
 # shellcheck disable=SC2034  # gelezen door fsc_tb() uit de caller-scope (lib/fsc-harness.sh).
 COMPOSE=(docker compose -f "$HERE/docker-compose.yaml")
 SERVICE_NAME="berichtenmagazijn"
@@ -19,7 +30,10 @@ GROUP_ID="moza-fbs-test"                 # = GROUP_ID env-var op de manager; als
 # overrulebaar, met de standalone-waarde als default. Geprefixt met FSC_ omdat een kale `MANAGER=`
 # in iemands shell anders stilzwijgend een mTLS-call mét het internal-cert van deze peer naar een
 # vreemd endpoint zou sturen.
-STUB_URL="${FSC_STUB_URL:-http://stub-upstream:8080}"
+# De dienst wijst naar de upstream die de inway fronter. In de kale harness is dat de
+# http-echo-stub; zodra de echte applicatie erachter hangt, is het die. FSC_STUB_URL blijft als
+# oude naam werken zodat bestaande aanroepen niet stilvallen.
+UPSTREAM_URL="${FSC_UPSTREAM_URL:-${FSC_STUB_URL:-http://stub-upstream:8080}}"
 
 # shellcheck disable=SC2034  # gelezen door fsc_tb() uit de caller-scope (lib/fsc-harness.sh).
 CERT=/pki/internal/magazijn-a/manager/cert.pem
@@ -41,14 +55,14 @@ case "$MANAGER" in
   *) echo "FAIL: FSC_MANAGER moet met https:// beginnen: '${MANAGER}'" >&2; exit 2 ;;
 esac
 
-# STUB_URL gaat ongeëscaped een handgebouwde JSON-body in (CreateService, hieronder). Een
+# UPSTREAM_URL gaat ongeëscaped een handgebouwde JSON-body in (CreateService, hieronder). Een
 # aanhalingsteken zou daar uit de string breken en velden kunnen toevoegen.
-case "$STUB_URL" in
+case "$UPSTREAM_URL" in
   http://*|https://*) ;;
-  *) echo "FAIL: FSC_STUB_URL moet met http:// of https:// beginnen: '${STUB_URL}'" >&2; exit 2 ;;
+  *) echo "FAIL: FSC_UPSTREAM_URL moet met http:// of https:// beginnen: '${UPSTREAM_URL}'" >&2; exit 2 ;;
 esac
-case "$STUB_URL" in
-  *'"'*|*'\'*) echo "FAIL: FSC_STUB_URL bevat een aanhalingsteken of backslash." >&2; exit 2 ;;
+case "$UPSTREAM_URL" in
+  *'"'*|*'\'*) echo "FAIL: FSC_UPSTREAM_URL bevat een aanhalingsteken of backslash." >&2; exit 2 ;;
 esac
 
 # Vang curl-/toolbox-stderr op i.p.v. weg te gooien: een mTLS-/netwerk-/dode-container-fout
@@ -73,11 +87,28 @@ done
 echo "  inway_address=$INWAY_ADDR"
 
 echo "publish: $SERVICE_NAME aanmaken (idempotent)..."
-if fsc_tb "$CONTROLLER/v1/services" | grep -q "\"$SERVICE_NAME\""; then
-  echo "  bestaat al, skip create."
+BESTAAND="$(fsc_tb "$CONTROLLER/v1/services" || true)"
+if printf '%s' "$BESTAAND" | grep -q "\"$SERVICE_NAME\""; then
+  # Bestaat al — maar met wélke upstream? Zonder deze controle wisselt een run met een andere
+  # FSC_UPSTREAM_URL stilzwijgend niets, en blijft de inway naar de oude upstream wijzen terwijl
+  # het script "klaar" meldt. Dat kost je een half uur zoeken in de verkeerde hoek.
+  #
+  # Met jq en niet met grep: een grep-patroon over JSON breekt zodra het antwoord met spaties wordt
+  # opgemaakt, en de URL zou als regex worden gelezen (een punt matcht dan elk teken).
+  HUIDIGE_URL="$(printf '%s' "$BESTAAND" \
+    | jq -r --arg n "$SERVICE_NAME" '.services[]? | select(.name == $n) | .endpoint_url' 2>/dev/null || true)"
+
+  if [ "$HUIDIGE_URL" = "$UPSTREAM_URL" ]; then
+    echo "  bestaat al met dezelfde upstream, skip create."
+  else
+    echo "  bestaat al met upstream ${HUIDIGE_URL:-<onbekend>}; bijwerken naar ${UPSTREAM_URL}..."
+    fsc_tb -X PUT "$CONTROLLER/v1/services/$SERVICE_NAME" -H 'Content-Type: application/json' \
+       -d "{\"name\":\"$SERVICE_NAME\",\"endpoint_url\":\"$UPSTREAM_URL\",\"inway_address\":\"$INWAY_ADDR\"}"
+    echo "  bijgewerkt."
+  fi
 else
   fsc_tb -X POST "$CONTROLLER/v1/services" -H 'Content-Type: application/json' \
-     -d "{\"name\":\"$SERVICE_NAME\",\"endpoint_url\":\"$STUB_URL\",\"inway_address\":\"$INWAY_ADDR\"}"
+     -d "{\"name\":\"$SERVICE_NAME\",\"endpoint_url\":\"$UPSTREAM_URL\",\"inway_address\":\"$INWAY_ADDR\"}"
   echo "  aangemaakt."
 fi
 

--- a/demo/environment/magazijn-a/deploy/zad/README.md
+++ b/demo/environment/magazijn-a/deploy/zad/README.md
@@ -43,7 +43,8 @@ ingress-URL — `ZAD_MAGAZIJNA_DEPLOYMENT` (default `test`) bepaalt welke, zie
 | `upsert-peer.sh` | `validate`/`plan`/`apply` tegen de ZAD v2 Operations Manager API — lokaal/handmatig hulpmiddel voor de eenmalige component-creatie (env/ports/certs) en voor debugging. |
 | `cert-manifest.md` | Runbook: welk cert-bestand op welk `/etc/fsc/...`-pad, per component (UI-only bijlagen). |
 | `verify-zad.md` | Runbook: announce/publiceren/discover ná een geslaagde apply, + de acceptatiecriteria. |
-| `../../../../../.github/workflows/deploy.yml` (root) | `deploy-test-magazijnen`-job: de DOORLOPENDE image-tag-updates (elke push naar main). Twee stappen — `magazijna`/`magazijnb` op deployment `test`, de vijf `magazijna-fsc*`-componenten op `fsc-magazijna`. Niet de eenmalige creatie (die doet `upsert-peer.sh`). |
+| `../../../federatie/contracts/zad-runbook.md` | Runbook: het contract-bootstrap-component (`magazijna-fscbootstrap`, rol provider) neerzetten — env, cert-attachments, verificatie. |
+| `../../../../../.github/workflows/deploy.yml` (root) | `deploy-test-magazijnen`-job: de DOORLOPENDE image-tag-updates (elke push naar main). Twee stappen — `magazijna`/`magazijnb` op deployment `test`, de zes `magazijna-fsc*`-componenten op `fsc-magazijna`. Niet de eenmalige creatie (die doet `upsert-peer.sh`). |
 
 ## Volgorde
 

--- a/demo/environment/magazijn-a/deploy/zad/upsert-peer.sh
+++ b/demo/environment/magazijn-a/deploy/zad/upsert-peer.sh
@@ -27,6 +27,10 @@
 #   ./deploy/zad/upsert-peer.sh validate                          # read-only auth-check
 #   ./deploy/zad/upsert-peer.sh plan   [deployment] [tag]         # toont bodies, muteert niet
 #   ./deploy/zad/upsert-peer.sh apply  [deployment] [tag]         # muteert + pollt tasks
+# LET OP: `magazijna-fscbootstrap` staat wel in de deployment-lijst hieronder (anders haalt een
+# upsert hem eruit) maar krijgt hier geen env en geen poorten: zijn env (FSC_ROL=provider, de
+# allowlist) en zijn cert-attachments zijn UI-werk, zie federatie/contracts/zad-runbook.md.
+
 set -euo pipefail
 
 MODE="${1:?usage: upsert-peer.sh <validate|plan|apply> [deployment=fsc-magazijna] [tag=v2.5.2]}"
@@ -80,6 +84,12 @@ CONTROLLER_IMAGE="${ZAD_CONTROLLER_IMAGE:-ghcr.io/minbzk/moza-fsc-testnet-contro
 INWAY_IMAGE="docker.io/federatedserviceconnectivity/inway:${IMAGE_TAG}"
 TXLOG_IMAGE="${ZAD_TXLOG_IMAGE:-ghcr.io/minbzk/moza-fsc-testnet-txlog-migrate:${TXLOG_TAG}}"
 POSTGRES_IMAGE="${ZAD_POSTGRES_IMAGE:-docker.io/library/postgres:17}"   # self-hosted DB (spiegelt deploy/local)
+# De contract-bootstrap komt uit DEZE repo (build-contract-bootstrap in deploy.yml), niet uit
+# repo A, en volgt dus niet de FSC-versietag.
+# Geen kale `:main`-default: de deploy-workflow pusht uitsluitend `main-<sha7>` en `pr-<n>-<sha7>`,
+# dus `:main` bestaat niet en zou een ImagePullBackOff opleveren tot de eerstvolgende deploy hem
+# overschrijft. Zet de tag expliciet, of laat het component met rust — `deploy.yml` houdt hem bij.
+BOOTSTRAP_IMAGE="${ZAD_BOOTSTRAP_IMAGE:-__ZET_ZAD_BOOTSTRAP_IMAGE__}"
 
 # Concrete hostnamen voor déze (vaste) deployment — zowel voor de plan-/apply-output als, direct,
 # voor de inter-component-adressen in de env_vars-blobs. Geen $DEPLOYMENT_NAME-substitutie: de
@@ -238,9 +248,9 @@ component_body() {  # $1=name $2=image $3=ports_json $4=env  [$5=services_json=[
 
 DEPLOY_BODY="$(jq -n --arg d "${DEPLOYMENT}" --arg cf "${CLONE_FROM}" \
   --arg mgr "${MANAGER_IMAGE}" --arg ctl "${CONTROLLER_IMAGE}" --arg inway "${INWAY_IMAGE}" \
-  --arg txlog "${TXLOG_IMAGE}" --arg pg "${POSTGRES_IMAGE}" \
+  --arg txlog "${TXLOG_IMAGE}" --arg pg "${POSTGRES_IMAGE}" --arg boot "${BOOTSTRAP_IMAGE}" \
   '{deploymentName:$d, domain_format:"component-deployment-project",
-    components:[{reference:"magazijna-fscpg", image:$pg}, {reference:"magazijna-fscmgr", image:$mgr}, {reference:"magazijna-fscctl", image:$ctl}, {reference:"magazijna-fscinway", image:$inway}, {reference:"magazijna-fsctxlog", image:$txlog}]}
+    components:[{reference:"magazijna-fscpg", image:$pg}, {reference:"magazijna-fscmgr", image:$mgr}, {reference:"magazijna-fscctl", image:$ctl}, {reference:"magazijna-fscinway", image:$inway}, {reference:"magazijna-fsctxlog", image:$txlog}, {reference:"magazijna-fscbootstrap", image:$boot}]}
    + (if $cf=="" then {} else {cloneFrom:$cf, forceClone:false} end)')"
 
 # Poorten per component (ports[0] = ingress). manager/controller exposen naast de ingress hun interne

--- a/demo/environment/magazijn-a/pki/gen-csr.sh
+++ b/demo/environment/magazijn-a/pki/gen-csr.sh
@@ -34,7 +34,7 @@ PEER="magazijn-a"
 OIN="00000000000000100000"                                # = subject.serialNumber = Peer ID
 # endpoint:component-korte-naam (de ZAD-component + Service heet `<deployment>-<short>`). Volgorde
 # bepaalt de uitvoer-volgorde; spiegelt de MGZ*_SVC-namen in upsert-peer.sh.
-ENDPOINTS=( "manager:magazijna-fscmgr" "controller:magazijna-fscctl" "inway:magazijna-fscinway" "txlog:magazijna-fsctxlog" )
+ENDPOINTS=( "manager:magazijna-fscmgr" "controller:magazijna-fscctl" "inway:magazijna-fscinway" "txlog:magazijna-fsctxlog" "bootstrap:magazijna-fscbootstrap" )
 
 # Genereer per endpoint de csr.json. SAN-volgorde: peer-identiteit (alleen manager) ->
 # <endpoint>.<peer>.fsc-test.local -> externe mesh-host -> Service-kortnaam -> Service-FQDN.

--- a/demo/environment/magazijn-a/pki/issue.sh
+++ b/demo/environment/magazijn-a/pki/issue.sh
@@ -44,12 +44,20 @@ done
 find "${BASE_DIR}/peers" -name csr.json -print0 | while IFS= read -r -d '' CSR; do
   REL="$(dirname "${CSR#"${BASE_DIR}/peers/"}")"   # <peer>/<endpoint>
   PEER="${REL%%/*}"
+  ENDPOINT="${REL##*/}"
   GROUP_OUT="${BASE_DIR}/out/${REL}"
   INT_OUT="${BASE_DIR}/internal/${REL}"
   ICA_DIR="${BASE_DIR}/internal/${PEER}/ca"
 
   # GROUP (extern, group-intermediate). Hecht intermediate aan voor de keten.
-  if [ -s "${GROUP_OUT}/cert.pem" ] && [ -s "${GROUP_OUT}/key.pem" ] && [ "${FORCE}" -eq 0 ]; then
+  #
+  # Niet voor client-only endpoints. Een group-cert is de identiteit waarmee een component zich in
+  # de mesh als deze peer voordoet; wie hem niet nodig heeft, hoort hem ook niet te krijgen. De
+  # contract-bootstrap praat alleen met de interne manager-API van zijn eigen peer en bedient zelf
+  # geen TLS, dus hij komt met het internal-cert hieronder toe.
+  if [ "${ENDPOINT}" = bootstrap ]; then
+    echo "skip group ${REL} (client-only endpoint)"
+  elif [ -s "${GROUP_OUT}/cert.pem" ] && [ -s "${GROUP_OUT}/key.pem" ] && [ "${FORCE}" -eq 0 ]; then
     echo "skip group ${REL} (geen -f)"
   else
     mkdir -p "${GROUP_OUT}"

--- a/demo/environment/magazijn-a/pki/peers/magazijn-a/bootstrap/csr.json
+++ b/demo/environment/magazijn-a/pki/peers/magazijn-a/bootstrap/csr.json
@@ -1,0 +1,20 @@
+{
+  "CN": "bootstrap.magazijn-a.fsc-test.local",
+  "key": {
+    "algo": "rsa",
+    "size": 4096
+  },
+  "hosts": [
+    "bootstrap.magazijn-a.fsc-test.local",
+    "magazijna-fscbootstrap-fsc-magazijna-mpfm-w3h.rig.prd1.gn2.quattro.rijksapps.nl",
+    "fsc-magazijna-magazijna-fscbootstrap",
+    "fsc-magazijna-magazijna-fscbootstrap.rig-prd-mpfm-w3h.svc.cluster.local"
+  ],
+  "serialnumber": "00000000000000100000",
+  "names": [
+    {
+      "O": "magazijn-a",
+      "C": "NL"
+    }
+  ]
+}

--- a/demo/environment/magazijn-a/pki/zad-bundle.sh
+++ b/demo/environment/magazijn-a/pki/zad-bundle.sh
@@ -22,6 +22,10 @@ env_for() {
     out/*/cert.pem)         echo "TLS_GROUP_CERT (+ TLS_GROUP_TOKEN_CERT, TLS_GROUP_CONTRACT_CERT)" ;;
     out/*/key.pem)          echo "TLS_GROUP_KEY (+ TLS_GROUP_TOKEN_KEY, TLS_GROUP_CONTRACT_KEY)" ;;
     internal/*/ca/root.pem) echo "TLS_ROOT_CERT (+ TLS_INTERNAL_UNAUTHENTICATED_ROOT_CERT)" ;;
+    # Vóór de algemene internal-regels: het bootstrap-component is geen FSC-binary en leest geen
+    # TLS_*-variabelen, maar gebruikt hetzelfde internal-cert als client naar de manager-API.
+    internal/*/bootstrap/cert.pem) echo "FSC_{CONSUMER,PROVIDER}_CERT (client-cert contract-bootstrap)" ;;
+    internal/*/bootstrap/key.pem)  echo "FSC_{CONSUMER,PROVIDER}_KEY" ;;
     internal/*/cert.pem)    echo "TLS_CERT (+ TLS_INTERNAL_UNAUTHENTICATED_CERT)" ;;
     internal/*/key.pem)     echo "TLS_KEY (+ TLS_INTERNAL_UNAUTHENTICATED_KEY)" ;;
     *)                      echo "?" ;;

--- a/demo/podman-prepare.sh
+++ b/demo/podman-prepare.sh
@@ -33,7 +33,12 @@ trap 'rm -f "$REGISTER.tmp" "$PROXIES.tmp"' EXIT
 # zijn eigen invoerbestand kan lezen én erin schrijven.
 sed 's|http://magazijn-stubs:8080|http://127.0.0.1:8092|g' "$REGISTER" > "$REGISTER.tmp"
 
-sed -e 's|"berichtenmagazijn-a:8090"|"127.0.0.1:8090"|' \
+# `listen` gaat mee van 0.0.0.0 naar 127.0.0.1: in een gedeelde netns bindt een wildcard op élke
+# interface van de machine, en achter deze proxies zitten Redis en de magazijn-API's. Bovendien
+# botst een wildcard-bind met elke specifieke bind op dezelfde poort — bijvoorbeeld van een
+# FSC-federatie die in dezelfde netns draait.
+sed -e 's|"listen": "0\.0\.0\.0:|"listen": "127.0.0.1:|g' \
+    -e 's|"berichtenmagazijn-a:8090"|"127.0.0.1:8090"|' \
     -e 's|"berichtenmagazijn-b:8090"|"127.0.0.1:8091"|' \
     -e 's|"redis:6379"|"127.0.0.1:6379"|' \
     -e 's|"profiel-service:8080"|"127.0.0.1:8089"|' \
@@ -87,8 +92,8 @@ fi
 # Een listen-adres op een containernaam laadt Toxiproxy niet (`Failed to populate proxies`), en dan
 # staat er een gezonde proxy-loze Toxiproxy die elke naïeve probe groen laat.
 if grep -o '"listen": *"[^"]*"' "$PROXIES.tmp" |
-   grep -vE '"listen": *"(0\.0\.0\.0|127\.0\.0\.1):[0-9]+"' >&2; then
-    echo "FOUT: bovenstaande toxiproxy-listen-adressen zijn geen IP:poort." >&2
+   grep -vE '"listen": *"127\.0\.0\.1:[0-9]+"' >&2; then
+    echo "FOUT: bovenstaande toxiproxy-listen-adressen staan niet op 127.0.0.1." >&2
     exit 1
 fi
 

--- a/demo/podman-up.sh
+++ b/demo/podman-up.sh
@@ -19,13 +19,27 @@
 #   DEMO_HOST=10.0.0.5 demo/podman-up.sh
 #
 # DEMO_HOST is het adres waarop je de demo benadert (voor de CORS-allowlist van de uitvraag);
-# default localhost.
+# default localhost. De poorten zelf blijven op loopback — zie DEMO_BIND in compose.yaml, en de
+# toelichting bij de laatste controle onderaan dit script.
 set -euo pipefail
 
 WORTEL="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$WORTEL"
 
 export DEMO_HOST="${DEMO_HOST:-localhost}"
+
+# DEMO_BIND stuurt op welk hostadres compose publiceert (zie compose.yaml). Alleen loopback of de
+# wildcard: elke controle in dit script gaat over 127.0.0.1, en dat adres blijft bij beide
+# bereikbaar. Bij een specifiek adres (`DEMO_BIND=10.0.0.5`) zouden die probes 180 seconden lang
+# aflopen en de start laten falen terwijl de stack gezond draait.
+case "${DEMO_BIND:-127.0.0.1}" in
+    127.0.0.1|0.0.0.0) ;;
+    *)
+        echo "FOUT: DEMO_BIND='${DEMO_BIND}' wordt niet ondersteund; gebruik 127.0.0.1 (default) of 0.0.0.0." >&2
+        echo "      De controles in dit script gaan over 127.0.0.1; een specifiek adres laat ze aflopen." >&2
+        exit 2
+        ;;
+esac
 
 # Doorgeven aan compose én aan de generator vanaf één plek; beide hebben hun eigen default.
 export DEMO_MAGAZIJN_STUBS="${DEMO_MAGAZIJN_STUBS:-12}"
@@ -380,12 +394,23 @@ wacht_op "console"             demo-console        curl -sSf --max-time 3 http:/
 # (migraties, vier tegelijk verbindende clients) en is sinds de vorige controle niet meer bekeken.
 vereis_draaiend "${INFRA[@]}" "${SERVICES[@]}"
 
-# Alle probes hierboven lopen over 127.0.0.1; is de demo op een ander adres aangekondigd, dan is
-# dát het adres dat moet werken (firewall, of hostnet in een VM waar niets naar buiten komt).
+# Bewust GEEN probe op $DEMO_HOST: het bedieningspaneel bindt altijd op loopback (geen
+# authenticatie, en POST /api/demo/legen doet een TRUNCATE op beide magazijn-databases). Een probe
+# op een ander adres zou dus per definitie aflopen op een timeout en de start laten falen terwijl
+# de stack gezond draait. DEMO_HOST stuurt alleen de CORS-allowlist en de URL's hieronder; om er
+# van een andere machine bij te kunnen heb je een tunnel nodig, bijvoorbeeld
+# `ssh -L 8095:127.0.0.1:8095 <host>`.
 if [ "$DEMO_HOST" != "localhost" ]; then
-    wacht_op "console op $DEMO_HOST" demo-console curl -sSf --max-time 3 "http://${DEMO_HOST}:8095/"
+    echo "Let op: het bedieningspaneel luistert alleen op 127.0.0.1. DEMO_HOST zet de CORS-allowlist;"
+    echo "       tunnel poort 8095 (en 8086) als je er vanaf ${DEMO_HOST} bij wilt."
 fi
 
 echo
-echo "Draait ($MODUS). Bedieningspaneel: http://${DEMO_HOST}:8095/"
-echo "                 Berichtenbox:    http://${DEMO_HOST}:8095/berichtenbox.html"
+# Bewust de loopback-URL en niet ${DEMO_HOST}: het bedieningspaneel bindt alleen op 127.0.0.1, dus
+# een kopieerbare regel met een ander adres wijst naar iets dat niet bestaat.
+echo "Draait ($MODUS). Bedieningspaneel: http://127.0.0.1:8095/"
+echo "                 Berichtenbox:    http://127.0.0.1:8095/berichtenbox.html"
+
+if [ "$DEMO_HOST" != "localhost" ]; then
+    echo "                 (vanaf ${DEMO_HOST}: tunnel eerst 8095 en 8086 naar deze machine)"
+fi

--- a/docs/demo-runbook.md
+++ b/docs/demo-runbook.md
@@ -84,6 +84,30 @@ demo/podman-up.sh                        # kiest zelf de werkbare netwerkmodus
 DEMO_HOST=10.0.0.5 demo/podman-up.sh     # ander adres dan localhost in de CORS-allowlist
 ```
 
+De stack luistert standaard **alleen op `127.0.0.1`**: zonder die grens staan Redis (zonder
+wachtwoord), drie PostgreSQL-instanties met demo-credentials en de WireMock-admin-API's op elke
+interface van de machine — op een kantoor- of thuisnetwerk dus voor het hele subnet.
+
+Wil je de demo aan iemand anders tonen, dan zet je hem bewust open, en heb je **beide** variabelen
+nodig: `DEMO_BIND` voor de poorten en `DEMO_HOST` voor de CORS-allowlist.
+
+```bash
+DEMO_BIND=0.0.0.0 DEMO_HOST=10.0.0.5 demo/podman-up.sh
+```
+
+`DEMO_BIND` kent maar twee waarden: `127.0.0.1` (default) en `0.0.0.0`. Een specifiek adres wordt
+geweigerd, omdat elke controle in `podman-up.sh` over 127.0.0.1 loopt en anders afloopt op een
+timeout terwijl de stack gezond draait.
+
+Twee beperkingen daarbij:
+
+- **`DEMO_BIND` geldt alleen in bridge-modus.** In `hostnet` publiceert compose geen poorten en
+  binden de containers zelf; die staan vast op loopback, want in een gedeelde netns is een
+  wildcard-bind de hele machine — en botst hij bovendien met elke specifieke bind van een
+  FSC-federatie in dezelfde netns.
+- **Het bedieningspaneel blijft altijd op loopback** (`demo-console`, poort 8095): het heeft geen
+  authenticatie en zijn `POST /api/demo/legen` doet een TRUNCATE op beide magazijn-databases.
+
 Het script zoekt de podman-API-socket (start hem zo nodig), kiest een compose-implementatie en
 controleert dat die de gestapelde bestanden aankan, controleert dat de drie demo-images gebouwd
 zijn, genereert de stub-artefacten, en controleert na elke start dat elke container draait. Redis,
@@ -101,10 +125,16 @@ Forceren kan met `MODUS=bridge` of `MODUS=hostnet`. Buiten Linux wordt `hostnet`
 automatisch gekozen: podman draait daar in een VM, dus de gedeelde namespace is die van de VM en
 zonder gepubliceerde poorten komt er niets door naar je werkplek.
 
-In `hostnet` delen alle containers één netwerknamespace. De zes Toxiproxy-proxy-listeners, die in
-`bridge` alleen intern bestonden, staan dan open op elk adres van de machine. Draai deze modus dus
-alleen op een vertrouwd netwerk. (De poorten die `compose.yaml` publiceert, waaronder alle drie de
-Postgres-instanties, binden ook in `bridge` al op alle interfaces.)
+In `hostnet` delen alle containers één netwerknamespace: de zes Toxiproxy-proxy-listeners, die in
+`bridge` alleen intern bestonden, zijn dan ook op de machine zelf zichtbaar. Ze binden — net als
+alle andere services in deze modus — op `127.0.0.1`, dus ze zijn niet van buiten de machine
+bereikbaar. Een CI-job (`demo-stack-op-loopback`) bewaakt dat: elke listener in de gerenderde merge
+moet op loopback staan, anders faalt de build.
+
+Dat is geen detail van deze modus maar de eis die hem werkbaar maakt. In een gedeelde namespace is
+een wildcard-bind (`0.0.0.0`) de hele machine — Redis zonder wachtwoord, drie PostgreSQL-instanties
+met demo-credentials — en botst hij bovendien met elke specifieke bind op dezelfde poort, zoals die
+van een FSC-federatie die in dezelfde namespace draait.
 
 Botst een van die poorten met iets dat al draait, dan hangt het van de poort af hoe dat zich
 uit. Een service die zelf niet kan binden stopt, en het script meldt welke container dat is mét

--- a/docs/plans/2026-08-13-b2-implementatieplan.md
+++ b/docs/plans/2026-08-13-b2-implementatieplan.md
@@ -1,0 +1,183 @@
+# B2 implementatieplan: de FBS-keten lokaal door FSC
+
+**Status:** Uitgevoerd
+
+**Doel:** `berichtenuitvraag` haalt bij magazijn-a op via outway → router → inway →
+`berichtenmagazijn-a`, lokaal, met bewijs dat de data uit dat magazijn komt en dat de transactie in
+beide txlogs staat.
+
+**Spec:** `docs/plans/2026-08-13-b2-lokale-fsc-keten-uitvraag-magazijn.md`
+
+**Aanpak:** Bedrading, geen applicatiecode. De FSC-laag komt uit #197 (adres per component) en #200
+(contract + grant-hash); de FBS-laag uit `compose.yaml`. Wat ontbreekt is dat ze op één machine
+naast elkaar kunnen draaien en dat de drie koppelpunten (inway-upstream, outway-URL, grant-hash)
+gezet worden.
+
+**Stack:** bash, docker/podman compose, OpenFSC v2.5.2, Quarkus.
+
+## Globale randvoorwaarden
+
+- Federatie op `127.20.0.0/16`, één adres per component, standaardpoorten. Demo-stack op
+  `127.0.0.1`.
+- De outway spreekt **plain HTTP** op zijn listener — vastgesteld uit `smoke-contract.sh` van #200
+  (`OUTWAY="http://127.0.0.1:$((CONS_BLOK + 40))"`). Lokaal wordt dat `http://127.20.1.5:8443`.
+- Elke shell-wijziging blijft door `shellcheck -x -S warning`.
+- Geen enkele listener buiten loopback, in beide stacks.
+
+## Volgorde en afhankelijkheden
+
+Taak 1 is een enabler op de branch van #200; taak 2 t/m 5 staan op `feature/b2-lokale-fsc-keten`,
+die daarna op #200 gerebased wordt.
+
+---
+
+### Taak 1: #200 naar het adresmodel
+
+**Waarom:** #200 staat op de oude #197 en rekent op tien plekken met `BLOK`. Zonder deze stap kan
+B2 niet draaien, want de contract-bootstrap levert het grant-hash.
+
+**Bestanden:**
+- Rebase: `feature/782-fsc-contract-magazijn-uitvraag` op `feature/fsc-lokale-federatie-harness`
+- Wijzig: `demo/environment/federatie/contracts/fbs-contracten.sh` (regels 31–72)
+- Wijzig: `demo/environment/federatie/smoke-contract.sh` (regels 41–186)
+
+**Stappen:**
+
+- [ ] 1.1 Rebase de #200-branch op de nieuwe #197-kop. Conflicten in `peers.env`, de twee
+      `compose/*.yaml`, `haproxy.federatie.cfg`, `smoke-federatie.sh`, `merge-guard.sh` en
+      `fsc-harness-overlays.yml` lost je op ten gunste van **onze** kant (het adresmodel); de
+      bestanden die alleen #200 toevoegt (`contracts/*`, `smoke-contract.sh`) neem je ongewijzigd
+      over.
+- [ ] 1.2 In `fbs-contracten.sh`: `fsc_peer_waarde BLOK` → `fsc_peer_waarde NET`, en de
+      manager-URL's `…:$((BLOK + 1))` → `…:9443`. De variabelen heten dan `CONS_NET`/`PROV_NET` en
+      worden alleen nog gebruikt voor de foutmelding bij een ontbrekende peer.
+- [ ] 1.3 In `smoke-contract.sh`: `OUTWAY="http://127.0.0.1:$((CONS_BLOK + 40))"` →
+      `OUTWAY="http://$(fsc_component_adres "$CONS_NET" outway):8443"`. De helper `manager_json`
+      krijgt het net in plaats van het blok: `poort=9443`, en
+      `--resolve "${naam}:9443:$(fsc_component_adres "$net" manager)"`.
+- [ ] 1.4 De `--resolve "${INWAY_NAAM}:443:127.0.0.1"` op regel 137 → `${ADRES_ROUTER}`.
+- [ ] 1.5 Verifiëren: `shellcheck -x -S warning` schoon; `federatie.sh up`;
+      `contracts/fbs-contracten.sh`; `smoke-contract.sh` groen; `smoke-federatie.sh` groen.
+- [ ] 1.6 Committen en pushen naar de #200-branch.
+
+---
+
+### Taak 2: loopback-discipline voor de demo-stack
+
+**Waarom:** de blokkade. De demo-stack bindt wildcard; dat botst met élke specifieke bind van de
+federatie op dezelfde poort (`Failed to bind to /0.0.0.0:8081`). En het zet Redis en PostgreSQL op
+alle interfaces van de machine.
+
+**Bestanden:**
+- Wijzig: `compose.yaml` — elke `ports:`-publicatie krijgt het `127.0.0.1:`-voorvoegsel
+- Wijzig: `compose.podman-hostnet.yaml` — expliciet bind-adres per service
+- Wijzig: `.github/workflows/fsc-harness-overlays.yml` — derde job op de demo-merge
+
+**Stappen:**
+
+- [ ] 2.1 In `compose.yaml` elke publicatie van `"<poort>:<poort>"` naar
+      `"127.0.0.1:<poort>:<poort>"`. Dat zijn: redis, magazijn-a, magazijn-b, profiel-service,
+      aanmeld-stub, notificatie-stub, postgres-uitvraag, postgres-a, postgres-b,
+      berichtenmagazijn-a, berichtenmagazijn-b, toxiproxy, magazijn-stubs, berichtenuitvraag.
+      `demo-console` staat al goed.
+- [ ] 2.2 In `compose.podman-hostnet.yaml` per service een expliciet bind-adres:
+      - wiremocks (`magazijn-a`, `magazijn-b`, `profiel-service`, `aanmeld-stub`,
+        `notificatie-stub`, `magazijn-stubs`): `--bind-address 127.0.0.1` aan `command` toevoegen;
+      - Quarkus (`berichtenmagazijn-a/-b`, `berichtenuitvraag`, `demo-console`):
+        `QUARKUS_HTTP_HOST: 127.0.0.1`;
+      - `redis`: `command: ["redis-server", "--bind", "127.0.0.1", "--port", "<poort>"]`;
+      - `postgres-a/-b/-uitvraag`: `-c listen_addresses=127.0.0.1` aan `command`;
+      - `toxiproxy`: luisteradres in `demo/generated/proxies.json` (gegenereerd door
+        `demo/podman-prepare.sh`) op `127.0.0.1`.
+- [ ] 2.3 Verifiëren dat de merge schoon is:
+      `docker compose -f compose.yaml -f compose.podman.yaml -f compose.podman-hostnet.yaml config
+      --format json | .github/scripts/merge-guard.sh "demo (hostnet-merge)"`. De guard eist
+      `network_mode: host` op élke service; klopt dat niet voor de demo-stack, dan draai je alleen
+      de listener-checks — zie stap 2.4.
+- [ ] 2.4 Als `merge-guard.sh` niet één-op-één past op de demo-merge (andere eisen: geen `/pki`,
+      geen `!reset`-verplichting), splits dan de listener-checks (`env_lek`, `bind_lek`, `pg_lek`,
+      `pg_mist`) af naar een aanroepbare modus `--alleen-listeners`, en gebruik die voor de
+      demo-merge. Niet dupliceren: één script blijft de bron.
+- [ ] 2.5 Job toevoegen aan `.github/workflows/fsc-harness-overlays.yml` die die controle op de
+      demo-merge draait. Pad-filter uitbreiden met `compose*.yaml`.
+- [ ] 2.6 Runtime-bewijs: demo-stack omhoog, dan van een niet-loopback-adres van de host
+      controleren dat niets meer bereikbaar is (vóór deze taak waren `:6379` en `:8082` dat wél).
+- [ ] 2.7 Committen.
+
+---
+
+### Taak 3: de inway wijst naar het echte magazijn
+
+**Bestanden:**
+- Wijzig: `demo/environment/magazijn-a/deploy/local/publish-service.sh` (regel ~22)
+
+**Stappen:**
+
+- [ ] 3.1 `STUB_URL="${FSC_STUB_URL:-http://stub-upstream:8080}"` hernoemen naar
+      `UPSTREAM_URL="${FSC_UPSTREAM_URL:-${FSC_STUB_URL:-http://stub-upstream:8080}}"`. De oude
+      variabele blijft als fallback werken, zodat `smoke-federatie.sh` (die hem zet) niet stilvalt.
+- [ ] 3.2 Dezelfde hernoeming in `logius/deploy/local/publish-service.sh`, zodat de twee peers niet
+      uit elkaar lopen.
+- [ ] 3.3 `shellcheck` schoon; `smoke-federatie.sh` nog steeds groen (die gebruikt de oude naam).
+- [ ] 3.4 Committen.
+
+---
+
+### Taak 4: de uitvraag door de outway
+
+**Bestanden:**
+- Wijzig: `demo/environment/federatie/contracts/fbs-contracten.sh` — grant-hash wegschrijven
+- Wijzig: `compose.podman-hostnet.yaml` — `MAGAZIJN_A_URL` + `MAGAZIJN_A_GRANT_HASH`
+- Wijzig: `demo/generated/`-generatie in `demo/podman-prepare.sh`
+
+**Stappen:**
+
+- [ ] 4.1 `fbs-contracten.sh` schrijft per magazijn een regel naar
+      `demo/generated/fsc-grants.env`: `MAGAZIJN_A_GRANT_HASH=<hash>`. Bestaand bestand wordt
+      overschreven, niet aangevuld — anders stapelen hashes uit eerdere runs zich op.
+- [ ] 4.2 `compose.podman-hostnet.yaml`: `berichtenuitvraag` krijgt
+      `env_file: [demo/generated/fsc-grants.env]` en `MAGAZIJN_A_URL: http://127.20.1.5:8443`.
+      Ontbreekt het bestand, dan moet compose niet fataal falen: `required: false` op de `env_file`.
+- [ ] 4.3 Toxiproxy-upstream voor magazijn-a naar de outway laten wijzen in
+      `demo/generated/proxies.json`, zodat de storing-knop blijft werken en de FSC-keten erachter
+      zit.
+- [ ] 4.4 Verifiëren: beide stacks omhoog, `curl` op de uitvraag levert berichten van magazijn-a.
+- [ ] 4.5 Committen.
+
+---
+
+### Taak 5: ketensmoke
+
+**Bestanden:**
+- Maak: `demo/environment/federatie/smoke-keten.sh`
+
+**Stappen:**
+
+- [ ] 5.1 Assert 1 — ophalen levert data uit de database van magazijn-a: een bericht via `psql` in
+      `postgres-a` zetten met een herkenbare inhoud, dat ophalen via de uitvraag, en op die inhoud
+      matchen. Een 200 van de stub kan die inhoud niet hebben.
+- [ ] 5.2 Assert 2 — dezelfde `Fsc-Transaction-Id` in beide txlogs: uitgaand bij logius, inkomend
+      bij magazijn-a, via de txlog-API op `9443` per peer.
+- [ ] 5.3 Assert 3 — grant-hash leegmaken en herstarten laat de call niet meer door de outway
+      (verwacht `400 UNKNOWN_GRANT_HASH_IN_HEADER` of een lege grant → geen FSC-headers → de outway
+      weigert).
+- [ ] 5.4 Assert 4 — magazijn-b blijft rechtstreeks werken.
+- [ ] 5.5 `shellcheck` schoon, smoke groen, opnemen in de `harness-scripts`-job.
+- [ ] 5.6 Committen en de branch pushen.
+
+---
+
+## Verificatie van het geheel
+
+1. `federatie.sh up` + `smoke-federatie.sh` groen.
+2. `contracts/fbs-contracten.sh` + `smoke-contract.sh` groen.
+3. Demo-stack omhoog naast de federatie, `smoke-keten.sh` groen.
+4. `merge-guard.sh` groen op alle merges: twee standalone, twee federatie, één demo.
+5. `shellcheck` + de bash-unittests groen.
+6. Van buiten loopback is niets van beide stacks bereikbaar.
+
+## Reviewrondes
+
+Na de implementatie: reviewrondes tot er geen hoge bevindingen meer zijn, met de
+`pr-review-toolkit`-agents en `/code-review`. Hoge bevindingen worden direct opgelost, medium in
+overleg, laag genoteerd.

--- a/docs/plans/2026-08-13-b2-lokale-fsc-keten-uitvraag-magazijn.md
+++ b/docs/plans/2026-08-13-b2-lokale-fsc-keten-uitvraag-magazijn.md
@@ -1,0 +1,133 @@
+# B2: de FBS-keten lokaal door FSC
+
+**Status:** Uitgevoerd
+
+## Context
+
+Na #197 (federatie-harness) en #200 (contract uitvraag↔magazijn) staat de FSC-laag lokaal
+compleet: twee peers, één directory, een wederzijds ondertekend contract, en een bewezen data-pad
+outway → router → inway. Achter die inway zit alleen nog een `stub-upstream` (http-echo).
+
+De FBS-applicatie draait er los naast, in `compose.yaml`: `berichtenuitvraag` haalt rechtstreeks op
+bij `berichtenmagazijn-a` en `-b`. Die twee werelden raken elkaar nergens.
+
+Deze stap verbindt ze: de uitvraag haalt bij magazijn-a op **door de FSC-keten**, met de echte
+`berichtenmagazijn` als upstream van de inway.
+
+## Wat er níét voor nodig is
+
+Applicatiecode. `MagazijnRouter` hangt al een `FscOutwayHeadersFilter` aan een magazijn zodra dat
+een `grantHash` heeft:
+
+```
+magazijnen."00000000000000100000".url=${MAGAZIJN_A_URL}
+magazijnen."00000000000000100000".grantHash=${MAGAZIJN_A_GRANT_HASH:}
+```
+
+Leeg = rechtstreeks; gevuld = `Fsc-Grant-Hash` + `Fsc-Transaction-Id` op elke call. Hetzelfde
+patroon bestaat al voor `berichtenmagazijn → profiel-service`. Dit is dus bedrading, geen bouwwerk.
+
+## Ontwerp
+
+### 1. Loopback-discipline voor de demo-stack
+
+**Dit is de blokkade, en hij is empirisch vastgesteld.** De demo-stack bindt in hostnet-modus
+wildcard, niet op een adres:
+
+```
+FatalStartupException: java.io.IOException: Failed to bind to /0.0.0.0:8081
+```
+
+Een wildcard-bind botst met élke specifieke bind op dezelfde poort. De federatie heeft `:8081` op
+zeven component-adressen (monitoring), dus `0.0.0.0:8081` kan er niet bij. Dat de rest wél opkwam
+was toeval: `8082` gebruikt de federatie niet meer, en de demo-postgres pakte `[::]:5432` naast de
+federatie op IPv4.
+
+Elke demo-service krijgt daarom een expliciet bind-adres op `127.0.0.1`:
+
+| Service | Waar |
+|---|---|
+| wiremocks (`magazijn-a/-b`, stubs) | `--bind-address 127.0.0.1` |
+| Quarkus-services | `QUARKUS_HTTP_HOST=127.0.0.1` (staat nu op `0.0.0.0`) |
+| redis | `--bind 127.0.0.1` |
+| postgres | `-c listen_addresses=127.0.0.1` |
+| toxiproxy | listen-adres in `demo/generated/proxies.json` |
+
+Dat lost niet alleen de botsing op. Zonder deze stap staat de demo-stack op álle interfaces van de
+machine — geverifieerd: `172.20.0.2:6379` (Redis, zonder auth) en `:8082` waren van buiten loopback
+bereikbaar. Op een ontwikkelmachine aan een kantoornetwerk is dat Redis zonder wachtwoord en
+PostgreSQL met demo-credentials voor het hele subnet. De FSC-harnessen hebben hier een CI-guard
+tegen (`.github/scripts/merge-guard.sh`); de demo-stack heeft er geen.
+
+Merk op dat dit breder is dan hostnet: `compose.yaml` publiceert `"6379:6379"`, `"5432:5432"` enz.,
+en dat is bij zowel Docker als podman `0.0.0.0`. Alleen `demo-console` staat op `127.0.0.1:8095`.
+Het voorstel is dus om élke publicatie in `compose.yaml` op `127.0.0.1:` te zetten, en de
+hostnet-overlay expliciet te laten binden.
+
+**Guard erachter,** anders rot het terug: de bestaande `merge-guard.sh` accepteert al elk `127.x`
+en toetst precies dit. Hij hoeft alleen op de demo-merge losgelaten te worden — een derde job in
+`fsc-harness-overlays.yml`, of een eigen workflow als die naam te misleidend wordt.
+
+### 2. De inway wijst naar het echte magazijn
+
+`magazijn-a/deploy/local/publish-service.sh` registreert de dienst met een `endpoint_url`. Die
+wijst nu naar `stub-upstream`; hij moet naar `berichtenmagazijn-a` wijzen — in de demo-stack onder
+hostnet is dat `http://127.0.0.1:8090`.
+
+Het adres komt uit `FSC_STUB_URL`, dat al overrulebaar is. De naam dekt de lading dan niet meer;
+hernoemen naar `FSC_UPSTREAM_URL` met de oude als fallback, of accepteren dat de variabele breder is
+dan zijn naam suggereert. Voorkeur: hernoemen, het is één plek per peer.
+
+### 3. De uitvraag door de outway
+
+Twee env-vars op `berichtenuitvraag` in de demo-stack:
+
+- `MAGAZIJN_A_URL` → de outway van logius. Lokaal `127.20.1.5:8443`.
+- `MAGAZIJN_A_GRANT_HASH` → het grant-hash uit de bootstrap van #200.
+
+`MAGAZIJN_B_URL` blijft ongemoeid. Dat is opzet: één magazijn door FSC, één rechtstreeks, naast
+elkaar in dezelfde demo. Dat toont het verschil en houdt een werkend vergelijkingspad over als de
+FSC-keten stuk is.
+
+**Toxiproxy blijft waar hij staat.** De uitvraag praat nu via `127.0.0.1:18090` naar toxiproxy, die
+doorzet naar het magazijn; dat is de storing-knop van de demo. Voor magazijn-a wordt de *upstream*
+van die proxy de outway, zodat de storing-knop blijft werken en de FSC-keten er achter zit.
+
+**Het koppelpunt is het grant-hash.** Compose kan dat niet uit een draaiende manager halen, dus de
+bootstrap van #200 schrijft het naar een gegenereerd env-bestand (`demo/generated/`, waar de
+toxiproxy-definities ook al staan) dat de demo-stack inleest. Zonder dat bestand blijft de var leeg
+en valt de uitvraag terug op rechtstreeks — dezelfde degradatie die de config al kent.
+
+### 4. Bewijs
+
+Eén smoke die de keten aantoont en kán falen:
+
+| Assert | Wat het uitsluit |
+|---|---|
+| een bericht ophalen via `berichtenuitvraag` levert data die aantoonbaar uit de database van `berichtenmagazijn-a` komt | een 200 die net zo goed van de stub had kunnen komen |
+| dezelfde `Fsc-Transaction-Id` in beide txlogs, uitgaand bij logius en inkomend bij magazijn-a | dat de call buiten FSC om ging |
+| grant-hash leegmaken → de call komt niet door de outway | dat de FSC-headers decoratief zijn |
+| magazijn-b blijft rechtstreeks werken | dat de omzetting het niet-FSC-pad sloopt |
+
+## Verificatie
+
+- Beide stacks tegelijk omhoog onder rootless podman, `smoke-federatie.sh` én de nieuwe ketensmoke
+  groen.
+- `merge-guard.sh` op de demo-merge: alle listeners op loopback.
+- Negatieve controle: van buiten loopback is niets van de demo-stack meer bereikbaar.
+
+## Scope-grens
+
+Eén magazijn (magazijn-a) door FSC. Magazijn-b, de profiel-stub en de notificatie-stub blijven
+rechtstreeks; die hebben eigen issues (#730, #784). De isolatie-kanttekening uit #197 blijft
+onverkort gelden: onder FSC bestaat hier geen grens tussen de peers, dus hier valt geen
+autorisatie-eigenschap mee te bewijzen.
+
+## Open punten
+
+- **Spreekt de outway plain HTTP of TLS op zijn listener?** Dat bepaalt of `MAGAZIJN_A_URL`
+  `http://` of `https://` wordt, en of er een CA-bundel bij moet. Op ZAD staat er een https-ingress
+  voor; lokaal is de listener kaal. Eén call tegen de draaiende outway beslist dit — eerste stap
+  van de uitvoering.
+- **Volgorde ten opzichte van #200.** Deze stap heeft het grant-hash uit die bootstrap nodig. Hij
+  stapelt dus op #200, niet ernaast.

--- a/docs/plans/2026-08-13-contract-bootstrap-idempotentie-fix.md
+++ b/docs/plans/2026-08-13-contract-bootstrap-idempotentie-fix.md
@@ -1,0 +1,105 @@
+# Contract-bootstrap: idempotentie zonder provider-blinde-vlek
+
+**Status:** Concept
+**PR:** nieuwe branch bovenop `feature/782-fsc-contract-magazijn-uitvraag` (PR #200), dus een
+vierde gestapelde PR (A #197 → B #200 → **deze fix op B** → C ZAD-transport, nog te doen).
+**Aanleiding:** [reviewcomment op PR #200](https://github.com/MinBZK/moza-poc-fbs-berichtenbox/pull/200#issuecomment-5280760966),
+bevindingen 1 en 2 (Hoog).
+
+## Context
+
+PR #200 (`contracts/bootstrap.sh`) claimt state-loze idempotentie: "drie runs, één contract",
+afgeleid uit de contracten zelf in plaats van een lokaal state-bestand. De review op die PR vond
+twee Hoog-bevindingen die precies díe claim ondermijnen:
+
+1. **`bestaande_contracten()` (regel 121) kijkt alleen naar de provider-manager.** Het contract
+   telt als "bestaand" zodra het daar `CONTRACT_STATE_VALID` is. Maar de PR-beschrijving zelf
+   noemt het scenario waarin de accept-handtekening wél bij de provider landt maar de push naar de
+   consumer-manager stokt (best-effort, geen cron-retry) — dan blijft het contract bij de consumer
+   `proposed` en kan de outway de grant niet resolven. Een retry ziet op de provider al VALID,
+   meldt "BOOTSTRAP OK (bestaand contract)" en doet niets — silent false-positive success.
+2. **De existence-check (stap 2) en de contract-POST (stap 3) zijn niet atomair (regel 143).** Twee
+   gelijktijdige aanroepen — concurrente CI-jobs, of een retry na een run die vóór VALID stierf —
+   passeren beide de `BESTAAND=""`-check en posten elk een nieuw contract. De bestaande
+   `AANTAL -gt 1`-WAARSCHUWING signaleert dit achteraf, maar voorkomt of herstelt het niet.
+
+Dit landt bewust **niet** in PR #200 zelf: de reviewer (deze sessie/gebruiker) is niet de auteur
+van #200, en rechtstreeks pushen op die branch zou reviewer en auteur in een lock zetten (de
+auteur moet dan alsnog zelf pushen/rebasen om verder te kunnen reviewen/mergen). Vandaar een losse,
+gestapelde PR die de #200-auteur zelf kan reviewen en inmergen — zelfde patroon als de bestaande
+A→B→C-stapeling.
+
+Buiten scope van dit plan: het [generieke mechanisme in `moza-fsc-testnet` overnemen](https://github.com/MinBZK/MijnOverheidZakelijk/issues/952)
+(issue #952). Deze fix repareert de kopie in `moza-poc-fbs-berichtenbox`; zodra #952 is opgelost
+kan die kopie alsnog vervangen worden door de generieke variant.
+
+## Gewenst resultaat
+
+- Een bootstrap-run meldt "bestaand contract" alleen als het contract **op zowel provider als
+  consumer** VALID/gesynct is. Is de provider VALID maar de consumer niet, dan forceert het script
+  de her-distributie die er voor dát scenario al staat, in plaats van te stoppen.
+- Duplicaten die door een racecondition ontstaan, worden bij de eerstvolgende run automatisch
+  opgeruimd (self-healing) in plaats van alleen gemeld.
+
+## Aanpak
+
+### 1. Consumer-sync meewegen in de existence-check
+
+`bestaande_contracten()` blijft de provider bevragen (dat is en blijft de plek waar het contract
+canoniek ontstaat), maar het resultaat telt alleen als "bestaand" als de consumer-kant het ook als
+VALID/gesynct ziet. Daarvoor hergebruikt bootstrap.sh de bestaande gedeelde helper
+`fsc_contract_state()` (`lib/fsc-harness.sh:109`) tegen de consumer-manager, in plaats van zijn
+eigen smallere `consumer_state()` (regel 219) — dat lost meteen ook bevinding 7 (Medium,
+gedupliceerde/afwijkende matchlogica) op.
+
+Is de provider VALID maar de consumer niet gesynct: dit is precies het scenario waarvoor het
+script al een geforceerde her-distributie kent (zie PR #200-beschrijving, "Wat opviel"). De
+existence-check triggert die her-distributie i.p.v. de run als "klaar" te beschouwen.
+
+### 2. Race op de check-en-POST self-healing maken
+
+Een lock toevoegen lost het probleem niet echt op: concurrente CI-jobs draaien op verschillende
+runners, dus een lokaal lockbestand voorkomt niets, en een gedeeld lock (bv. via de manager-API)
+zou weer een vorm van state introduceren die de hele opzet van deze PR juist vermeed.
+
+In plaats daarvan wordt de `AANTAL -gt 1`-tak self-healing: bij meer dan één matchende VALID
+contract voor dezelfde identiteit (service + provider + consumer-outway + thumbprint) revoke't het
+script alle contracten op één na — de oudste, canonieke — via de bestaande revoke-call op de
+provider-manager. Dat verandert de garantie van "nooit een duplicaat" (niet haalbaar zonder lock)
+naar "een duplicaat overleeft nooit de volgende run" — consistent met hoe de rest van het script al
+richting self-healing-i.p.v.-voorkomen buigt (zie de her-distributie in punt 1).
+
+### 3. Gedeelde matcher voor "geldig contract"
+
+Bevinding 6 (Medium): de contract-matchcriteria in `bestaande_contracten()` (checkt `has_revoked` +
+outway-thumbprint, niet `signatures.accept`) en in `smoke-contract.sh` (checkt `signatures.accept`
+voor beide peers, niet `has_revoked`/thumbprint) lopen al uiteen. Beide criteria zijn nodig voor
+een correcte "is dit contract geldig en van toepassing"-check; deze fix voegt één gedeelde
+jq-matcher toe aan `lib/fsc-harness.sh` die beide toetst, en laat bootstrap.sh én smoke-contract.sh
+'m allebei aanroepen.
+
+## Meteen meegenomen (kleine, losse Medium/Laag-fixes uit dezelfde review)
+
+- **Bevinding 3, 4 (Medium):** de twee `jq`-aanroepen zonder `\|\|`-fallback
+  (`smoke-contract.sh:78`, `bootstrap.sh:189`) krijgen alsnog de guard die de rest van beide
+  bestanden al gebruikt — zelfde faalklasse als de `ok_tenzij`-bug uit reviewronde 4 van #200.
+- **Bevinding 5 (Medium):** de shellcheck-glob in `.github/workflows/fsc-harness-overlays.yml:245`
+  krijgt `demo/environment/federatie/contracts/*.sh` toegevoegd.
+- **Bevinding 9, 10 (Laag):** `contract_zichtbaar()` en de idempotentie-her-run in
+  `smoke-contract.sh` tonen voortaan de onderliggende fout/output bij falen, i.p.v. die weg te
+  gooien.
+- **Bevinding 8 (Laag):** de idempotentie-assert in `smoke-contract.sh` (regel 179) vergelijkt
+  voortaan per magazijn de contract-hash vóór/na, niet alleen de geaggregeerde COUNT.
+
+## Verificatie
+
+- `smoke-contract.sh` blijft groen op de lokale federatie (zelfde vijf asserts als #200, plus de
+  verscherpte idempotentie-assert uit punt 8).
+- Nieuw scenario in `smoke-contract.sh` of een los testscript: provider VALID + consumer bewust
+  `proposed` gehouden (her-distributie-push overslaan) → bootstrap.sh moet de her-distributie
+  forceren, niet vroegtijdig "bestaand" melden.
+- Nieuw scenario: twee bootstrap.sh-aanroepen kunstmatig na elkaar zonder existence-check ertussen
+  (bv. door de check tijdelijk te stubben) → twee contracten ontstaan, een derde aanroep ruimt de
+  jongste op en laat er één over.
+- `shellcheck` op `contracts/bootstrap.sh` en `contracts/fbs-contracten.sh` slaagt (nu voor het
+  eerst via CI, bevinding 5).

--- a/docs/plans/2026-08-15-contract-bootstrap-zad-gesplitst.md
+++ b/docs/plans/2026-08-15-contract-bootstrap-zad-gesplitst.md
@@ -1,0 +1,185 @@
+# Contract-bootstrap op ZAD: gesplitst per peer
+
+**Status:** Uitgevoerd
+
+## Context
+
+De contract-bootstrap uit #200 zet lokaal één wederzijds ondertekend
+`ServiceConnectionGrant`-contract op tussen de uitvraag-peer (consumer) en elk magazijn
+(provider). Eén script praat daarbij met **twee** managers: het POST bij de consumer en
+accepteert bij de provider.
+
+Op ZAD kan dat niet. Elk deployment krijgt een gerenderde
+`<deployment>-tenant-baseline-network-policy` met `podSelector: {deployment: <naam>}`:
+
+- **ingress** alleen van pods met hetzelfde `deployment`-label, de `rig`-ingresscontroller,
+  `rig-prd-operations` en `rig-prd-backup`;
+- **egress** alleen naar kube-dns, hetzelfde deployment, die twee namespaces,
+  `<project>-infrastructure`, en `0.0.0.0/0` beperkt tot TCP 443/80.
+
+De isolatie loopt dus per **deployment**, niet per project. Daar komt bij dat de
+manager-internal-API (`:9443` authenticated, `:9444` unauthenticated) géén route heeft — de
+ingress publiceert alleen backend-poort `:8443`, de mesh-poort met `ssl-passthrough`. De twee
+peers zitten bovendien in aparte namespaces (`rig-prd-mpfb-8wh` / `rig-prd-mpfm-w3h`).
+
+Eén proces dat beide managers aanspreekt bestaat op ZAD dus niet, en er is geen configuratie
+die dat oplost: netwerkpolicies zijn op ZAD niet aanpasbaar.
+
+## Gewenst resultaat
+
+Elke peer bootstrapt zijn eigen kant tegen zijn **eigen** manager. Het contract kruist via de
+FSC-mesh, precies de weg die de managers al gebruiken. De contract-API van geen enkele peer
+wordt daarvoor van buiten bereikbaar gemaakt.
+
+## Rolverdeling
+
+De bestaande stroom valt uiteen langs de manager-grens:
+
+| Stap | Manager | Rol na de splitsing |
+|------|---------|---------------------|
+| Outway-thumbprint berekenen | — (lokaal bestand) | consumer |
+| Bestaat er al een geldig contract? | provider | **verhuist naar consumer** (zie hieronder) |
+| `POST /v1/contracts` | consumer | consumer |
+| Wachten tot het contract bij de provider staat | provider | vervalt — de provider-helft kijkt bij elke aanroep één keer in zijn eigen lijst; het herhalen zit in de aanroeper |
+| `PUT /v1/contracts/{hash}/accept` | provider | provider |
+| Her-distributie van de accept-handtekening forceren | provider | provider |
+| Wachten tot de consumer het contract geldig ziet | consumer | consumer |
+
+De twee helften coördineren niet met elkaar; ze convergeren. De consumer dient in en wacht;
+de provider ziet het contract via de mesh binnenkomen en tekent. Beide draaien herhaald, dus
+de volgorde waarin ze starten doet er niet toe.
+
+**De existence-check verhuist naar de consumer-kant.** Nu draait hij tegen de contractenlijst
+van de provider. Dat kan straks niet meer, en het hoeft ook niet: hetzelfde contract staat na
+de mesh-sync op beide managers. De consumer is bovendien de juiste kant om het aan af te
+lezen — daar haalt de outway zijn grant vandaan.
+
+Wel verandert de betekenis van een randgeval. Bij de provider zag de check alleen contracten die
+de mesh gehaald hadden; bij de consumer telt ook een contract dat net is ingediend en nog nergens
+anders bestaat. De matcher geeft die bewust wél terug, met hun state erbij. Alleen op "geldig"
+filteren zou hier averechts werken: in de gesplitste opzet zit er tijd tussen indienen en tekenen,
+en in dat gat zou elke ronde er nóg een contract bij posten. De consumer-helft leest de state dus
+zelf: geldig én door de provider getekend is klaar, alles daartussen is wachten.
+
+## De provider tekent niet blind
+
+Nu is de accept een gerichte handeling: het script weet welk hash het zelf net heeft laten
+indienen. Na de splitsing kent de provider dat hash niet — hij vindt een contract in zijn
+lijst en moet zelf besluiten of hij tekent. Dat is een autorisatiebesluit, en de peer die het
+contract aanbiedt bepaalt de inhoud ervan.
+
+Een contract draagt een **lijst** grants. Alleen kijken of er een grant in zit die ons bevalt
+is daarom niet genoeg: een tegenpartij kan een tweede grant meesturen die we per ongeluk
+mee-ondertekenen. De regel is dus dat het contract als geheel moet kloppen.
+
+De provider tekent een contract alleen als **alle** volgende dingen gelden:
+
+1. het contract hoort bij onze eigen group;
+2. het gebruikt het afgesproken hash-algoritme — dat bindt de content aan de handtekening;
+3. het draagt een geldigheidsduur, en die blijft onder een bovengrens;
+4. het draagt **precies één** grant;
+5. die grant is van type `GRANT_TYPE_SERVICE_CONNECTION`;
+6. `grant.service.peer_id` is de **eigen** OIN;
+7. `grant.service.name` staat in de lijst diensten die deze peer aanbiedt;
+8. de outway wordt geïdentificeerd op public-key-thumbprint en niet op domeinnaam;
+9. `grant.outway.peer_id` staat in de lijst toegestane consumer-OIN's;
+10. het contract is nog niet door ons getekend en niet ingetrokken.
+
+Faalt er één, dan laat de provider het contract met rust en meldt dat. Niet-tekenen is de
+veilige uitkomst: zonder handtekening werkt het contract niet.
+
+De punten 1 tot en met 3 gaan niet over de grant maar over het contract eromheen. Zonder die
+drie bepaalt de allowlist wel *wie* er mag afnemen, maar bepaalt de tegenpartij in zijn eentje
+*hoe lang* en onder welke voorwaarden.
+
+De **waarde** van de thumbprint wordt niet getoetst, het **type** wel (punt 8). De waarde kan de
+provider niet onafhankelijk verifiëren — hij heeft het outway-cert van de consumer niet — en dat
+hoeft ook niet: die wordt aan zijn eigen kant cryptografisch afgedwongen op een later moment. De
+outway haalt zijn token bij de manager van de provider, die de presentatie tegen de thumbprint in
+de grant houdt, en de inway verifieert `cnf.x5t#S256` tegen het verbindingscertificaat.
+
+Twee dingen zijn geen eigenschap van het contract maar van de verwerking, en horen er toch bij.
+Elke waarde uit het contract komt van de tegenpartij en gaat een regelgebaseerde stroom in; een
+newline in een dienstnaam zou daar een tweede record schrijven dat de aanroeper als eigen regel
+leest, en zo de hele toets omzeilen. Stuurtekens worden daarom vervangen. En een hash of OIN uit
+die stroom gaat een URL-pad in, dus de vorm ervan wordt gecontroleerd voordat er een call op volgt.
+
+## Idempotentie
+
+Blijft state-loos, op dezelfde grond als in #200: het bestaan van een contract wordt afgeleid
+uit de contracten zelf.
+
+- **Consumer:** service + provider-OIN + eigen OIN + thumbprint samen zijn de identiteit.
+  Bestaat er een geldig contract voor die combinatie, dan is er niets te doen. Bij meer dan
+  één trekt hij de overtollige in en houdt het gesorteerd-eerste hash aan — stabiel over runs.
+- **Provider:** tekent alleen wat nog niet getekend is. Een tweede ronde vindt niets meer.
+
+Beide helften draaien op ZAD in een lus. Herhaling is dus geen randgeval maar de normale
+werking, en dat is precies waarom de idempotentie niet op een state-bestand mag leunen.
+
+## Lokaal hetzelfde pad
+
+`bootstrap.sh` wordt de lokale orkestrator: hij draait de consumer-helft en daarna de
+provider-helft, elk met **alleen** de env van zijn eigen kant. De gedeelde stappen verhuizen
+naar `lib/fsc-contract.sh`.
+
+Dat is niet alleen ontdubbeling. Het lokale pad draait daarmee exact de code die op ZAD
+draait, dus de bestaande federatie-smoke toetst de gesplitste implementatie in plaats van een
+variant ervan. Zonder dat zou de ZAD-code alleen op ZAD bewezen kunnen worden, en daar is de
+terugkoppeling traag.
+
+De scheiding wordt afgedwongen en niet alleen afgesproken: elke helft start met `env -u` op de
+adres- en certificaatvariabelen van de overkant. Een aanroep naar de overkant kan daardoor niet
+per ongeluk blijven staan — er is geen adres, cert of CA voor. Het is een denylist, dus een
+nieuwe variabele van de overkant moet er expliciet bij; de fixture-test bewaakt dat geen van
+beide helften de namen van de overkant noemt.
+
+## ZAD-bedrading
+
+**Vorm.** ZAD kent alleen langlopende componenten en staat geen component-args toe. De
+bootstrap wordt dus een component met een eigen image, waarvan het entrypoint de rol uit env
+leest, de lus draait en daarna blijft draaien. Een herstart is onschadelijk: de eerste ronde
+constateert dan dat het werk al gedaan is.
+
+**Image.** `fbs-fsc-contract-bootstrap`: een kleine basis plus `bash`, `curl`, `jq` en `openssl` —
+dezelfde afhankelijkheden die de scripts lokaal ook hebben. De build-context is
+`demo/environment/` en niet de contracts-map zelf, want de scripts leunen op `../../lib`. Gebouwd
+en gepusht door dezelfde job-vorm als `fbs-externe-stubs`.
+
+**Componenten.** Eén per peer, in de deployment van die peer, zodat de
+NetworkPolicy-voorwaarde "zelfde `deployment`-label" geldt:
+
+| Deployment | Component | Rol |
+|------------|-----------|-----|
+| `fsc-logius` (`mpfb-8wh`) | `logius-fscbootstrap` | consumer |
+| `fsc-magazijna` (`mpfm-w3h`) | `magazijna-fscbootstrap` | provider |
+
+**Client-cert.** De internal-API op `:9443` is mTLS. De component krijgt een eigen
+internal-cert (`bootstrap`) uit `pki/issue.sh`, niet het cert van een andere component: wie
+een cert deelt, deelt een identiteit, en dan is in het txlog niet meer te zien wie wat deed.
+
+**Thumbprint.** De consumer-helft heeft de thumbprint van zijn outway nodig. Op ZAD komt die
+uit env in plaats van uit een bestand, zodat het outway-group-cert niet aan een tweede
+component hoeft te hangen. De waarde is stabiel zolang het sleutelpaar dat is; bij rotatie
+binnen hetzelfde sleutelpaar verandert hij niet. Het runbook zegt hoe je hem berekent.
+
+**Handwerk dat blijft.** Cert-attachments zijn UI-only — de v2-API kloont ze niet — dus de
+eenmalige creatie van beide componenten en het koppelen van de certs gaat via het runbook,
+zoals bij de bestaande peer-componenten. `deploy.yml` doet daarna alleen tag-updates.
+
+## Wat hier niet in zit
+
+Het datapad van de app naar de outway. Dat loopt op ZAD tegen dezelfde deployment-isolatie
+aan, maar heeft de mesh niet als uitweg: de uitvraag moet er buitenlangs, via de publieke
+outway-route, en die is als enige van de drie niet `ssl-passthrough` maar edge-terminated.
+Dat vraagt een eigen afweging en een eigen issue.
+
+## Verificatie
+
+- De federatie-smoke blijft groen: één contract, wederzijds geldig, herhaalde run levert geen
+  tweede op.
+- Een smoke op de splitsing: elke helft raakt alleen zijn eigen manager aan, en de twee samen
+  convergeren ongeacht de volgorde waarin ze draaien.
+- Weiger-gevallen op de autorisatie-invariant: een contract met twee grants, met een vreemde
+  dienst, met een onbekende consumer-OIN en met een vreemde provider-OIN wordt niet getekend.
+- De ZAD-kant is pas na een deploy-ronde bewezen; tot dan draagt het runbook de stappen.

--- a/services/berichtenuitvraag/src/main/resources/application.properties
+++ b/services/berichtenuitvraag/src/main/resources/application.properties
@@ -143,10 +143,16 @@ magazijnen."00000000000000100000".url=${MAGAZIJN_A_URL}
 magazijnen."00000000000000100000".naam=Magazijn A
 # FSC-outway-routering: aanwezig → Fsc-Grant-Hash/-Transaction-Id op elke call naar dit
 # magazijn (zie FscOutwayHeadersFilter); lege default (geen env-var) → geen header, magazijn
-# blijft direct/zonder outway bereikbaar. Magazijn B heeft nog geen outway-contract.
+# blijft direct/zonder outway bereikbaar.
+#
+# Elk magazijn krijgt deze sleutel, ook als er (nog) geen contract voor is. Ontbreekt hij, dan
+# levert de contract-bootstrap wel een MAGAZIJN_<X>_GRANT_HASH maar bindt niets die waarde: het
+# magazijn wordt dan zónder Fsc-Grant-Hash aangeroepen, dus buiten de FSC-keten om, terwijl alles
+# groen meldt. Een leeg gelaten env-var is hier de veilige uitkomst, een ontbrekende sleutel niet.
 magazijnen."00000000000000100000".grantHash=${MAGAZIJN_A_GRANT_HASH:}
 magazijnen."00000001823288444000".url=${MAGAZIJN_B_URL}
 magazijnen."00000001823288444000".naam=Magazijn B
+magazijnen."00000001823288444000".grantHash=${MAGAZIJN_B_GRANT_HASH:}
 %test.magazijnen."00000000000000100000".url=http://localhost:8081
 %test.magazijnen."00000001823288444000".url=http://localhost:8082
 
@@ -259,9 +265,14 @@ profiel.resolver.cache.max-size=10000
 # %dev: twee lokaal-draaiende berichtenmagazijn-instances. Magazijn A op de
 # default-poort (8090); magazijn B start je in een tweede terminal op 8091 met:
 #     ./mvnw quarkus:dev -pl services/berichtenmagazijn -Dquarkus.http.port=8091
+#
 # De env-vars horen op de %dev-regel zelf: die schaduwt de gelijknamige basissleutel
 # hierboven, dus de ${ENV} dáár bereikt dit profiel nooit. Sleutels zonder %dev-regel
 # (grantHash, naam) komen wél uit de basisregel. In de demo wijzen ze naar container-DNS.
+# MAGAZIJN_A_URL/MAGAZIJN_B_URL blijven daarom ook hier leidend als ze gezet zijn. Zonder die
+# fallback overrulet de %dev-regel de omgeving, en dan wijst het magazijn-adres stilzwijgend naar
+# localhost terwijl de omgeving iets anders zegt — bijvoorbeeld een FSC-outway. Dat is niet te
+# zien aan het gedrag: het ophalen slaagt gewoon, alleen langs de verkeerde weg.
 %dev.magazijnen."00000000000000100000".url=${MAGAZIJN_A_URL:http://localhost:8090}
 %dev.magazijnen."00000001823288444000".url=${MAGAZIJN_B_URL:http://localhost:8091}
 
@@ -322,8 +333,8 @@ logboekdataverwerking.clickhouse.table=logboek_dataverwerkingen
 %dev.logboekdataverwerking.postgresql.username=${LDV_POSTGRES_USERNAME:ldv}
 %dev.logboekdataverwerking.postgresql.password=${LDV_POSTGRES_PASSWORD:ldv}
 %dev.logboekdataverwerking.clickhouse.endpoint=${LDV_CLICKHOUSE_ENDPOINT:http://localhost:8123}
-%dev.logboekdataverwerking.clickhouse.username=ldv
-%dev.logboekdataverwerking.clickhouse.password=ldv
+%dev.logboekdataverwerking.clickhouse.username=${CLICKHOUSE_USERNAME:ldv}
+%dev.logboekdataverwerking.clickhouse.password=${CLICKHOUSE_PASSWORD:ldv}
 %test.logboekdataverwerking.postgresql.url=jdbc:postgresql://localhost:5434/ldv_logging
 %test.logboekdataverwerking.postgresql.username=ldv
 %test.logboekdataverwerking.postgresql.password=ldv

--- a/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/ApplicationPropertiesTest.kt
+++ b/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/ApplicationPropertiesTest.kt
@@ -60,4 +60,92 @@ class ApplicationPropertiesTest {
             "$sleutel moet beginnen met \${$envVar:<default>}, maar was: $waarde",
         )
     }
+
+    /**
+     * Elk geconfigureerd magazijn moet een `grantHash`-sleutel hebben, ook zonder contract.
+     *
+     * Ontbreekt hij, dan levert de contract-bootstrap wel een `MAGAZIJN_<X>_GRANT_HASH` maar bindt
+     * niets die waarde: dat magazijn wordt zónder `Fsc-Grant-Hash` aangeroepen — dus buiten de
+     * FSC-keten om — terwijl zowel de bootstrap als het ophalen groen melden. Een lege env-var is
+     * de veilige uitkomst; een ontbrekende sleutel is onzichtbaar.
+     */
+    @Test
+    fun `elk magazijn met een url heeft ook een grantHash-sleutel`() {
+        val properties = Properties().apply {
+            File("src/main/resources/application.properties").inputStream().use { load(it) }
+        }
+
+        val urlSleutel = Regex("""^magazijnen\."(\d+)"\.url$""")
+        val oins = properties.stringPropertyNames()
+            .mapNotNull { urlSleutel.find(it)?.groupValues?.get(1) }
+            .toSortedSet()
+
+        assertTrue(oins.isNotEmpty(), "geen enkel magazijn in application.properties — deze test meet niets")
+
+        val zonderGrantHash = oins.filter { properties.getProperty("""magazijnen."$it".grantHash""") == null }
+
+        assertEquals(
+            emptyList<String>(),
+            zonderGrantHash,
+            "magazijn(en) zonder grantHash-sleutel: die worden buiten de FSC-keten om aangeroepen",
+        )
+    }
+
+    /**
+     * Een `%dev`-override mag de env-var van de basissleutel niet doodslaan.
+     *
+     * Leest de basissleutel `${VAR}` en zet `%dev` er een kale waarde tegenover, dan wint die kale
+     * waarde onder `QUARKUS_PROFILE=dev` — en dat is aan het gedrag niet te zien: de service start,
+     * het verkeer gaat alleen naar het verkeerde adres. Zo liepen de magazijn-URL's langs de
+     * FSC-outway heen en Redis/Profiel langs Toxiproxy. Deze test dekt de hele klasse: elke
+     * `%dev`-sleutel die een env-var-gestuurde basissleutel overschrijft, moet diezelfde var noemen.
+     */
+    @Test
+    fun `dev-overrides slaan de env-var van hun basissleutel niet dood`() {
+        val properties = Properties().apply {
+            File("src/main/resources/application.properties").inputStream().use { load(it) }
+        }
+
+        val envVar = Regex("""\$\{([A-Z0-9_]+)[:}]""")
+        val overtreders = properties.stringPropertyNames()
+            .filter { it.startsWith("%dev.") }
+            .mapNotNull { devSleutel ->
+                val basis = devSleutel.removePrefix("%dev.")
+                val basisVar = envVar.find(properties.getProperty(basis) ?: "")?.groupValues?.get(1)
+                    ?: return@mapNotNull null
+                val devWaarde = properties.getProperty(devSleutel) ?: ""
+
+                if (devWaarde.contains("\${$basisVar")) null else "$devSleutel (basis leest \$$basisVar)"
+            }
+            .sorted()
+
+        assertEquals(
+            emptyList<String>(),
+            overtreders,
+            "deze %dev-overrides negeren de env-var van hun basissleutel; het verkeer gaat dan stil naar het verkeerde adres",
+        )
+    }
+
+    /**
+     * De `%dev`-magazijn-URL's moeten hun env-var respecteren. Stond er een kale `localhost`-waarde,
+     * dan overrulet het dev-profiel de omgeving en praat de uitvraag met het magazijn naast de deur
+     * terwijl `MAGAZIJN_A_URL` naar een FSC-outway wijst. Dat is aan het gedrag niet te zien: het
+     * ophalen slaagt, alleen loopt het verkeer buiten de keten om en blijft het transactielogboek
+     * leeg.
+     */
+    @Test
+    fun `dev-magazijn-URLs laten de omgeving voorgaan op de localhost-default`() {
+        val properties = Properties().apply {
+            File("src/main/resources/application.properties").inputStream().use { load(it) }
+        }
+
+        assertEquals(
+            "\${MAGAZIJN_A_URL:http://localhost:8090}",
+            properties.getProperty("%dev.magazijnen.\"00000000000000100000\".url"),
+        )
+        assertEquals(
+            "\${MAGAZIJN_B_URL:http://localhost:8091}",
+            properties.getProperty("%dev.magazijnen.\"00000001823288444000\".url"),
+        )
+    }
 }


### PR DESCRIPTION
> Tweede van vier: A federatie-harness (#197, gemerged) → **B deze** → C lokale keten (#206) →
> D ZAD-transport (nog te doen). Staat rechtstreeks op `main`.

Closes MinBZK/MijnOverheidZakelijk#782

## Aanleiding

Een peer mag pas iets bij een ander afnemen als er een wederzijds ondertekend
`ServiceConnectionGrant`-contract ligt. Het generieke mechanisme staat in `moza-fsc-testnet`; deze
PR past het toe op de FBS-peers en maakt er een lijst van in plaats van een gekopieerd blok.

## Wat er in zit

`contracts/fbs-contracten.sh` loopt over `MAGAZIJNEN` uit `peers.env` en zet per magazijn één
contract op, zodat de uitvraag-outway `berichtenmagazijn` bij elk van hen mag ophalen. **Een
magazijn toevoegen is één naam erbij** — precies wat nodig is om op ZAD met het aantal magazijnen
te kunnen variëren.

## De kern: idempotent zónder state-file

De generieke variant onthoudt de content-hash van het geaccepteerde contract in een bestand naast
het script. Dat werkt op een ontwikkelmachine, maar niet in een deploy: elke job start met een lege
schijf, dus **elke run maakt er nóg een geldig contract bij**, onbegrensd. Dat was de blokkade voor
acceptatiecriterium 2 ("idempotent uitvoerbaar in de FBS-deploy").

`contracts/bootstrap.sh` leidt het bestaan nu af uit de contracten zelf: service, provider,
consumer-outway en thumbprint vormen samen de identiteit van een serviceConnection. Alleen op
servicenaam matchen zou niet volstaan — het servicePublication-contract voor dezelfde dienst staat
op dezelfde manager en zou altijd meetellen.

Gemeten: drie opeenvolgende runs leveren precies één contract op.

## Bewijs

`smoke-contract.sh` legt vijf eigenschappen vast. De middelste drie zijn er omdat een 200 op
zichzelf niets zegt:

| Assert | Uitkomst |
|---|---|
| contract | geldig én met handtekeningen van beide peers op **beide** managers — niet alleen `signatures.accept`, want de manager gebruikt de grant pas bij `CONTRACT_STATE_VALID` |
| data-pad | outway → router → inway → upstream geeft **200** met de echo van dát magazijn; de stub van de uitvraag-peer zegt iets anders, dus dit onderscheidt de juiste peer van een toevallige 200 |
| afdwinging | onbekende grant-hash op de outway → **400**; rechtstreeks naar de inway mét geldig group-cert maar zónder token → **401** |
| verantwoording | dezelfde transactie in beide txlogs, uitgaand bij de uitvraag en inkomend bij het magazijn, met grant-hash |
| idempotentie | de bootstrap nog eens draaien levert geen tweede contract op |

Alle vijf groen op de lokale federatie uit #197.

## Wat opviel

De provider tekent niet vanzelf: `AUTO_SIGN_GRANTS` dekt alleen (delegated)servicePublication, dus
de accept is een expliciete `PUT`. En landt de accept-handtekening daarna niet bij de consumer —
die push is best-effort, met begrensde backoff en zonder cron-retry — dan blijft het contract daar
`proposed` en ziet de outway de grant nooit, terwijl de provider hem wél als geldig ziet. Het
script forceert in dat geval de her-distributie.

De outway haalt zijn eigen token op tijdens egress; dat wordt hier dus niet nagebouwd. De
token-probe in de generieke variant gebruikt de content-hash als scope terwijl FSC de grant-hash
wil, en geeft daarom altijd een fout — die is hier weggelaten.

## Nog te doen

**D: het ZAD-transport.** Uitgezocht op de gerenderde GitOps-manifests; hier staat wat dat opleverde,
zodat D niet opnieuw hoeft te beginnen.

Elk ZAD-deployment krijgt een `<deployment>-tenant-baseline-network-policy` met
`podSelector: {deployment: <naam>}`. Ingress alleen van pods met hetzelfde `deployment`-label, de
`rig`-ingresscontroller, `rig-prd-operations` en `rig-prd-backup`; egress alleen naar kube-dns,
hetzelfde deployment, die twee namespaces, `<project>-infrastructure`, en `0.0.0.0/0` beperkt tot
TCP 443/80. Isolatie loopt dus per **deployment**, niet per project: ook `test` (app) en
`fsc-logius` (peer) in hetzelfde project `mpfb-8wh` kunnen elkaars ClusterIP niet bereiken.

Twee gevolgen:

1. **Eén one-shot die beide peers bedient kan niet.** De manager-internal-API (`:9443` auth,
   `:9444` unauth) heeft geen route en is alleen binnen het eigen deployment bereikbaar; de peers
   zitten bovendien in aparte namespaces (`rig-prd-mpfb-8wh` / `rig-prd-mpfm-w3h`). D wordt dus een
   one-shot **per peer** tegen zijn eigen manager, waarna het contract via de mesh kruist — precies
   de weg die de managers al gebruiken. Dat is geen concessie: de contract-API van elke peer blijft
   onbereikbaar van buiten.
2. **Het datapad app → outway moet buitenlangs.** De outway-ClusterIP is vanuit `test` dicht, dus
   de app bereikt hem via zijn publieke route
   (`logius-fscoutway-fsc-logius-mpfb-8wh.rig.prd1.gn2.quattro.rijksapps.nl`). Anders dan de
   manager- en inway-route is die **niet** `ssl-passthrough` maar edge-terminated.

> **TODO** — netwerkpolicies zijn op ZAD niet configureerbaar, dus buitenlangs is voorlopig de enige
> weg. Hetzelfde bleek al bij een ander ticket; daarvoor wordt een issue aangemaakt en dit geval
> hoort daarbij. Tot dat er ligt, is punt 2 een bewuste tussenoplossing en geen eindbeeld: de
> outway is de component die namens de peer diens identiteit meegeeft, dus wie hem bereikt spreekt
> als die peer.

**Terug naar `moza-fsc-testnet`.** De state-loze idempotentie hoort daar thuis, anders drift deze
kopie: #952.

🤖 Gegenereerd met [Claude Code](https://claude.com/claude-code)

