### PR TITLE
fix(demo): consumer-sync-blinde-vlek en duplicaten in contract-bootstrap (review #200)

### DIFF
--- a/.github/workflows/fsc-harness-overlays.yml
+++ b/.github/workflows/fsc-harness-overlays.yml
@@ -243,6 +243,7 @@ jobs:
           if ! shellcheck -x -S warning \
                  demo/environment/lib/*.sh \
                  demo/environment/federatie/*.sh \
+                 demo/environment/federatie/contracts/*.sh \
                  demo/environment/*/deploy/local/*.sh \
                  demo/environment/*/pki/*.sh \
                  .github/scripts/*.sh; then

--- a/demo/environment/federatie/contracts/bootstrap.sh
+++ b/demo/environment/federatie/contracts/bootstrap.sh
@@ -9,7 +9,10 @@
 #   1. bereken de SPKI-SHA256-thumbprint van het GROUP-cert van de consumer-outway. Dat is waarmee
 #      de outway zich naar de provider-inway identificeert, en het is stabiel bij cert-rotatie
 #      binnen hetzelfde sleutelpaar;
-#   2. bestaat er al een geldig contract voor precies deze combinatie? -> klaar;
+#   2. bestaat er al een geldig contract voor precies deze combinatie? Zo ja, en staat het ook al
+#      geldig bij de consumer: klaar. Staat het alleen bij de provider geldig (de accept-push naar
+#      de consumer kan stranden, zie stap 5), dan wordt hier hetzelfde herstel toegepast als bij een
+#      verse bootstrap, zónder opnieuw te posten;
 #   3. POST /v1/contracts op de EIGEN manager. Die tekent server-side namens de consumer en synct
 #      het contract via de mesh naar de provider;
 #   4. poll de provider tot het contract er is, dan PUT /v1/contracts/{hash}/accept op de
@@ -25,6 +28,13 @@
 # geldig contract bij. Deze variant leidt het bestaan af uit de contracten zelf — service, provider,
 # consumer-outway en thumbprint samen zijn de identiteit — zodat een herhaalde run een no-op is,
 # waar hij ook draait.
+#
+# De existence-check (stap 2) en de POST (stap 3) zijn niet atomair: twee gelijktijdige of
+# herhaalde runs kunnen allebei een nieuw contract posten. Dat wordt hier niet voorkomen (dat vergt
+# een lock, en dus weer state), maar wel zelf-herstellend gemaakt: bij meer dan één geldig contract
+# voor dezelfde combinatie trekt de eerstvolgende run de overtollige in via
+# `PUT /v1/contracts/{hash}/revoke` en gebruikt verder altijd het (sorteer-)eerste hash — stabiel
+# over runs heen, ook als de volgorde van de manager-API zelf niet gegarandeerd stabiel is.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
@@ -103,56 +113,112 @@ provider_api() { api "$PROVIDER_MANAGER" "$PROVIDER_CERT" "$PROVIDER_KEY" "$PROV
 command -v openssl >/dev/null 2>&1 || { echo "FAIL: openssl niet gevonden." >&2; exit 1; }
 [ -r "$OUTWAY_CERT" ] || { echo "FAIL: outway-cert niet leesbaar: ${OUTWAY_CERT} (pki/issue.sh gedraaid?)" >&2; exit 1; }
 
-THUMB="$(openssl x509 -in "$OUTWAY_CERT" -pubkey -noout 2>"$ERRLOG" \
-           | openssl pkey -pubin -outform DER 2>>"$ERRLOG" \
-           | openssl dgst -sha256 -r 2>>"$ERRLOG" | cut -d' ' -f1)" || THUMB=""
-case "$THUMB" in
-  [0-9a-f]*) [ "${#THUMB}" -eq 64 ] || { echo "FAIL: thumbprint is geen 64 hex-tekens: '${THUMB}'" >&2; exit 1; } ;;
-  *) echo "FAIL: kon de outway-thumbprint niet berekenen uit ${OUTWAY_CERT}: $(fsc_last_error)" >&2; exit 1 ;;
-esac
+THUMB="$(fsc_outway_thumbprint "$OUTWAY_CERT")" \
+  || { echo "FAIL: kon de outway-thumbprint niet berekenen uit ${OUTWAY_CERT}: $(fsc_last_error)" >&2; exit 1; }
 echo "bootstrap: outway public-key-thumbprint = ${THUMB}"
 
-# --- 2. Bestaat het contract al? ----------------------------------------------------------------
+# --- Sync-helpers (gebruikt door zowel de existence-check als de verse bootstrap-flow) -----------
+VALID_STATE=contract_state_valid
+
+# contract_zichtbaar <hash>: staat dit contract al in de contractenlijst van de provider?
+contract_zichtbaar() {
+  local hash="$1" rc
+  provider_api "${PROVIDER_MANAGER}/v1/contracts" 2>"$ERRLOG" \
+    | jq -e --arg h "$hash" 'any(.contracts[]?; .hash == $h)' >/dev/null 2>>"$ERRLOG"
+  rc=$?
+  fsc_warn_errlog "sync-poll (provider)"
+  return "$rc"
+}
+
+# consumer_state <hash>: manager-state van dit contract op de consumer, of "onbekend".
+consumer_state() {
+  local hash="$1" json rc state
+  json="$(consumer_api "${CONSUMER_MANAGER}/v1/contracts" 2>"$ERRLOG")"
+  rc=$?
+  fsc_warn_errlog "state-poll (consumer)"
+  [ "$rc" -eq 0 ] || { echo onbekend; return; }
+
+  state="$(fsc_contract_state "$json" "$hash")"
+  [ "$state" = unknown ] && echo onbekend || printf '%s\n' "$state"
+}
+
+# wacht_op_valid <hash>: pollt tot de consumer het contract als geldig ziet, of tot SYNC_TIMEOUT.
+wacht_op_valid() {
+  local hash="$1" elapsed=0
+  while [ "$elapsed" -lt "$SYNC_TIMEOUT" ]; do
+    [ "$(consumer_state "$hash")" = "$VALID_STATE" ] && return 0
+
+    sleep "$SYNC_INTERVAL"; elapsed=$((elapsed + SYNC_INTERVAL))
+    echo "  ...contract nog niet 'valid' op de consumer (${elapsed}s)" >&2
+  done
+  return 1
+}
+
+# zorg_dat_consumer_gesynct <hash>: wacht tot de consumer het contract geldig ziet; forceert één
+# keer de her-distributie van de accept-handtekening als dat niet vanzelf lukt binnen SYNC_TIMEOUT
+# (het canonieke herstel voor een gestrande best-effort-push, zie de moduledoc).
+zorg_dat_consumer_gesynct() {
+  local hash="$1"
+  wacht_op_valid "$hash" && return 0
+
+  echo "bootstrap: accept-handtekening opnieuw laten distribueren..." >&2
+  provider_api -X PUT \
+    "${PROVIDER_MANAGER}/v1/contracts/${hash}/distributions/${CONSUMER_OIN}/DISTRIBUTION_ACTION_SUBMIT_ACCEPT_SIGNATURE/retry" \
+    -H 'Content-Type: application/json' >/dev/null \
+    || echo "  WARN: her-distributie gaf een fout: $(fsc_last_error)" >&2
+
+  wacht_op_valid "$hash"
+}
+
+# --- 2. Bestaat het contract al? ------------------------------------------------------------------
 # De identiteit van een serviceConnection is de combinatie service + provider + consumer-outway +
 # thumbprint. Alleen op servicenaam matchen zou het servicePublication-contract voor dezelfde
 # dienst meetellen, dat op dezelfde manager staat en altijd matcht.
-bestaande_contracten() {  # echoot de hashes van geldige, niet-ingetrokken contracten voor deze combinatie
+bestaande_contracten() {  # hashes van geldige, niet-ingetrokken contracten voor deze combinatie, gesorteerd
   local json
   json="$(provider_api "${PROVIDER_MANAGER}/v1/contracts")" || {
     echo "FAIL: kon de contracten van de provider niet ophalen: $(fsc_last_error)" >&2
     return 1
   }
 
-  printf '%s' "$json" | jq -r \
-    --arg svc "$SERVICE_NAME" --arg prov "$PROVIDER_OIN" \
-    --arg cons "$CONSUMER_OIN" --arg thumb "$THUMB" '
-    [ .contracts[]?
-      | select(.state == "CONTRACT_STATE_VALID" and (.has_revoked // false) == false)
-      | select(any(.content.grants[]?;
-            .type == "GRANT_TYPE_SERVICE_CONNECTION"
-            and .service.name == $svc
-            and .service.peer_id == $prov
-            and .outway.peer_id == $cons
-            and .outway.identification.public_key_thumbprint == $thumb))
-      | .hash ] | .[]' 2>"$ERRLOG" || {
-    echo "FAIL: contract-JSON niet te parsen: $(fsc_last_error)" >&2
-    return 1
-  }
+  fsc_grant_actief "$json" "$SERVICE_NAME" "$PROVIDER_OIN" "$CONSUMER_OIN" "$THUMB" | sort
 }
 
 BESTAAND="$(bestaande_contracten)" || exit 1
 if [ -n "$BESTAAND" ]; then
   AANTAL="$(printf '%s\n' "$BESTAAND" | grep -c .)"
+  HASH="$(printf '%s\n' "$BESTAAND" | head -n1)"
   echo "OK: er is al een geldig contract voor ${SERVICE_NAME} (${CONSUMER_OIN} -> ${PROVIDER_OIN})."
+  printf '%s\n' "$BESTAAND" | sed 's/^/  contract: /'
 
   if [ "$AANTAL" -gt 1 ]; then
-    # Duplicaten zijn niet fataal — de outway gebruikt er één — maar ze wijzen op een eerdere run
-    # zonder deze controle, en ze stapelen zich op.
-    echo "  WAARSCHUWING: ${AANTAL} geldige contracten voor dezelfde combinatie; ruim de overtollige op." >&2
+    # Kan ontstaan doordat deze existence-check en de POST (stap 3) niet atomair zijn: twee
+    # gelijktijdige of herhaalde runs kunnen allebei een nieuw contract posten. De outway gebruikt
+    # er sowieso maar één — het gesorteerd-eerste hash hierboven — maar de rest ruimt zichzelf hier
+    # op, zodat een volgende run weer bij één contract uitkomt.
+    echo "  WAARSCHUWING: ${AANTAL} geldige contracten voor dezelfde combinatie; trek de overtollige in." >&2
+    printf '%s\n' "$BESTAAND" | tail -n +2 | while IFS= read -r dup; do
+      provider_api -X PUT "${PROVIDER_MANAGER}/v1/contracts/${dup}/revoke" \
+          -H 'Content-Type: application/json' >/dev/null 2>"$ERRLOG" \
+        && echo "  ingetrokken: ${dup}" >&2 \
+        || echo "  WARN: kon duplicaat ${dup} niet intrekken: $(fsc_last_error)" >&2
+    done
   fi
 
-  printf '%s\n' "$BESTAAND" | sed 's/^/  contract: /'
-  echo "BOOTSTRAP OK (bestaand contract)."
+  if [ "$(consumer_state "$HASH")" = "$VALID_STATE" ]; then
+    echo "BOOTSTRAP OK (bestaand contract)."
+    exit 0
+  fi
+
+  # Geldig op de provider, maar (nog) niet gesynct naar de consumer — zonder deze controle zou een
+  # retry hier ten onrechte "klaar" melden terwijl de outway de grant nooit ziet (zie moduledoc).
+  echo "bootstrap: contract ${HASH} is geldig op de provider maar nog niet gesynct naar de consumer..." >&2
+  zorg_dat_consumer_gesynct "$HASH" || {
+    echo "FAIL: contract ${HASH} werd niet 'valid' op de consumer (state: $(consumer_state "$HASH"))." >&2
+    exit 1
+  }
+  echo "OK: contract ${HASH} is alsnog wederzijds gesynct."
+  echo "BOOTSTRAP OK (bestaand contract, opnieuw gesynct)."
   exit 0
 fi
 
@@ -186,20 +252,15 @@ RESP="$(consumer_api -X POST "${CONSUMER_MANAGER}/v1/contracts" -H 'Content-Type
   }
 }")" || { echo "FAIL: POST /v1/contracts geweigerd: ${RESP:-<leeg>} $(fsc_last_error)" >&2; exit 1; }
 
-HASH="$(printf '%s' "$RESP" | jq -r '.content_hash // empty' 2>/dev/null)"
+HASH="$(printf '%s' "$RESP" | jq -r '.content_hash // empty' 2>/dev/null)" || HASH=""
 [ -n "$HASH" ] || { echo "FAIL: respons zonder content_hash (formaat geweigerd?): ${RESP}" >&2; exit 1; }
 echo "  consumer-handtekening gezet; mesh-sync gestart; content_hash=${HASH}"
 
 # --- 4. Provider accepteert ----------------------------------------------------------------------
-contract_zichtbaar() {
-  provider_api "${PROVIDER_MANAGER}/v1/contracts" 2>/dev/null \
-    | jq -e --arg h "$HASH" 'any(.contracts[]?; .hash == $h)' >/dev/null 2>&1
-}
-
 echo "bootstrap: wachten tot het contract naar de provider gesynct is..."
 elapsed=0; gesynct=0
 while [ "$elapsed" -lt "$SYNC_TIMEOUT" ]; do
-  if contract_zichtbaar; then gesynct=1; break; fi
+  if contract_zichtbaar "$HASH"; then gesynct=1; break; fi
 
   sleep "$SYNC_INTERVAL"; elapsed=$((elapsed + SYNC_INTERVAL))
   echo "  ...nog niet gesynct (${elapsed}s)" >&2
@@ -216,38 +277,11 @@ provider_api -X PUT "${PROVIDER_MANAGER}/v1/contracts/${HASH}/accept" -H 'Conten
 echo "  provider-handtekening gezet."
 
 # --- 5. Wachten tot de consumer het contract als geldig ziet --------------------------------------
-consumer_state() {
-  consumer_api "${CONSUMER_MANAGER}/v1/contracts" 2>/dev/null \
-    | jq -r --arg h "$HASH" 'first(.contracts[]? | select(.hash == $h) | .state) // "onbekend"' 2>/dev/null \
-    || echo onbekend
-}
-
-wacht_op_valid() {
-  local elapsed=0
-  while [ "$elapsed" -lt "$SYNC_TIMEOUT" ]; do
-    [ "$(consumer_state)" = "CONTRACT_STATE_VALID" ] && return 0
-
-    sleep "$SYNC_INTERVAL"; elapsed=$((elapsed + SYNC_INTERVAL))
-    echo "  ...contract nog niet 'valid' op de consumer (${elapsed}s)" >&2
-  done
-  return 1
-}
-
 echo "bootstrap: wachten tot de consumer het contract als geldig ziet..."
-if ! wacht_op_valid; then
-  # De accept-handtekening wordt best-effort naar de consumer gepusht; strandt die, dan blijft het
-  # contract daar `proposed` en ziet de outway de grant nooit. Dit is het canonieke herstel.
-  echo "bootstrap: accept-handtekening opnieuw laten distribueren..." >&2
-  provider_api -X POST \
-    "${PROVIDER_MANAGER}/v1/contracts/${HASH}/distributions/${CONSUMER_OIN}/DISTRIBUTION_ACTION_SUBMIT_ACCEPT_SIGNATURE/retry" \
-    -H 'Content-Type: application/json' >/dev/null \
-    || echo "  WARN: her-distributie gaf een fout: $(fsc_last_error)" >&2
-
-  wacht_op_valid || {
-    echo "FAIL: contract ${HASH} werd niet 'valid' op de consumer (state: $(consumer_state))." >&2
-    exit 1
-  }
-fi
+zorg_dat_consumer_gesynct "$HASH" || {
+  echo "FAIL: contract ${HASH} werd niet 'valid' op de consumer (state: $(consumer_state "$HASH"))." >&2
+  exit 1
+}
 
 echo "OK: contract ${HASH} is wederzijds ondertekend en geldig."
 echo "BOOTSTRAP OK."

--- a/demo/environment/federatie/smoke-contract.sh
+++ b/demo/environment/federatie/smoke-contract.sh
@@ -44,6 +44,12 @@ CONS_OIN="$(fsc_peer_waarde OIN "$UITVRAAG")"
 
 OUTWAY="http://127.0.0.1:$((CONS_BLOK + 40))"
 
+# Thumbprint van de consumer-outway — zelfde grootheid als bootstrap.sh gebruikt om een contract
+# te identificeren. Nodig om hier dezelfde matcher (fsc_grant_actief) te kunnen hergebruiken.
+CONS_OUTWAY_CERT="${ENVDIR}/${UITVRAAG}/pki/out/${UITVRAAG}/outway/cert.pem"
+CONS_THUMB="$(fsc_outway_thumbprint "$CONS_OUTWAY_CERT")" \
+  || { echo "FAIL: kon de outway-thumbprint niet berekenen uit ${CONS_OUTWAY_CERT}: $(fsc_last_error)" >&2; exit 1; }
+
 # manager_json <peer> <blok>: de contracten van die peer via zijn interne API (blok+01).
 manager_json() {
   local peer="$1" blok="$2" naam="manager.$1.fsc-test.local" poort=$(( $2 + 1 ))
@@ -73,23 +79,19 @@ for magazijn in $MAGAZIJNEN; do
       continue
     fi
 
-    # Beide handtekeningen én de lifecycle-state. `signatures.accept` alleen is niet genoeg: de
-    # manager gebruikt de grant pas als het contract óók `CONTRACT_STATE_VALID` is.
-    GEVONDEN="$(printf '%s' "$JSON" | jq -r \
-      --arg svc "$MAGAZIJN_DIENST" --arg prov "$PROV_OIN" --arg cons "$CONS_OIN" '
-      [ .contracts[]?
-        | select(.state == "CONTRACT_STATE_VALID")
-        | select(any(.content.grants[]?;
-              .type == "GRANT_TYPE_SERVICE_CONNECTION"
-              and .service.name == $svc and .service.peer_id == $prov
-              and .outway.peer_id == $cons))
-        | select((.signatures.accept | has($prov)) and (.signatures.accept | has($cons)))
-        | .content.grants[] | select(.type == "GRANT_TYPE_SERVICE_CONNECTION") | .hash ]
-      | .[0] // ""' 2>/dev/null)"
+    # Zelfde matcher als contracts/bootstrap.sh gebruikt om een bestaand contract te herkennen:
+    # lifecycle-state, niet-ingetrokken, beide handtekeningen én de outway-thumbprint. Dat laatste
+    # ontbrak hier voorheen — zonder thumbprint-check zou een contract voor een andere (bv. na
+    # certificaatrotatie verouderde) consumer-outway ook meetellen.
+    CONTRACT_HASH="$(fsc_grant_actief "$JSON" "$MAGAZIJN_DIENST" "$PROV_OIN" "$CONS_OIN" "$CONS_THUMB" \
+      | sort | head -n1)" || CONTRACT_HASH=""
 
-    if [ -n "$GEVONDEN" ]; then
+    if [ -n "$CONTRACT_HASH" ]; then
       ok "${peer}: contract geldig met handtekeningen van beide peers"
-      [ -n "$GRANT" ] || GRANT="$GEVONDEN"
+      if [ -z "$GRANT" ]; then
+        # De grant-hash (voor de Fsc-Grant-Hash-header) is niet het contract-hash zelf.
+        GRANT="$(fsc_grant_hash "$JSON" "$CONTRACT_HASH" "$MAGAZIJN_DIENST" "$CONS_THUMB")"
+      fi
     else
       fout "${peer}: geen geldig contract met beide handtekeningen voor ${MAGAZIJN_DIENST}"
     fi
@@ -174,21 +176,37 @@ done
 
 # --- 5. Idempotentie ------------------------------------------------------------------------------
 # Zonder state-file: de bootstrap moet het bestaande contract herkennen uit de contracten zelf.
-# Anders zou elke deploy er een geldig contract bij maken.
+# Anders zou elke deploy er een geldig contract bij maken. Een aggregaat-COUNT over alle magazijnen
+# zou een verschuiving (het ene magazijn erbij, het andere eraf) niet zien; per-magazijn hetzelfde
+# canonieke contract-hash vóór en na is de eigenlijke garantie.
 echo "===== 5. idempotentie ====="
-VOOR="$(manager_json "$UITVRAAG" "$CONS_BLOK" | jq '[.contracts[]?|select(any(.content.grants[]?; .type=="GRANT_TYPE_SERVICE_CONNECTION"))]|length' 2>/dev/null || echo -1)"
 
-if "${HERE}/contracts/fbs-contracten.sh" >/dev/null 2>&1; then
-  NA="$(manager_json "$UITVRAAG" "$CONS_BLOK" | jq '[.contracts[]?|select(any(.content.grants[]?; .type=="GRANT_TYPE_SERVICE_CONNECTION"))]|length' 2>/dev/null || echo -2)"
+contract_hashes_per_magazijn() {  # gebruikt $UITVRAAG/$CONS_BLOK/$CONS_THUMB uit de buitenste scope
+  local json magazijn prov_oin hash
+  json="$(manager_json "$UITVRAAG" "$CONS_BLOK")" || json=""
+  for magazijn in $MAGAZIJNEN; do
+    prov_oin="$(fsc_peer_waarde OIN "$magazijn")"
+    hash="$(fsc_grant_actief "$json" "$MAGAZIJN_DIENST" "$prov_oin" "$CONS_OIN" "$CONS_THUMB" \
+      | sort | head -n1)" || hash=""
+    printf '%s=%s\n' "$magazijn" "$hash"
+  done
+}
 
-  if [ "$VOOR" -gt 0 ] && [ "$NA" -eq "$VOOR" ]; then
-    ok "her-draaien van de bootstrap levert geen extra contract op (${VOOR} -> ${NA})"
+VOOR="$(contract_hashes_per_magazijn)"
+HERDRAAI_LOG="$(mktemp)"
+
+if "${HERE}/contracts/fbs-contracten.sh" >"$HERDRAAI_LOG" 2>&1; then
+  NA="$(contract_hashes_per_magazijn)"
+
+  if [ -n "$VOOR" ] && [ "$VOOR" = "$NA" ] && ! printf '%s\n' "$VOOR" | grep -q '=$'; then
+    ok "her-draaien van de bootstrap levert per magazijn hetzelfde contract op"
   else
-    fout "aantal serviceConnection-contracten ging van ${VOOR} naar ${NA}"
+    fout "contract-hash per magazijn verschilt (of ontbreekt) vóór/na de her-draai — vóór: [${VOOR}] na: [${NA}]"
   fi
 else
-  fout "fbs-contracten.sh faalde bij de her-draai"
+  fout "fbs-contracten.sh faalde bij de her-draai: $(tail -n 10 "$HERDRAAI_LOG")"
 fi
+rm -f "$HERDRAAI_LOG"
 
 echo
 if [ "$FOUTEN" -eq 0 ]; then

--- a/demo/environment/lib/fsc-harness.sh
+++ b/demo/environment/lib/fsc-harness.sh
@@ -126,6 +126,49 @@ fsc_grant_hash() {
     | ($g[0] // "unknown")' 2>/dev/null || echo unknown
 }
 
+# --- contract-matching (gedeeld door contracts/bootstrap.sh en federatie/smoke-contract.sh) ----
+# Eén matcher voor "is dit contract geldig en van toepassing op deze serviceConnection", zodat
+# beide scripts niet elk hun eigen (en dus potentieel afwijkende) criteria hanteren.
+
+# fsc_outway_thumbprint <cert-pad>: SPKI-SHA256-thumbprint (64 lowercase hex) van een outway-
+# groepscert op stdout; leeg + non-zero exit bij een ontbrekend/onleesbaar/corrupt certificaat.
+# Vereist $ERRLOG (fsc_errlog_init).
+fsc_outway_thumbprint() {
+  local cert="$1" thumb
+  [ -r "$cert" ] || return 1
+  thumb="$(openssl x509 -in "$cert" -pubkey -noout 2>>"$ERRLOG" \
+             | openssl pkey -pubin -outform DER 2>>"$ERRLOG" \
+             | openssl dgst -sha256 -r 2>>"$ERRLOG" | cut -d' ' -f1)" || return 1
+  case "$thumb" in
+    [0-9a-f]*) [ "${#thumb}" -eq 64 ] || return 1 ;;
+    *) return 1 ;;
+  esac
+  printf '%s' "$thumb"
+}
+
+# fsc_grant_actief <json> <service> <provider_oin> <consumer_oin> <outway_thumbprint>: hashes
+# (één per regel) van niet-ingetrokken CONTRACT_STATE_VALID-contracten die de accept-handtekening
+# van zowel provider als consumer dragen, voor precies deze serviceConnection-combinatie. Leeg bij
+# geen match. De identiteit van een serviceConnection is service + provider + consumer-outway +
+# thumbprint samen: op servicenaam alleen matchen zou ook het servicePublication-contract voor
+# dezelfde dienst meetellen, dat op dezelfde manager staat en altijd aanwezig is.
+fsc_grant_actief() {
+  [ "$HAVE_JQ" -eq 1 ] || return 0
+  printf '%s' "$1" | jq -r \
+    --arg svc "$2" --arg prov "$3" --arg cons "$4" --arg thumb "$5" '
+    [ .contracts[]?
+      | select(.state == "CONTRACT_STATE_VALID" and (.has_revoked // false) == false)
+      | select( ((.signatures.accept // {}) | has($prov))
+                and ((.signatures.accept // {}) | has($cons)) )
+      | select(any(.content.grants[]?;
+            .type == "GRANT_TYPE_SERVICE_CONNECTION"
+            and .service.name == $svc
+            and .service.peer_id == $prov
+            and .outway.peer_id == $cons
+            and .outway.identification.public_key_thumbprint == $thumb))
+      | .hash ] | .[]' 2>/dev/null
+}
+
 # --- federatie-helpers ------------------------------------------------------------------------
 # Gebruikt door demo/environment/federatie/. Staan hier en niet in die map omdat ze door meerdere
 # scripts én door de bash-unittests gedeeld worden.

--- a/demo/environment/lib/test-fsc-harness.sh
+++ b/demo/environment/lib/test-fsc-harness.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Fixture-test voor fsc_scrub_errlog: toetst tegen de exacte ANSI-bytes uit de PR-166-bug-report
-# (ericwout-overheid, 2026-08-12) — reproductie van de podman-external-compose-provider-banner.
+# Fixture-tests voor de pure-logica-helpers in fsc-harness.sh: fsc_scrub_errlog (tegen de exacte
+# ANSI-bytes uit de PR-166-bug-report, ericwout-overheid, 2026-08-12), en de contract-matcher/
+# thumbprint-helpers die bootstrap.sh en smoke-contract.sh delen.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
@@ -45,6 +46,104 @@ assert_empty_after_scrub "banner-only wordt leeg (geen vals alarm)" "$BANNER"
 REAL_ERROR="${BANNER}curl: (7) Failed to connect to manager.logius.fsc-test.local port 9443: Connection refused
 "
 assert_survives_scrub "echte curl-fout blijft zichtbaar na scrub" "$REAL_ERROR" "Connection refused"
+
+fsc_have_jq
+[ "$HAVE_JQ" -eq 1 ] || { echo "FAIL: jq is vereist voor deze fixture-tests." >&2; exit 1; }
+
+# --- fsc_grant_actief -------------------------------------------------------------------------
+# Vaste testidentiteit; de waarden zelf doen er niet toe, alleen dat thumbprint 1 != thumbprint 2.
+SVC=berichtenmagazijn
+PROV=00000000000000100000
+CONS=00000000000000001000
+THUMB="$(printf 'a%.0s' $(seq 1 64))"
+ANDERE_THUMB="$(printf 'b%.0s' $(seq 1 64))"
+
+# contract_json <hash> <state> <has_revoked> <heeft-provider-sig> <heeft-consumer-sig> <thumb>
+contract_json() {
+  jq -n --arg h "$1" --arg st "$2" --argjson rv "$3" --argjson hp "$4" --argjson hc "$5" \
+        --arg svc "$SVC" --arg prov "$PROV" --arg cons "$CONS" --arg thumb "$6" '
+    { hash: $h, state: $st, has_revoked: $rv,
+      signatures: { accept: ( {}
+        + (if $hp then {($prov): true} else {} end)
+        + (if $hc then {($cons): true} else {} end) ) },
+      content: { grants: [ {
+        type: "GRANT_TYPE_SERVICE_CONNECTION",
+        service: { name: $svc, peer_id: $prov },
+        outway: { peer_id: $cons, identification: { public_key_thumbprint: $thumb } }
+      } ] } }'
+}
+
+# contracts_json <contract-json...>: bundelt losse contract-objecten tot { "contracts": [...] }.
+contracts_json() { printf '%s\n' "$@" | jq -s '{ contracts: . }'; }
+
+assert_grant_hashes() {
+  local desc="$1" json="$2" verwacht="$3" thumb="${4:-$THUMB}" kregen
+  kregen="$(fsc_grant_actief "$json" "$SVC" "$PROV" "$CONS" "$thumb")"
+  if [ "$kregen" = "$verwacht" ]; then
+    echo "OK: $desc"
+  else
+    echo "FAIL: $desc — verwacht [$verwacht], kreeg [$kregen]" >&2
+    fails=$((fails + 1))
+  fi
+}
+
+VALID_VOLLEDIG="$(contract_json h1 CONTRACT_STATE_VALID false true true "$THUMB")"
+assert_grant_hashes "geldig + niet-ingetrokken + beide handtekeningen -> gevonden" \
+  "$(contracts_json "$VALID_VOLLEDIG")" "h1"
+
+GEREVOKED="$(contract_json h2 CONTRACT_STATE_VALID true true true "$THUMB")"
+assert_grant_hashes "ingetrokken contract telt niet mee" \
+  "$(contracts_json "$GEREVOKED")" ""
+
+ZONDER_CONSUMER_SIG="$(contract_json h3 CONTRACT_STATE_VALID false true false "$THUMB")"
+assert_grant_hashes "ontbrekende consumer-handtekening telt niet mee" \
+  "$(contracts_json "$ZONDER_CONSUMER_SIG")" ""
+
+ANDERE_STATE="$(contract_json h4 CONTRACT_STATE_PROPOSED false true true "$THUMB")"
+assert_grant_hashes "niet-VALID state telt niet mee" \
+  "$(contracts_json "$ANDERE_STATE")" ""
+
+ANDER_THUMB_CONTRACT="$(contract_json h5 CONTRACT_STATE_VALID false true true "$ANDERE_THUMB")"
+assert_grant_hashes "afwijkende outway-thumbprint telt niet mee" \
+  "$(contracts_json "$ANDER_THUMB_CONTRACT")" ""
+
+assert_grant_hashes "twee geldige contracten voor dezelfde combinatie komen beide terug" \
+  "$(contracts_json "$VALID_VOLLEDIG" "$(contract_json h1b CONTRACT_STATE_VALID false true true "$THUMB")")" \
+  "$(printf 'h1\nh1b')"
+
+assert_grant_hashes "lege contractenlijst geeft niets terug" \
+  "$(contracts_json)" ""
+
+# --- fsc_outway_thumbprint ---------------------------------------------------------------------
+CERTDIR="$(mktemp -d)"
+trap 'rm -rf "$CERTDIR"' EXIT
+openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -nodes -days 1 \
+  -subj "/CN=test-outway" -keyout "$CERTDIR/key.pem" -out "$CERTDIR/cert.pem" >/dev/null 2>&1
+
+ERRLOG="$(mktemp)"
+GEVONDEN="$(fsc_outway_thumbprint "$CERTDIR/cert.pem")" && THUMB_OK=1 || THUMB_OK=0
+if [ "$THUMB_OK" -eq 1 ] && printf '%s' "$GEVONDEN" | grep -qE '^[0-9a-f]{64}$'; then
+  echo "OK: fsc_outway_thumbprint geeft 64 lowercase hex-tekens voor een geldig cert"
+else
+  echo "FAIL: fsc_outway_thumbprint op een geldig cert gaf '$GEVONDEN' (ok=$THUMB_OK)" >&2
+  fails=$((fails + 1))
+fi
+
+if GEVONDEN="$(fsc_outway_thumbprint "$CERTDIR/niet-bestaand.pem" 2>/dev/null)"; then
+  echo "FAIL: fsc_outway_thumbprint had moeten falen op een ontbrekend bestand, gaf '$GEVONDEN'" >&2
+  fails=$((fails + 1))
+else
+  echo "OK: fsc_outway_thumbprint faalt op een ontbrekend certificaatbestand"
+fi
+
+printf 'dit is geen certificaat' > "$CERTDIR/rommel.pem"
+if GEVONDEN="$(fsc_outway_thumbprint "$CERTDIR/rommel.pem" 2>/dev/null)"; then
+  echo "FAIL: fsc_outway_thumbprint had moeten falen op een corrupt bestand, gaf '$GEVONDEN'" >&2
+  fails=$((fails + 1))
+else
+  echo "OK: fsc_outway_thumbprint faalt op een corrupt certificaatbestand"
+fi
+rm -f "$ERRLOG"
 
 if [ "$fails" -eq 0 ]; then
   echo "ALLE ASSERTS GROEN"

--- a/docs/plans/2026-08-13-contract-bootstrap-idempotentie-fix.md
+++ b/docs/plans/2026-08-13-contract-bootstrap-idempotentie-fix.md
@@ -1,0 +1,105 @@
+# Contract-bootstrap: idempotentie zonder provider-blinde-vlek
+
+**Status:** Concept
+**PR:** nieuwe branch bovenop `feature/782-fsc-contract-magazijn-uitvraag` (PR #200), dus een
+vierde gestapelde PR (A #197 → B #200 → **deze fix op B** → C ZAD-transport, nog te doen).
+**Aanleiding:** [reviewcomment op PR #200](https://github.com/MinBZK/moza-poc-fbs-berichtenbox/pull/200#issuecomment-5280760966),
+bevindingen 1 en 2 (Hoog).
+
+## Context
+
+PR #200 (`contracts/bootstrap.sh`) claimt state-loze idempotentie: "drie runs, één contract",
+afgeleid uit de contracten zelf in plaats van een lokaal state-bestand. De review op die PR vond
+twee Hoog-bevindingen die precies díe claim ondermijnen:
+
+1. **`bestaande_contracten()` (regel 121) kijkt alleen naar de provider-manager.** Het contract
+   telt als "bestaand" zodra het daar `CONTRACT_STATE_VALID` is. Maar de PR-beschrijving zelf
+   noemt het scenario waarin de accept-handtekening wél bij de provider landt maar de push naar de
+   consumer-manager stokt (best-effort, geen cron-retry) — dan blijft het contract bij de consumer
+   `proposed` en kan de outway de grant niet resolven. Een retry ziet op de provider al VALID,
+   meldt "BOOTSTRAP OK (bestaand contract)" en doet niets — silent false-positive success.
+2. **De existence-check (stap 2) en de contract-POST (stap 3) zijn niet atomair (regel 143).** Twee
+   gelijktijdige aanroepen — concurrente CI-jobs, of een retry na een run die vóór VALID stierf —
+   passeren beide de `BESTAAND=""`-check en posten elk een nieuw contract. De bestaande
+   `AANTAL -gt 1`-WAARSCHUWING signaleert dit achteraf, maar voorkomt of herstelt het niet.
+
+Dit landt bewust **niet** in PR #200 zelf: de reviewer (deze sessie/gebruiker) is niet de auteur
+van #200, en rechtstreeks pushen op die branch zou reviewer en auteur in een lock zetten (de
+auteur moet dan alsnog zelf pushen/rebasen om verder te kunnen reviewen/mergen). Vandaar een losse,
+gestapelde PR die de #200-auteur zelf kan reviewen en inmergen — zelfde patroon als de bestaande
+A→B→C-stapeling.
+
+Buiten scope van dit plan: het [generieke mechanisme in `moza-fsc-testnet` overnemen](https://github.com/MinBZK/MijnOverheidZakelijk/issues/952)
+(issue #952). Deze fix repareert de kopie in `moza-poc-fbs-berichtenbox`; zodra #952 is opgelost
+kan die kopie alsnog vervangen worden door de generieke variant.
+
+## Gewenst resultaat
+
+- Een bootstrap-run meldt "bestaand contract" alleen als het contract **op zowel provider als
+  consumer** VALID/gesynct is. Is de provider VALID maar de consumer niet, dan forceert het script
+  de her-distributie die er voor dát scenario al staat, in plaats van te stoppen.
+- Duplicaten die door een racecondition ontstaan, worden bij de eerstvolgende run automatisch
+  opgeruimd (self-healing) in plaats van alleen gemeld.
+
+## Aanpak
+
+### 1. Consumer-sync meewegen in de existence-check
+
+`bestaande_contracten()` blijft de provider bevragen (dat is en blijft de plek waar het contract
+canoniek ontstaat), maar het resultaat telt alleen als "bestaand" als de consumer-kant het ook als
+VALID/gesynct ziet. Daarvoor hergebruikt bootstrap.sh de bestaande gedeelde helper
+`fsc_contract_state()` (`lib/fsc-harness.sh:109`) tegen de consumer-manager, in plaats van zijn
+eigen smallere `consumer_state()` (regel 219) — dat lost meteen ook bevinding 7 (Medium,
+gedupliceerde/afwijkende matchlogica) op.
+
+Is de provider VALID maar de consumer niet gesynct: dit is precies het scenario waarvoor het
+script al een geforceerde her-distributie kent (zie PR #200-beschrijving, "Wat opviel"). De
+existence-check triggert die her-distributie i.p.v. de run als "klaar" te beschouwen.
+
+### 2. Race op de check-en-POST self-healing maken
+
+Een lock toevoegen lost het probleem niet echt op: concurrente CI-jobs draaien op verschillende
+runners, dus een lokaal lockbestand voorkomt niets, en een gedeeld lock (bv. via de manager-API)
+zou weer een vorm van state introduceren die de hele opzet van deze PR juist vermeed.
+
+In plaats daarvan wordt de `AANTAL -gt 1`-tak self-healing: bij meer dan één matchende VALID
+contract voor dezelfde identiteit (service + provider + consumer-outway + thumbprint) revoke't het
+script alle contracten op één na — de oudste, canonieke — via de bestaande revoke-call op de
+provider-manager. Dat verandert de garantie van "nooit een duplicaat" (niet haalbaar zonder lock)
+naar "een duplicaat overleeft nooit de volgende run" — consistent met hoe de rest van het script al
+richting self-healing-i.p.v.-voorkomen buigt (zie de her-distributie in punt 1).
+
+### 3. Gedeelde matcher voor "geldig contract"
+
+Bevinding 6 (Medium): de contract-matchcriteria in `bestaande_contracten()` (checkt `has_revoked` +
+outway-thumbprint, niet `signatures.accept`) en in `smoke-contract.sh` (checkt `signatures.accept`
+voor beide peers, niet `has_revoked`/thumbprint) lopen al uiteen. Beide criteria zijn nodig voor
+een correcte "is dit contract geldig en van toepassing"-check; deze fix voegt één gedeelde
+jq-matcher toe aan `lib/fsc-harness.sh` die beide toetst, en laat bootstrap.sh én smoke-contract.sh
+'m allebei aanroepen.
+
+## Meteen meegenomen (kleine, losse Medium/Laag-fixes uit dezelfde review)
+
+- **Bevinding 3, 4 (Medium):** de twee `jq`-aanroepen zonder `\|\|`-fallback
+  (`smoke-contract.sh:78`, `bootstrap.sh:189`) krijgen alsnog de guard die de rest van beide
+  bestanden al gebruikt — zelfde faalklasse als de `ok_tenzij`-bug uit reviewronde 4 van #200.
+- **Bevinding 5 (Medium):** de shellcheck-glob in `.github/workflows/fsc-harness-overlays.yml:245`
+  krijgt `demo/environment/federatie/contracts/*.sh` toegevoegd.
+- **Bevinding 9, 10 (Laag):** `contract_zichtbaar()` en de idempotentie-her-run in
+  `smoke-contract.sh` tonen voortaan de onderliggende fout/output bij falen, i.p.v. die weg te
+  gooien.
+- **Bevinding 8 (Laag):** de idempotentie-assert in `smoke-contract.sh` (regel 179) vergelijkt
+  voortaan per magazijn de contract-hash vóór/na, niet alleen de geaggregeerde COUNT.
+
+## Verificatie
+
+- `smoke-contract.sh` blijft groen op de lokale federatie (zelfde vijf asserts als #200, plus de
+  verscherpte idempotentie-assert uit punt 8).
+- Nieuw scenario in `smoke-contract.sh` of een los testscript: provider VALID + consumer bewust
+  `proposed` gehouden (her-distributie-push overslaan) → bootstrap.sh moet de her-distributie
+  forceren, niet vroegtijdig "bestaand" melden.
+- Nieuw scenario: twee bootstrap.sh-aanroepen kunstmatig na elkaar zonder existence-check ertussen
+  (bv. door de check tijdelijk te stubben) → twee contracten ontstaan, een derde aanroep ruimt de
+  jongste op en laat er één over.
+- `shellcheck` op `contracts/bootstrap.sh` en `contracts/fbs-contracten.sh` slaagt (nu voor het
+  eerst via CI, bevinding 5).


### PR DESCRIPTION
> **Gestapeld op #200.** Base staat op `feature/782-fsc-contract-magazijn-uitvraag`. Losse PR i.p.v.
> commits op #200 zelf: ik ben niet de auteur van #200, dus rechtstreeks pushen zou reviewer en
> auteur in een lock zetten.

## Aanleiding

De [review op #200](https://github.com/MinBZK/moza-poc-fbs-berichtenbox/pull/200#issuecomment-5280760966)
vond twee Hoog-bevindingen in `contracts/bootstrap.sh` die de idempotentie-claim van die PR
("drie runs, één contract") ondermijnen:

1. De existence-check kijkt alleen naar de provider-manager — als de accept-handtekening daar wel
   landt maar de push naar de consumer stokt, meldt een retry ten onrechte "bestaand contract".
2. De existence-check en de contract-POST zijn niet atomair — concurrente/herhaalde runs kunnen
   elk een nieuw contract posten; de bestaande `AANTAL -gt 1`-check signaleert dit alleen.

Plan: `docs/plans/2026-08-13-contract-bootstrap-idempotentie-fix.md`.

## Wat er in zit

- **Consumer-sync meewegen.** Een contract telt pas als "bestaand" als ook de consumer het als
  `CONTRACT_STATE_VALID` ziet, niet alleen de provider. Is dat nog niet zo, dan hergebruikt de
  existence-check dezelfde her-distributie/wacht-logica als een verse bootstrap
  (`zorg_dat_consumer_gesynct`), in plaats van voortijdig "klaar" te melden.
- **Zelf-herstellende duplicaten.** Bij meer dan één geldig contract voor dezelfde combinatie trekt
  de eerstvolgende run de overtollige in via `PUT /v1/contracts/{hash}/revoke`. Dit endpoint werd
  nergens in de FSC-repo-familie (`moza-fsc-testnet`, `moza-fsc-org-a`, `moza-fsc-testconsumer`)
  eerder gebruikt of geverifieerd; ik heb het bevestigd tegen de upstream OpenFSC-spec
  (`rinis-oss/fsc/open-fsc` op GitLab, tag `v2.5.2` — dezelfde versie als hier gepind) vóór het te
  implementeren. Het canonieke contract is voortaan het gesorteerd-eerste hash, stabiel over runs.
- **Bijvangst: verkeerd HTTP-verb.** Bij dat spec-onderzoek bleek de bestaande her-distributie-call
  (al in #200) `-X POST` te gebruiken waar de spec `PUT` voorschrijft — de fallback voor een
  gestrande accept-push faalde dus vermoedelijk al stil. Meegefixt, want mijn nieuwe
  `zorg_dat_consumer_gesynct` bouwt er direct op voort.
- **Gedeelde contract-matcher.** `fsc_grant_actief()` en `fsc_outway_thumbprint()` (nieuw, TDD in
  `demo/environment/lib/test-fsc-harness.sh`) vervangen de losstaande, uiteenlopende jq-matchers in
  bootstrap.sh en smoke-contract.sh — inclusief de thumbprint-check die smoke-contract.sh nog miste.
- **smoke-contract.sh sectie 5** vergelijkt nu per magazijn het canonieke contract-hash vóór/na de
  her-run i.p.v. een geaggregeerde COUNT, en toont de her-run-output bij falen.
- **CI:** shellcheck-glob in `fsc-harness-overlays.yml` uitgebreid met `contracts/*.sh`.

## Verificatie

- `shellcheck -x -S warning` met exact de CI-glob (lokaal gedownloade standalone-binary): groen,
  inclusief de nieuwe `contracts/*.sh`.
- Alle `demo/environment/lib/test-*.sh` (inclusief de nieuwe fixture-tests voor
  `fsc_grant_actief`/`fsc_outway_thumbprint`, TDD): groen.
- **Niet gedaan in deze sessie:** een volledige live-federatie-run van `smoke-contract.sh`. Dat
  vergt de podman-hostnet-opstelling uit `federatie/README.md`, inclusief een host-brede
  poort-privilegewijziging (`sysctl net.ipv4.ip_unprivileged_port_start=0`) — niet iets om
  automatisch te doen. Dit is de belangrijkste openstaande verificatiestap vóór merge; zie
  "Verificatie" in het plan voor de scenario's die daar nog tegenaan moeten (provider-VALID/
  consumer-proposed geforceerd, en de duplicaten-opruiming).
