### PR TITLE
chore(ci): sla bouwen en uitrollen over als de wijziging de uitrol niet raakt

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,8 +14,13 @@ permissions: read-all
 # uitkomst die niemand meer leest. Alleen voor PR's annuleren — op main is elke analyse de
 # baseline van dát commit, en de Scorecard-SAST-check kijkt of een gemergede PR een CodeQL-upload
 # had. Die upload komt van de laatste run op de PR, en die wordt hier nooit geannuleerd.
+#
+# Buiten een PR is de groep per run uniek. Een gedeelde groep zou daar namelijk óók annuleren:
+# GitHub houdt per groep hoogstens één wachtende run vast en gooit een eerdere wachtende weg,
+# ook met `cancel-in-progress: false`. Drie merges kort na elkaar zouden dan de middelste
+# commit zonder analyse en zonder SARIF-upload laten.
 concurrency:
-  group: codeql-${{ github.event.pull_request.number || github.ref }}
+  group: codeql-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # CodeQL draait op ELKE PR, óók docs-only. De OpenSSF Scorecard SAST-check bemonstert de

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,14 @@ on:
 
 permissions: read-all
 
+# Een opvolgende push maakt de vorige analyse achterhaald: die draait ~6 minuten door voor een
+# uitkomst die niemand meer leest. Alleen voor PR's annuleren — op main is elke analyse de
+# baseline van dát commit, en de Scorecard-SAST-check kijkt of een gemergede PR een CodeQL-upload
+# had. Die upload komt van de laatste run op de PR, en die wordt hier nooit geannuleerd.
+concurrency:
+  group: codeql-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # CodeQL draait op ELKE PR, óók docs-only. De OpenSSF Scorecard SAST-check bemonstert de
 # laatste ~30 gemergede PRs en kijkt per PR of er een CodeQL-SARIF-upload was; één overgeslagen
 # analyse laat die PR ongedekt en verlaagt de check-score. CodeQL analyseert bovendien de hele

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -182,10 +182,19 @@ jobs:
           echo "Gewijzigde bestanden:"
           printf '%s\n' "$files"
 
-          if printf '%s\n' "$files" | grep -qvE '(^docs/|\.md$)'; then
+          # Paden die noch de gebouwde images noch de uitrol kunnen veranderen: documentatie, de
+          # Bruno-collectie, de fuzz-configuratie en de workflows die uitsluitend toetsen. Zonder
+          # dit filter kostte een PR aan bijvoorbeeld de fuzz-configuratie tóch twee jib-builds
+          # plus drie previews — uitrollen van een image dat per definitie gelijk is aan main.
+          #
+          # deploy.yml zelf, .github/actions/ en de zad-actions staan er bewust NIET bij: die
+          # bepalen de uitrol, dus juist daar is een preview het bewijs dat de wijziging klopt.
+          niet_deploybaar='(^docs/|\.md$|^bruno/|^\.clusterfuzzlite/|^\.github/workflows/(test|detekt|codeql|scorecard|architecture|pin-consistency|cflite_pr|cflite_batch|cflite_cron|fuzz-base-image)\.yml$)'
+
+          if printf '%s\n' "$files" | grep -qvE "$niet_deploybaar"; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Alleen documentatie gewijzigd — deploy overgeslagen."
+            echo "Geen wijziging die de images of de uitrol raakt — bouwen en deployen overgeslagen."
             echo "run=false" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -158,6 +158,8 @@ jobs:
           # Het type komt van GitHub zelf (enum), niet uit door de indiener bepaalde tekst.
           PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
         run: |
+          set -euo pipefail
+
           if [ "$EVENT" != "pull_request" ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
             exit 0
@@ -189,14 +191,31 @@ jobs:
           #
           # deploy.yml zelf, .github/actions/ en de zad-actions staan er bewust NIET bij: die
           # bepalen de uitrol, dus juist daar is een preview het bewijs dat de wijziging klopt.
-          niet_deploybaar='(^docs/|\.md$|^bruno/|^\.clusterfuzzlite/|^\.github/workflows/(test|detekt|codeql|scorecard|architecture|pin-consistency|cflite_pr|cflite_batch|cflite_cron|fuzz-base-image)\.yml$)'
+          # demo-console en demo/ horen erbij: die module wordt door geen enkele deploy uitgerold
+          # (de images zijn berichtenuitvraag en berichtenmagazijn), en test.yml scoopt er zijn
+          # tests al apart op.
+          niet_deploybaar='(^docs/|\.md$|^bruno/|^demo/|^services/demo-console/|^\.clusterfuzzlite/|^\.github/workflows/(test|detekt|codeql|scorecard|architecture|pin-consistency|cflite_pr|cflite_batch|cflite_cron|fsc-harness-overlays|fuzz-base-image)\.yml$)'
 
-          if printf '%s\n' "$files" | grep -qvE "$niet_deploybaar"; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Geen wijziging die de images of de uitrol raakt — bouwen en deployen overgeslagen."
-            echo "run=false" >> "$GITHUB_OUTPUT"
-          fi
+          # Herestring in plaats van een pipe: `grep -q` sluit de pipe bij de eerste match, en
+          # met `pipefail` zou die SIGPIPE als "niets te deployen" doorgaan. `grep` geeft 1 bij
+          # geen match en 2 bij een echte fout; alleen 1 mag tot overslaan leiden, want een
+          # overgeslagen deploy rapporteert `skipped` en telt als succes in de required checks.
+          rc=0
+          grep -qvE "$niet_deploybaar" <<<"$files" || rc=$?
+
+          case "$rc" in
+            0)
+              echo "run=true" >> "$GITHUB_OUTPUT"
+              ;;
+            1)
+              echo "Geen wijziging die de images of de uitrol raakt — bouwen en deployen overgeslagen."
+              echo "run=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::warning::Filter kon niet beoordelen (grep rc=$rc) — deploy draait fail-safe."
+              echo "run=true" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
 
   # Afgeleide waarden op één plek: image-tag + lowercase GHCR-owner (GHCR eist lowercase).
   #


### PR DESCRIPTION
Twee posten die alleen machinetijd kosten, gevonden bij een herijking van de tijden na #198 en
#204.

## 1. Bouwen en uitrollen bij PR's die de deployment niet kunnen raken

De deploy-filter sloot alleen `docs/` en `*.md` uit. PR #204 raakte uitsluitend CI-bestanden en
bouwde tóch twee jib-images (71-87s elk), de stubs-image, en rolde drie previews uit (65-424s) —
terwijl er geen regel runtime-code was gewijzigd, dus die previews zijn per definitie gelijk aan
main.

Uitgesloten zijn nu ook `bruno/`, `.clusterfuzzlite/` en de workflows die uitsluitend toetsen.

**Niet uitgesloten**, bewust: `deploy.yml` zelf, `.github/actions/` en de zad-actions. Die
bepalen de uitrol, dus juist daar is een preview het bewijs dat de wijziging klopt.

De toetsende controles (tests, detekt, fuzzing, pins) blijven gewoon draaien — die hangen niet
aan dit filter.

Het filter is tegen elf gevallen gehouden, waaronder de gemengde:

| Gewijzigde bestanden | Uitkomst |
|---|---|
| `.clusterfuzzlite/Dockerfile` + fuzz-workflow (zoals #204) | overslaan |
| `docs/…md`, `bruno/…`, `README.md` in een submap | overslaan |
| `.github/workflows/test.yml` | overslaan |
| `.github/workflows/deploy.yml` | **deployen** |
| `.github/actions/zad-deploy/action.yml` | **deployen** |
| `services/…/X.kt`, `compose.yaml` | **deployen** |
| `docs/x.md` + `services/…/pom.xml` (gemengd) | **deployen** |

## 2. CodeQL annuleert een achterhaalde analyse

`codeql.yml` had geen `concurrency`, terwijl `test.yml`, `detekt.yml` en `architecture.yml` die
wel hebben. Elke opvolgende push startte een nieuwe analyse terwijl de vorige (333-407s, mediaan
~363s) gewoon uitdraaide voor een uitkomst die niemand meer leest.

Alleen voor PR's geannuleerd. Op main is elke analyse de baseline van dát commit, en de
Scorecard-SAST-check kijkt of een gemergede PR een CodeQL-upload had — die komt van de laatste
run op de PR, en die wordt nooit geannuleerd.

`deploy.yml` krijgt bewust géén workflow-brede annulering: de preview-jobs staan expliciet op
`cancel-in-progress: false`, want halverwege afbreken laat een half uitgerolde preview achter. De
dure bouw-jobs daar annuleren zichzelf al per job.

## Wat dit oplevert

Vooral machinetijd: ~8-12 minuten per CI-only PR, plus ~6 minuten per achterhaalde CodeQL-run.
Wachttijd wint alleen de eerste post, en alleen voor PR's aan de bouwstraat zelf: die zijn dan
klaar na de controles in plaats van na de uitrol.

Onderdeel van MinBZK/MijnOverheidZakelijk#869.