### PR TITLE
De FBS-keten lokaal door FSC: uitvraag haalt op bij magazijn-a via de outway

### DIFF
--- a/.github/scripts/merge-guard.sh
+++ b/.github/scripts/merge-guard.sh
@@ -109,9 +109,13 @@ bind_mist=$(jq -r '.services | to_entries[] | . as $s
     elif ($img | test("toxiproxy")) then
       (if ($cmd | test("-host=127\\.")) then empty
        else "\($s.key): toxiproxy zonder `-host=127.x` (image-default is elke interface)" end)
-    elif ($env | has("QUARKUS_HTTP_HOST")) then
+    elif ($img | test("(^|/)fbs-")) then
+      # Op de image-familie en niet op `has("QUARKUS_HTTP_HOST")`: die gate maakte de tak leeg voor
+      # precies het geval waarvoor hij bestaat — een ONTBREKENDE variabele viel dan door naar
+      # `else empty`. Onze eigen services bakken `quarkus.http.host=0.0.0.0` in hun
+      # application.properties, dus afwezigheid betekent hier een wildcard-bind.
       (if (($env.QUARKUS_HTTP_HOST // "") | tostring | test("^127\\.")) then empty
-       else "\($s.key): QUARKUS_HTTP_HOST=\($env.QUARKUS_HTTP_HOST) staat niet op 127.x" end)
+       else "\($s.key): QUARKUS_HTTP_HOST=\($env.QUARKUS_HTTP_HOST // "<niet gezet>") staat niet op 127.x" end)
     else empty end' <<<"$MERGED")
 
 # De overlay hoort elke `ports:` uit de basis te resetten; een gepubliceerde poort in een gedeelde

--- a/.github/scripts/merge-guard.sh
+++ b/.github/scripts/merge-guard.sh
@@ -46,6 +46,10 @@ fi
 # even gevaarlijk, en de volgende die er een toevoegt verzint gegarandeerd een andere naam.
 LEK=':[0-9]{2,5}$'
 LEK="(^|[= ])(0\\.0\\.0\\.0|\\[::\\]|\\*)?${LEK}"
+# Een bind-adres ZONDER poort ontsnapt aan LEK: `QUARKUS_HTTP_HOST=0.0.0.0` draagt geen `:poort`.
+# Vandaar een tweede patroon op de kale wildcard-waarde. Ook dit staat op de waarde en niet op de
+# naam, zodat een volgende service die zijn bind-adres anders noemt er evengoed onder valt.
+KAAL_LEK='(^|[= ])(0\.0\.0\.0|\[?::\]?|\*)$' 
 
 fail=0
 meld() {
@@ -77,12 +81,12 @@ env_lek=$(jq -r '.services | to_entries[] | . as $s
 
 # Naam-onafhankelijk: elke env-waarde en elk `command`/`entrypoint`-token dat eruitziet als een
 # niet-loopback bind.
-bind_lek=$(jq -r --arg re "$LEK" '.services | to_entries[] | . as $s
+bind_lek=$(jq -r --arg re "$LEK" --arg kaal "$KAAL_LEK" '.services | to_entries[] | . as $s
   | ( ($s.value.environment // {}) | to_entries[]
         | select(.value != null) | "\(.key)=\(.value)" ),
     ( (($s.value.command // []) + ($s.value.entrypoint // []))[]?
         | select(type == "string") )
-  | select(test($re))
+  | select(test($re) or test($kaal))
   | "\($s.key): \(.)"' <<<"$MERGED")
 
 # De overlay hoort elke `ports:` uit de basis te resetten; een gepubliceerde poort in een gedeelde
@@ -108,8 +112,11 @@ pg_lek=$(jq -r '.services | to_entries[] | . as $s
 # --postgres. Die vlag stuurt alleen of postgres AANWEZIG moet zijn. Hing de eis aan de vlag, dan
 # zou een gast die zijn postgres uit het inactieve profiel haalt het image-default
 # `listen_addresses='*'` krijgen: de DB met harness-credentials op elke interface, en de guard groen.
+# Elke postgres in de merge, niet alleen een service die letterlijk `postgres` heet: de demo-stack
+# draait er drie (postgres-a, postgres-b, postgres-uitvraag). Op de naam én op de image matchen,
+# zodat een hernoemde service niet stil buiten de controle valt.
 pg_mist=$(jq -r '.services | to_entries[]
-  | select(.key == "postgres")
+  | select((.key | test("postgres")) or ((.value.image // "") | test("postgres")))
   | select(((.value.command // []) | map(select(test("listen_addresses="))) | length) == 0)
   | .key' <<<"$MERGED")
 

--- a/.github/scripts/merge-guard.sh
+++ b/.github/scripts/merge-guard.sh
@@ -89,6 +89,31 @@ bind_lek=$(jq -r --arg re "$LEK" --arg kaal "$KAAL_LEK" '.services | to_entries[
   | select(test($re) or test($kaal))
   | "\($s.key): \(.)"' <<<"$MERGED")
 
+# De checks hierboven toetsen een bind-adres dát er staat. Een ONTBREKENDE bind-directive ontsnapt
+# daaraan: valt `command:` weg uit de overlay, dan erft de service de image-default (`0.0.0.0`) en
+# is er niets meer om op te matchen. Per image-familie dus eisen dát de directive er is én dat hij
+# op loopback staat — dezelfde vorm als de postgres-controle hieronder, die dit al deed.
+#
+# Alleen families die in deze repo voorkomen; een service zonder van deze images valt terug op de
+# waarde-checks hierboven.
+bind_mist=$(jq -r '.services | to_entries[] | . as $s
+  | ($s.value.image // "") as $img
+  | ((($s.value.command // []) + ($s.value.entrypoint // [])) | map(select(type == "string")) | join(" ")) as $cmd
+  | ($s.value.environment // {}) as $env
+  | if ($img | test("redis")) then
+      (if ($cmd | test("--bind +127\\.")) then empty
+       else "\($s.key): redis zonder `--bind 127.x` (image-default is elke interface)" end)
+    elif ($img | test("wiremock")) then
+      (if ($cmd | test("--bind-address +127\\.")) then empty
+       else "\($s.key): wiremock zonder `--bind-address 127.x` (image-default is elke interface)" end)
+    elif ($img | test("toxiproxy")) then
+      (if ($cmd | test("-host=127\\.")) then empty
+       else "\($s.key): toxiproxy zonder `-host=127.x` (image-default is elke interface)" end)
+    elif ($env | has("QUARKUS_HTTP_HOST")) then
+      (if (($env.QUARKUS_HTTP_HOST // "") | tostring | test("^127\\.")) then empty
+       else "\($s.key): QUARKUS_HTTP_HOST=\($env.QUARKUS_HTTP_HOST) staat niet op 127.x" end)
+    else empty end' <<<"$MERGED")
+
 # De overlay hoort elke `ports:` uit de basis te resetten; een gepubliceerde poort in een gedeelde
 # netns is betekenisloos en verraadt een vergeten `!reset`.
 poorten=$(jq -r '.services | to_entries[]
@@ -158,6 +183,7 @@ meld "bind-adres dat niet op loopback staat:" "$bind_lek"
 meld "nog een gepubliceerde poort in de merge (mist een 'ports: !reset []'):" "$poorten"
 meld "onbegrensde herstartlus (zet een maximum in de overlay):" "$ongelimiteerd"
 meld "postgres luistert niet uitsluitend op loopback (127.x):" "$pg_lek"
+meld "bind-directive ontbreekt of staat niet op loopback:" "$bind_mist"
 meld "postgres zonder expliciete listen_addresses (het image kiest dan '*'):" "$pg_mist"
 meld "bind-regel in de gemounte haproxy-config die niet op loopback (127.x) staat:" "$haproxy_lek"
 

--- a/.github/workflows/fsc-harness-overlays.yml
+++ b/.github/workflows/fsc-harness-overlays.yml
@@ -28,10 +28,10 @@ on:
     types: [opened, synchronize, reopened]
     # De workflow staat in zijn eigen pad-filter: anders komt een verzwakking van de guard binnen
     # zonder dat de guard zelf ooit gedraaid heeft.
-    paths: ['demo/environment/**', '.github/workflows/fsc-harness-overlays.yml', '.github/scripts/merge-guard.sh']
+    paths: ['demo/environment/**', 'compose.yaml', 'compose.podman*.yaml', 'demo/podman-prepare.sh', '.github/workflows/fsc-harness-overlays.yml', '.github/scripts/merge-guard.sh']
   push:
     branches: [main]
-    paths: ['demo/environment/**', '.github/workflows/fsc-harness-overlays.yml', '.github/scripts/merge-guard.sh']
+    paths: ['demo/environment/**', 'compose.yaml', 'compose.podman*.yaml', 'demo/podman-prepare.sh', '.github/workflows/fsc-harness-overlays.yml', '.github/scripts/merge-guard.sh']
 
 # LET OP: `pull_request`, niet `pull_request_target`, en read-only zonder secrets. Beide jobs
 # `source`n demo/environment/federatie/peers.env respectievelijk renderen compose-bestanden uit de
@@ -250,6 +250,30 @@ jobs:
           fi
 
           exit "$fail"
+
+  # De demo-stack uit compose.yaml draait in dezelfde netns-modus als de harnessen, en dus onder
+  # dezelfde eis: geen enkele listener buiten loopback. Zonder deze job stond die stack op élke
+  # interface van de machine — Redis zonder wachtwoord en twee PostgreSQL-instanties met
+  # demo-credentials — en botste een wildcard-bind bovendien met elke specifieke bind van een
+  # federatie in dezelfde netns.
+  demo-stack-op-loopback:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Elke demo-service op de gedeelde netns, elke listener op loopback
+        run: |
+          set -euo pipefail
+
+          # `--profile demo` erbij: zonder dat profiel rendert compose de vier Quarkus-services en
+          # toxiproxy niet, en meet deze job precies de helft van de stack.
+          DEMO_HOST=localhost DEMO_MAGAZIJN_STUBS=2 docker compose --profile demo \
+            -f compose.yaml \
+            -f compose.podman.yaml \
+            -f compose.podman-hostnet.yaml config --format json \
+            | "$GITHUB_WORKSPACE/.github/scripts/merge-guard.sh" "demo-stack (hostnet-merge)"
 
   harness-scripts:
     runs-on: ubuntu-latest

--- a/.github/workflows/fsc-harness-overlays.yml
+++ b/.github/workflows/fsc-harness-overlays.yml
@@ -28,10 +28,10 @@ on:
     types: [opened, synchronize, reopened]
     # De workflow staat in zijn eigen pad-filter: anders komt een verzwakking van de guard binnen
     # zonder dat de guard zelf ooit gedraaid heeft.
-    paths: ['demo/environment/**', 'compose.yaml', 'compose.podman*.yaml', 'demo/podman-prepare.sh', '.github/workflows/fsc-harness-overlays.yml', '.github/scripts/merge-guard.sh']
+    paths: ['demo/environment/**', 'compose.yaml', 'compose.podman*.yaml', 'demo/*.sh', 'demo/genereer-magazijnen.py', 'toxiproxy/proxies.json', '.github/workflows/fsc-harness-overlays.yml', '.github/scripts/merge-guard.sh']
   push:
     branches: [main]
-    paths: ['demo/environment/**', 'compose.yaml', 'compose.podman*.yaml', 'demo/podman-prepare.sh', '.github/workflows/fsc-harness-overlays.yml', '.github/scripts/merge-guard.sh']
+    paths: ['demo/environment/**', 'compose.yaml', 'compose.podman*.yaml', 'demo/*.sh', 'demo/genereer-magazijnen.py', 'toxiproxy/proxies.json', '.github/workflows/fsc-harness-overlays.yml', '.github/scripts/merge-guard.sh']
 
 # LET OP: `pull_request`, niet `pull_request_target`, en read-only zonder secrets. Beide jobs
 # `source`n demo/environment/federatie/peers.env respectievelijk renderen compose-bestanden uit de

--- a/.github/workflows/fsc-harness-overlays.yml
+++ b/.github/workflows/fsc-harness-overlays.yml
@@ -302,6 +302,7 @@ jobs:
                  demo/environment/federatie/contracts/*.sh \
                  demo/environment/*/deploy/local/*.sh \
                  demo/environment/*/pki/*.sh \
+                 demo/*.sh \
                  .github/scripts/*.sh; then
             fail=1
           fi

--- a/compose.podman-hostnet.yaml
+++ b/compose.podman-hostnet.yaml
@@ -129,14 +129,30 @@ services:
   berichtenuitvraag:
     network_mode: host
     ports: !reset []
+    # Het grant-hash per magazijn komt uit de contract-bootstrap van de federatie
+    # (demo/environment/federatie/contracts/fbs-contracten.sh). Ontbreekt het bestand — geen
+    # federatie op deze machine — dan start de stack gewoon zonder, en valt de uitvraag terug op
+    # rechtstreeks verkeer: `magazijnen."<OIN>".grantHash` leeg betekent "geen FSC-headers".
+    env_file:
+      - path: demo/generated/fsc-grants.env
+        required: false
     depends_on:
       redis:
+        condition: service_started
+      # Deze overlay reset élke healthcheck (podman draait die via systemd-timers, en juist in de
+      # omgevingen die hostnet nodig hebben ontbreekt systemd). Een `condition: service_healthy`
+      # die uit de basis blijft staan, faalt dan met "has no healthcheck configured" — en omdat
+      # depends_on per sleutel gemerged wordt, moet elke wachtende sleutel hier expliciet terug.
+      postgres-uitvraag:
         condition: service_started
     environment:
       # 0.0.0.0 uit de basis zou in een gedeelde netns op élke interface van de machine binden.
       QUARKUS_HTTP_HOST: 127.0.0.1
       REDIS_HOSTS: redis://127.0.0.1:16379
-      MAGAZIJN_A_URL: http://127.0.0.1:18090
+      # Default: rechtstreeks via toxiproxy, zodat de storing-knop van de demo werkt. Zet
+      # MAGAZIJN_A_URL op de outway van de federatie (http://127.20.1.5:8443) om dit magazijn via
+      # de FSC-keten te laten lopen; het grant-hash komt dan uit env_file hierboven.
+      MAGAZIJN_A_URL: ${MAGAZIJN_A_URL:-http://127.0.0.1:18090}
       MAGAZIJN_B_URL: http://127.0.0.1:18091
       PROFIEL_SERVICE_URL: http://127.0.0.1:18089
       LDV_POSTGRES_URL: jdbc:postgresql://127.0.0.1:5434/ldv_logging

--- a/compose.podman-hostnet.yaml
+++ b/compose.podman-hostnet.yaml
@@ -28,36 +28,40 @@ services:
     network_mode: host
     ports: !reset []
     healthcheck: !reset null
+    # redis-stack-server start zonder bind op alle interfaces; in een gedeelde netns is dat de hele
+    # machine, en deze Redis heeft geen wachtwoord.
+    command: ["redis-stack-server", "--bind", "127.0.0.1"]
 
   magazijn-a:
     network_mode: host
     ports: !reset []
-    command: ["--port", "8081", "--verbose", "--global-response-templating"]
+    command: ["--bind-address", "127.0.0.1", "--port", "8081", "--verbose", "--global-response-templating"]
 
   magazijn-b:
     network_mode: host
     ports: !reset []
-    command: ["--port", "8082", "--verbose", "--global-response-templating"]
+    command: ["--bind-address", "127.0.0.1", "--port", "8082", "--verbose", "--global-response-templating"]
 
   profiel-service:
     network_mode: host
     ports: !reset []
-    command: ["--port", "8089", "--verbose"]
+    command: ["--bind-address", "127.0.0.1", "--port", "8089", "--verbose"]
 
   aanmeld-stub:
     network_mode: host
     ports: !reset []
-    command: ["--port", "8083", "--verbose", "--global-response-templating"]
+    command: ["--bind-address", "127.0.0.1", "--port", "8083", "--verbose", "--global-response-templating"]
 
   notificatie-stub:
     network_mode: host
     ports: !reset []
-    command: ["--port", "8084", "--verbose", "--global-response-templating"]
+    command: ["--bind-address", "127.0.0.1", "--port", "8084", "--verbose", "--global-response-templating"]
 
   postgres-a:
     network_mode: host
     ports: !reset []
     healthcheck: !reset null
+    command: ["postgres", "-c", "listen_addresses=127.0.0.1"]
 
   # PGPORT verplaatst zowel de server als pg_isready naar 5433; in een gedeelde netns kan de
   # tweede Postgres niet óók op 5432 luisteren.
@@ -65,6 +69,7 @@ services:
     network_mode: host
     ports: !reset []
     healthcheck: !reset null
+    command: ["postgres", "-c", "listen_addresses=127.0.0.1"]
     environment:
       PGPORT: "5433"
 
@@ -75,19 +80,21 @@ services:
     network_mode: host
     ports: !reset []
     healthcheck: !reset null
+    command: ["postgres", "-c", "listen_addresses=127.0.0.1"]
     environment:
       PGPORT: "5434"
 
   toxiproxy:
     network_mode: host
     ports: !reset []
+    command: ["-host=127.0.0.1", "-config=/proxies.json"]
     volumes:
       - ./demo/generated/proxies-host.json:/proxies.json:ro,z
 
   magazijn-stubs:
     network_mode: host
     ports: !reset []
-    command: ["--port", "8092", "--verbose"]
+    command: ["--bind-address", "127.0.0.1", "--port", "8092", "--verbose"]
 
   berichtenmagazijn-a:
     network_mode: host
@@ -96,6 +103,8 @@ services:
       postgres-a:
         condition: service_started
     environment:
+      # 0.0.0.0 uit de basis zou in een gedeelde netns op élke interface van de machine binden.
+      QUARKUS_HTTP_HOST: 127.0.0.1
       DB_JDBC_URL: jdbc:postgresql://127.0.0.1:5432/berichtenmagazijn
       AANMELD_URL: http://127.0.0.1:18086/api/v1/aanmeldingen
       NOTIFICATIE_URL: http://127.0.0.1:18084/events
@@ -108,6 +117,8 @@ services:
       postgres-b:
         condition: service_started
     environment:
+      # 0.0.0.0 uit de basis zou in een gedeelde netns op élke interface van de machine binden.
+      QUARKUS_HTTP_HOST: 127.0.0.1
       # Beide magazijnen luisteren in de basis op 8090; b wijkt hier uit naar zijn eigen poort.
       QUARKUS_HTTP_PORT: "8091"
       DB_JDBC_URL: jdbc:postgresql://127.0.0.1:5433/berichtenmagazijn
@@ -122,6 +133,8 @@ services:
       redis:
         condition: service_started
     environment:
+      # 0.0.0.0 uit de basis zou in een gedeelde netns op élke interface van de machine binden.
+      QUARKUS_HTTP_HOST: 127.0.0.1
       REDIS_HOSTS: redis://127.0.0.1:16379
       MAGAZIJN_A_URL: http://127.0.0.1:18090
       MAGAZIJN_B_URL: http://127.0.0.1:18091
@@ -135,6 +148,8 @@ services:
       redis:
         condition: service_started
     environment:
+      # 0.0.0.0 uit de basis zou in een gedeelde netns op élke interface van de machine binden.
+      QUARKUS_HTTP_HOST: 127.0.0.1
       TOXIPROXY_ADMIN_URL: http://127.0.0.1:8474
       REDIS_HOSTS: redis://127.0.0.1:6379
       UITVRAAG_URL: http://127.0.0.1:8086

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,13 +3,15 @@
 # non-interactief. De zelfgebouwde `fbs-demo/…`-images blijven kaal; compose.podman.yaml zet daar
 # `localhost/` voor.
 #
-# `DEMO_BIND` bepaalt op welk hostadres de stack publiceert; default `127.0.0.1`. Zonder die
-# binding staat de hele demo op élke interface van de machine: Redis zonder wachtwoord, twee
-# PostgreSQL-instanties met demo-credentials en de WireMock-admin-API's. Op een ontwikkelmachine
+# `DEMO_BIND` bepaalt op welk hostadres de stack publiceert; default `127.0.0.1`, en verder wordt
+# alleen `0.0.0.0` ondersteund — `demo/podman-up.sh` controleert elke service over 127.0.0.1 en een
+# specifiek adres laat die controles aflopen. Zonder die binding staat de hele demo op élke
+# interface van de machine: Redis zonder wachtwoord, drie PostgreSQL-instanties met
+# demo-credentials en de WireMock-admin-API's. Op een ontwikkelmachine
 # aan een kantoor- of thuisnetwerk is dat het hele subnet.
 #
-# Wil je de demo aan iemand anders tonen, zet 'm dan bewust open — `DEMO_BIND=0.0.0.0` of een
-# specifiek adres — in plaats van dat het de default is. `demo-console` doet hier NIET aan mee en
+# Wil je de demo aan iemand anders tonen, zet 'm dan bewust open met `DEMO_BIND=0.0.0.0`, in plaats
+# van dat het de default is. `demo-console` doet hier NIET aan mee en
 # blijft altijd op loopback; zie de toelichting daar.
 services:
   redis:

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,11 +2,20 @@
 # impliciet aan, podman alleen met ingestelde `unqualified-search-registries` en faalt anders
 # non-interactief. De zelfgebouwde `fbs-demo/…`-images blijven kaal; compose.podman.yaml zet daar
 # `localhost/` voor.
+#
+# `DEMO_BIND` bepaalt op welk hostadres de stack publiceert; default `127.0.0.1`. Zonder die
+# binding staat de hele demo op élke interface van de machine: Redis zonder wachtwoord, twee
+# PostgreSQL-instanties met demo-credentials en de WireMock-admin-API's. Op een ontwikkelmachine
+# aan een kantoor- of thuisnetwerk is dat het hele subnet.
+#
+# Wil je de demo aan iemand anders tonen, zet 'm dan bewust open — `DEMO_BIND=0.0.0.0` of een
+# specifiek adres — in plaats van dat het de default is. `demo-console` doet hier NIET aan mee en
+# blijft altijd op loopback; zie de toelichting daar.
 services:
   redis:
     image: docker.io/redis/redis-stack-server:7.4.0-v3
     ports:
-      - "6379:6379"
+      - "${DEMO_BIND:-127.0.0.1}:6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s
@@ -16,7 +25,7 @@ services:
   magazijn-a:
     image: docker.io/wiremock/wiremock:3.13.2
     ports:
-      - "8081:8080"
+      - "${DEMO_BIND:-127.0.0.1}:8081:8080"
     volumes:
       - ./wiremock/magazijn-a/mappings:/home/wiremock/mappings
       - ./wiremock/magazijn-a/__files:/home/wiremock/__files
@@ -25,7 +34,7 @@ services:
   magazijn-b:
     image: docker.io/wiremock/wiremock:3.13.2
     ports:
-      - "8082:8080"
+      - "${DEMO_BIND:-127.0.0.1}:8082:8080"
     volumes:
       - ./wiremock/magazijn-b/mappings:/home/wiremock/mappings
       - ./wiremock/magazijn-b/__files:/home/wiremock/__files
@@ -39,7 +48,7 @@ services:
   profiel-service:
     image: docker.io/wiremock/wiremock:3.13.2
     ports:
-      - "8089:8080"
+      - "${DEMO_BIND:-127.0.0.1}:8089:8080"
     volumes:
       # Gedeelde mappings met de ZAD externe-stubs-image (profiel + notificatie). WireMock
       # laadt álle mappings in deze map, dus ook notificatie-events.json (POST /events); lokaal
@@ -61,7 +70,7 @@ services:
   aanmeld-stub:
     image: docker.io/wiremock/wiremock:3.13.2
     ports:
-      - "8083:8080"
+      - "${DEMO_BIND:-127.0.0.1}:8083:8080"
     volumes:
       - ./wiremock/aanmeld-stub/mappings:/home/wiremock/mappings
     command: ["--verbose", "--global-response-templating"]
@@ -69,7 +78,7 @@ services:
   notificatie-stub:
     image: docker.io/wiremock/wiremock:3.13.2
     ports:
-      - "8084:8080"
+      - "${DEMO_BIND:-127.0.0.1}:8084:8080"
     volumes:
       - ./wiremock/notificatie-stub/mappings:/home/wiremock/mappings
     command: ["--verbose", "--global-response-templating"]
@@ -79,7 +88,7 @@ services:
   postgres-uitvraag:
     image: docker.io/library/postgres:18
     ports:
-      - "5434:5432"
+      - "${DEMO_BIND:-127.0.0.1}:5434:5432"
     environment:
       POSTGRES_USER: ldv
       POSTGRES_PASSWORD: ldv
@@ -95,7 +104,7 @@ services:
   postgres-a:
     image: docker.io/library/postgres:18
     ports:
-      - "5432:5432"
+      - "${DEMO_BIND:-127.0.0.1}:5432:5432"
     environment:
       POSTGRES_USER: berichtenmagazijn
       POSTGRES_PASSWORD: berichtenmagazijn
@@ -115,7 +124,7 @@ services:
   postgres-b:
     image: docker.io/library/postgres:18
     ports:
-      - "5433:5432"
+      - "${DEMO_BIND:-127.0.0.1}:5433:5432"
     environment:
       POSTGRES_USER: berichtenmagazijn
       POSTGRES_PASSWORD: berichtenmagazijn
@@ -147,7 +156,7 @@ services:
     image: fbs-demo/fbs-berichtenmagazijn:demo
     profiles: [demo]
     ports:
-      - "8090:8090"
+      - "${DEMO_BIND:-127.0.0.1}:8090:8090"
     depends_on:
       postgres-a:
         condition: service_healthy
@@ -178,7 +187,7 @@ services:
     image: fbs-demo/fbs-berichtenmagazijn:demo
     profiles: [demo]
     ports:
-      - "8091:8090"
+      - "${DEMO_BIND:-127.0.0.1}:8091:8090"
     depends_on:
       postgres-b:
         condition: service_healthy
@@ -204,7 +213,7 @@ services:
     image: ghcr.io/shopify/toxiproxy:2.12.0
     profiles: [demo]
     ports:
-      - "8474:8474"
+      - "${DEMO_BIND:-127.0.0.1}:8474:8474"
     volumes:
       - ./toxiproxy/proxies.json:/proxies.json:ro
     command: ["-host=0.0.0.0", "-config=/proxies.json"]
@@ -216,7 +225,7 @@ services:
     image: docker.io/wiremock/wiremock:3.13.2
     profiles: [demo]
     ports:
-      - "8092:8080"
+      - "${DEMO_BIND:-127.0.0.1}:8092:8080"
     volumes:
       - ./demo/generated/magazijn-stubs-mappings:/home/wiremock/mappings
     command: ["--verbose"]
@@ -225,7 +234,7 @@ services:
     image: fbs-demo/fbs-berichtenuitvraag:demo
     profiles: [demo]
     ports:
-      - "8086:8086"
+      - "${DEMO_BIND:-127.0.0.1}:8086:8086"
     depends_on:
       redis:
         condition: service_healthy
@@ -280,7 +289,7 @@ services:
       # POST /api/demo/legen doet een TRUNCATE op beide magazijn-databases; op 0.0.0.0 is dat
       # vanaf het hele netwerk bereikbaar. De Berichtenbox-UI praat sowieso alleen vanaf
       # localhost (vaste API-basis localhost:8086 plus de CORS-allowlist van de uitvraag).
-      - "127.0.0.1:8095:8095"
+      - "127.0.0.1:8095:8095"  # NIET via DEMO_BIND: zie de toelichting hierboven
     depends_on:
       berichtenmagazijn-a:
         condition: service_started

--- a/demo/environment/federatie/README.md
+++ b/demo/environment/federatie/README.md
@@ -175,6 +175,41 @@ de accept is een expliciete `PUT`. Landt de accept-handtekening daarna niet bij 
 push is best-effort, met begrensde backoff en zonder cron-retry), dan blijft het contract daar
 `proposed` en ziet de outway de grant nooit; het script forceert dan de her-distributie.
 
+## De FBS-applicatie door de keten
+
+Standaard front de inway een `stub-upstream` (http-echo) en praat de demo-stack rechtstreeks met de
+magazijnen. Met drie ingrepen loopt `berichtenuitvraag` bij magazijn-a écht door FSC:
+
+```bash
+# 1. de inway naar het echte magazijn laten wijzen (in plaats van de echo-stub)
+FSC_UPSTREAM_URL=http://127.0.0.1:8090 \
+  ../magazijn-a/deploy/local/publish-service.sh
+
+# 2. contract + grant-hash; schrijft demo/generated/fsc-grants.env
+./contracts/fbs-contracten.sh
+
+# 3. de demo-stack met de uitvraag door de outway van logius
+MODUS=hostnet MAGAZIJN_A_URL=http://127.20.1.5:8443 ../../podman-up.sh
+
+./smoke-keten.sh
+```
+
+`smoke-keten.sh` bewijst het in drie asserts: een bericht dat alleen in magazijn-a bestaat komt via
+de uitvraag terug, er staat een **nieuwe** transactie in beide txlogs, en magazijn-b blijft
+rechtstreeks werken. Die tweede assert is de eigenlijke: zonder nulmeting zou een transactie uit een
+eerdere run de smoke groen houden terwijl het verkeer buiten de outway om ging.
+
+Drie dingen om te weten:
+
+- **`MAGAZIJN_A_URL` moet ook in `%dev` doorwerken.** De demo draait met `QUARKUS_PROFILE=dev`, en
+  een kale `%dev.magazijnen."…".url=http://localhost:8090` overrulet de omgeving. Het ophalen slaagt
+  dan gewoon — alleen langs de verkeerde weg, en het transactielogboek blijft leeg.
+- **De sessiecache maskeert de keten.** Een tweede ophaling voor dezelfde ontvanger komt uit Redis
+  en raakt het magazijn niet; `smoke-keten.sh` gebruikt daarom per run een verse, elfproef-geldige
+  BSN.
+- **`publish-service.sh` werkt een gewijzigde upstream bij**, maar het `servicePublication`-contract
+  blijft staan. Wisselt de dienst van betekenis, dan hoort daar een nieuwe publicatie bij.
+
 ## Een peer toevoegen
 
 1. **`peers.env`** — de peer aan `GASTEN` toevoegen, met zijn `OIN_<peer>` en het volgende vrije

--- a/demo/environment/federatie/contracts/bootstrap.sh
+++ b/demo/environment/federatie/contracts/bootstrap.sh
@@ -188,7 +188,14 @@ bestaande_contracten() {  # hashes van geldige, niet-ingetrokken contracten voor
     return 1
   }
 
-  fsc_grant_actief "$json" "$SERVICE_NAME" "$PROVIDER_OIN" "$CONSUMER_OIN" "$THUMB" | sort
+  # Met eigen melding: `fsc_grant_actief` eindigt op `jq … 2>/dev/null` en heeft geen
+  # fallback-waarde. Antwoordt de manager met 200 maar zonder geldige JSON (een proxy-foutpagina,
+  # een afgekapt antwoord), dan faalt deze pipeline onder `pipefail` en zou de aanroeper zonder
+  # deze tak zwijgend afbreken — de laag erboven meldt dan alleen "contract niet opgezet".
+  fsc_grant_actief "$json" "$SERVICE_NAME" "$PROVIDER_OIN" "$CONSUMER_OIN" "$THUMB" | sort || {
+    echo "FAIL: de contractenlijst van de provider is niet te lezen — geen geldige JSON?" >&2
+    return 1
+  }
 }
 
 BESTAAND="$(bestaande_contracten)" || exit 1

--- a/demo/environment/federatie/contracts/fbs-contracten.sh
+++ b/demo/environment/federatie/contracts/fbs-contracten.sh
@@ -80,7 +80,9 @@ grant_regel_voor() {
   fsc_grant_bruikbaar "$grant" || return 1
 
   naam="$(printf '%s' "$magazijn" | tr '[:lower:]-' '[:upper:]_')"
-  printf '%s_GRANT_HASH=%s\n' "$naam" "$grant"
+  # Escapen voor compose: een kale `$` in dit bestand wordt als variabele-verwijzing gelezen en
+  # vreet de rest van het hash op. Zie fsc_compose_env_waarde.
+  printf '%s_GRANT_HASH=%s\n' "$naam" "$(fsc_compose_env_waarde "$grant")"
 }
 
 for magazijn in $MAGAZIJNEN; do

--- a/demo/environment/federatie/contracts/fbs-contracten.sh
+++ b/demo/environment/federatie/contracts/fbs-contracten.sh
@@ -147,6 +147,16 @@ if [ "$FOUTEN" -eq 0 ]; then
   echo "grant-hashes weggeschreven naar ${GRANTS}."
   echo "FBS-CONTRACTEN OK (${GEDAAN} magazijn(en))."
 else
+  # Ook het BESTAANDE bestand weg. Anders overleeft een grant-hash uit een eerdere federatie een
+  # mislukte run: na `federatie.sh down` (die de volumes wist) en een nieuwe `up` bestaat die grant
+  # niet meer, maar zou de demo-stack er wél mee starten en op elke magazijn-call een
+  # 400 UNKNOWN_GRANT_HASH_IN_HEADER krijgen. Geen bestand = geen FSC-headers = rechtstreeks
+  # verkeer, en dat is een eerlijke uitkomst van een mislukte contract-run.
+  if [ -e "$GRANTS" ]; then
+    rm -f "$GRANTS"
+    echo "grant-hashes uit een eerdere run verwijderd (${GRANTS}); de uitvraag valt terug op rechtstreeks verkeer." >&2
+  fi
+
   echo "FBS-CONTRACTEN ROOD: ${FOUTEN} van $((GEDAAN + FOUTEN)) mislukt." >&2
   exit 1
 fi

--- a/demo/environment/federatie/contracts/fbs-contracten.sh
+++ b/demo/environment/federatie/contracts/fbs-contracten.sh
@@ -3,7 +3,7 @@
 # magazijn, zodat de uitvraag-outway `berichtenmagazijn` bij elk van hen mag afnemen.
 #
 # Wie meedoet staat in peers.env (`UITVRAAG`, `MAGAZIJNEN`, `MAGAZIJN_DIENST`); dit script vertaalt
-# dat naar de peer-blokken en cert-paden en roept per magazijn `bootstrap.sh` aan. Een magazijn
+# dat naar de component-adressen en cert-paden en roept per magazijn `bootstrap.sh` aan. Een magazijn
 # toevoegen is daarmee één naam in `MAGAZIJNEN`.
 #
 # Idempotent, ook zonder lokale state: `bootstrap.sh` leidt uit de contracten zelf af of er al een
@@ -24,6 +24,11 @@ ENVDIR="$(cd "${FEDDIR}/.." && pwd)"
 # shellcheck source=../peers.env
 . "${FEDDIR}/peers.env"
 
+fsc_errlog_init
+# Zet $HAVE_JQ, waar fsc_grant_actief/fsc_grant_hash op leunen. bootstrap.sh doet dit voor zichzelf;
+# sinds dit script zélf het grant-hash afleidt, heeft het de vlag ook nodig.
+fsc_have_jq
+
 : "${UITVRAAG:?geen UITVRAAG in peers.env}"
 : "${MAGAZIJNEN:?geen MAGAZIJNEN in peers.env}"
 : "${MAGAZIJN_DIENST:?geen MAGAZIJN_DIENST in peers.env}"
@@ -37,6 +42,46 @@ CONS_OIN="$(fsc_peer_waarde OIN "$UITVRAAG")"
 
 FOUTEN=0
 GEDAAN=0
+
+# De demo-stack moet het grant-hash kennen om `Fsc-Grant-Hash` te kunnen zetten, en compose kan dat
+# niet uit een draaiende manager halen. Vandaar een gegenereerd env-bestand dat de uitvraag inleest.
+# Naar `.tmp` en pas aan het eind verplaatsen: een half geschreven bestand zou de uitvraag met een
+# grant-hash van het ene magazijn en niets voor het andere laten starten.
+GRANTS="$(cd "${ENVDIR}/.." && pwd)/generated/fsc-grants.env"
+mkdir -p "$(dirname "$GRANTS")"
+: > "$GRANTS.tmp"
+# Eén trap voor beide tijdelijke bestanden: fsc_errlog_init zette er al een op $ERRLOG, en een
+# tweede `trap ... EXIT` vervangt die in plaats van hem aan te vullen.
+trap 'rm -f "$GRANTS.tmp" "$ERRLOG"' EXIT
+
+# Het grant-hash is NIET het contract-hash: de outway routeert op de grant uit `content.grants[]`,
+# en wie het contract-hash op de header zet krijgt structureel 400 UNKNOWN_GRANT_HASH_IN_HEADER.
+CONS_THUMB="$(fsc_outway_thumbprint "${ENVDIR}/${UITVRAAG}/pki/out/${UITVRAAG}/outway/cert.pem")" || {
+  echo "FAIL: kon de outway-thumbprint van '${UITVRAAG}' niet berekenen: $(fsc_last_error)" >&2
+  exit 1
+}
+
+# grant_regel_voor <magazijn> <oin>: één `<PEER>_GRANT_HASH=<hash>`-regel op stdout.
+#
+# De env-naam is de peernaam in hoofdletters: `magazijn-a` -> `MAGAZIJN_A_GRANT_HASH`. Dat is
+# precies de naam die application.properties van de uitvraag leest voor het magazijn met die OIN.
+# Hernoem je een peer in peers.env, dan moet die property mee.
+#
+# De contracten komen van de manager van de CONSUMER: dat is de kant waar de outway zijn grant
+# vandaan haalt. Bij de provider staat hetzelfde contract, maar de uitvraag praat daar niet mee.
+grant_regel_voor() {
+  local magazijn="$1" oin="$2" json contract grant naam
+
+  json="$(fsc_manager_contracts "$ENVDIR" "$UITVRAAG" "$(fsc_component_adres "$CONS_NET" manager)")" || return 1
+  contract="$(fsc_grant_actief "$json" "$MAGAZIJN_DIENST" "$oin" "$CONS_OIN" "$CONS_THUMB" | sort | head -n1)"
+  [ -n "$contract" ] || return 1
+
+  grant="$(fsc_grant_hash "$json" "$contract" "$MAGAZIJN_DIENST" "$CONS_THUMB")"
+  [ -n "$grant" ] || return 1
+
+  naam="$(printf '%s' "$magazijn" | tr '[:lower:]-' '[:upper:]_')"
+  printf '%s_GRANT_HASH=%s\n' "$naam" "$grant"
+}
 
 for magazijn in $MAGAZIJNEN; do
   PROV_NET="$(fsc_peer_waarde NET "$magazijn")"
@@ -77,6 +122,10 @@ for magazijn in $MAGAZIJNEN; do
      FSC_PROVIDER_CA="${ENVDIR}/${magazijn}/pki/internal/${magazijn}/ca/root.pem" \
        "${HERE}/bootstrap.sh"; then
     GEDAAN=$((GEDAAN + 1))
+    grant_regel_voor "$magazijn" "$PROV_OIN" >> "$GRANTS.tmp" || {
+      echo "FAIL: contract staat, maar het grant-hash van ${magazijn} is niet af te leiden." >&2
+      FOUTEN=$((FOUTEN + 1))
+    }
   else
     echo "FAIL: contract ${UITVRAAG} -> ${magazijn} niet opgezet." >&2
     FOUTEN=$((FOUTEN + 1))
@@ -92,6 +141,10 @@ if [ "$GEDAAN" -eq 0 ] && [ "$FOUTEN" -eq 0 ]; then
 fi
 
 if [ "$FOUTEN" -eq 0 ]; then
+  # Overschrijven en niet aanvullen: hashes uit een eerdere run zouden anders blijven staan nadat
+  # een contract is ingetrokken of opnieuw uitgegeven, en de uitvraag zou dan een dode grant sturen.
+  mv "$GRANTS.tmp" "$GRANTS"
+  echo "grant-hashes weggeschreven naar ${GRANTS}."
   echo "FBS-CONTRACTEN OK (${GEDAAN} magazijn(en))."
 else
   echo "FBS-CONTRACTEN ROOD: ${FOUTEN} van $((GEDAAN + FOUTEN)) mislukt." >&2

--- a/demo/environment/federatie/contracts/fbs-contracten.sh
+++ b/demo/environment/federatie/contracts/fbs-contracten.sh
@@ -77,7 +77,7 @@ grant_regel_voor() {
   [ -n "$contract" ] || return 1
 
   grant="$(fsc_grant_hash "$json" "$contract" "$MAGAZIJN_DIENST" "$CONS_THUMB")"
-  [ -n "$grant" ] || return 1
+  fsc_grant_bruikbaar "$grant" || return 1
 
   naam="$(printf '%s' "$magazijn" | tr '[:lower:]-' '[:upper:]_')"
   printf '%s_GRANT_HASH=%s\n' "$naam" "$grant"

--- a/demo/environment/federatie/contracts/fbs-contracten.sh
+++ b/demo/environment/federatie/contracts/fbs-contracten.sh
@@ -158,7 +158,9 @@ else
   # verkeer, en dat is een eerlijke uitkomst van een mislukte contract-run.
   if [ -e "$GRANTS" ]; then
     rm -f "$GRANTS"
-    echo "grant-hashes uit een eerdere run verwijderd (${GRANTS}); de uitvraag valt terug op rechtstreeks verkeer." >&2
+    echo "grant-hashes uit een eerdere run verwijderd (${GRANTS})." >&2
+    echo "  Let op: compose leest env_file bij het AANMAKEN van een container, dus een al draaiende" >&2
+    echo "  uitvraag houdt de oude grant-hash tot je hem hercreëert (demo/podman-up.sh)." >&2
   fi
 
   echo "FBS-CONTRACTEN ROOD: ${FOUTEN} van $((GEDAAN + FOUTEN)) mislukt." >&2

--- a/demo/environment/federatie/contracts/fbs-contracten.sh
+++ b/demo/environment/federatie/contracts/fbs-contracten.sh
@@ -136,6 +136,10 @@ done
 
 # Nul magazijnen is geen succes maar een lege configuratie.
 if [ "$GEDAAN" -eq 0 ] && [ "$FOUTEN" -eq 0 ]; then
+  # Ook hier het oude bestand weg, om dezelfde reden als bij de foutuitgang hieronder: een
+  # grant-hash van een vorige federatie zou anders blijven staan en de demo-stack een dode grant
+  # laten sturen. `MAGAZIJNEN` met alleen spaties komt langs de `:?`-controle hierboven.
+  rm -f "$GRANTS"
   echo "FAIL: MAGAZIJNEN is leeg; er is geen enkel contract opgezet." >&2
   exit 1
 fi

--- a/demo/environment/federatie/federatie.sh
+++ b/demo/environment/federatie/federatie.sh
@@ -351,7 +351,10 @@ case "${1:-}" in
     echo
     echo "listeners in de gedeelde netns:"
     # Stderr apart houden: gevouwen in de lijst zou een foutregel hieronder als wildcard-bind lezen.
-    ALLE="$(ss -ltnH 2>"$ERRLOG" | awk '{print $4}' | sort -u -t: -k2 -n || true)"
+    # Eerst ontdubbelen, dán op poort ordenen. `sort -u -t: -k2 -n` vergelijkt alléén de sleutel,
+    # dus alle listeners op dezelfde poort vallen samen tot één regel — en laat je juist de
+    # wildcard-bind verdwijnen die de controle hieronder moet tonen.
+    ALLE="$(ss -ltnH 2>"$ERRLOG" | awk '{print $4}' | sort -u | sort -t: -k2 -n || true)"
     fsc_warn_errlog "ss faalde"
     if [ -n "$ALLE" ]; then
       printf '%s\n' "$ALLE" | sed 's/^/  /'

--- a/demo/environment/federatie/smoke-contract.sh
+++ b/demo/environment/federatie/smoke-contract.sh
@@ -94,8 +94,11 @@ for magazijn in $MAGAZIJNEN; do
     fi
   done
 
-  if [ -z "$GRANT" ]; then
-    fout "geen grant-hash gevonden — de asserts hieronder kunnen niet draaien"
+  if ! fsc_grant_bruikbaar "$GRANT"; then
+    # Niet `[ -z "$GRANT" ]`: fsc_grant_hash levert bij een mislukking de sentinel `unknown`, en
+    # dan zou deze tak nooit vuren. De asserts hieronder draaien vervolgens met een bogus header en
+    # melden een 400 op het data-pad — wat naar het verkeerde component wijst.
+    fout "geen bruikbaar grant-hash gevonden (${GRANT:-<leeg>}) — de asserts hieronder kunnen niet draaien"
     continue
   fi
 

--- a/demo/environment/federatie/smoke-contract.sh
+++ b/demo/environment/federatie/smoke-contract.sh
@@ -46,6 +46,10 @@ CONS_OIN="$(fsc_peer_waarde OIN "$UITVRAAG")"
 # de inway van de provider.
 OUTWAY="http://$(fsc_component_adres "$CONS_NET" outway):8443"
 
+# Ruimte voor de inway om een gewijzigde upstream op te pikken (zie de lus bij het data-pad).
+UPSTREAM_POGINGEN="${UPSTREAM_POGINGEN:-5}"
+UPSTREAM_WACHT="${UPSTREAM_WACHT:-3}"
+
 # Thumbprint van de consumer-outway — zelfde grootheid als bootstrap.sh gebruikt om een contract
 # te identificeren. Nodig om hier dezelfde matcher (fsc_grant_actief) te kunnen hergebruiken.
 CONS_OUTWAY_CERT="${ENVDIR}/${UITVRAAG}/pki/out/${UITVRAAG}/outway/cert.pem"
@@ -103,6 +107,26 @@ for magazijn in $MAGAZIJNEN; do
   fi
 
   # --- 2. Data-pad --------------------------------------------------------------------------------
+  # De echo-stub moet achter de inway staan: deze assert herkent het antwoord aan de tekst van die
+  # stub. smoke-keten.sh zet daar het échte magazijn neer, dus zonder deze regel hangt de uitkomst
+  # af van welke smoke er het laatst gedraaid heeft.
+  if ! fsc_zet_upstream "$ENVDIR" "$magazijn" "http://stub-upstream:8080" >/dev/null 2>"$ERRLOG"; then
+    fout "kon de stub-upstream van ${magazijn} niet zetten: $(fsc_last_error)"
+  fi
+
+  # Een gewijzigde upstream propageert asynchroon naar de inway: zonder deze lus meet de assert
+  # hieronder nog de vórige upstream. Pollen op de echo-tekst van de stub, want dát is waar de
+  # assert op matcht.
+  POGING=1
+
+  while [ "$POGING" -le "$UPSTREAM_POGINGEN" ]; do
+    curl -sS --noproxy '*' --max-time 10 "${OUTWAY}/" -H "Fsc-Grant-Hash: ${GRANT}" 2>/dev/null \
+      | grep -qF "hello from ${magazijn}" && break
+
+    [ "$POGING" -lt "$UPSTREAM_POGINGEN" ] && sleep "$UPSTREAM_WACHT"
+    POGING=$((POGING + 1))
+  done
+
   # De outway resolvet de grant-hash zelf naar dienst en inway, en haalt daarbij zijn eigen token
   # op. Dat token wordt hier dus niet nagebouwd.
   echo "== 2. data-pad =="

--- a/demo/environment/federatie/smoke-contract.sh
+++ b/demo/environment/federatie/smoke-contract.sh
@@ -52,16 +52,10 @@ CONS_OUTWAY_CERT="${ENVDIR}/${UITVRAAG}/pki/out/${UITVRAAG}/outway/cert.pem"
 CONS_THUMB="$(fsc_outway_thumbprint "$CONS_OUTWAY_CERT")" \
   || { echo "FAIL: kon de outway-thumbprint niet berekenen uit ${CONS_OUTWAY_CERT}: $(fsc_last_error)" >&2; exit 1; }
 
-# manager_json <peer> <net>: de contracten van die peer via zijn interne API. Elke manager luistert
-# op zijn eigen adres, op de standaardpoort 9443.
+# manager_json <peer> <net>: de contracten van die peer via zijn interne API, op het manager-adres
+# binnen zijn eigen /24.
 manager_json() {
-  local peer="$1" net="$2" naam="manager.$1.fsc-test.local" poort=9443
-  curl -sS --fail-with-body --noproxy '*' \
-    --resolve "${naam}:${poort}:$(fsc_component_adres "$net" manager)" \
-    --cert "${ENVDIR}/${peer}/pki/internal/${peer}/manager/cert.pem" \
-    --key  "${ENVDIR}/${peer}/pki/internal/${peer}/manager/key.pem" \
-    --cacert "${ENVDIR}/${peer}/pki/internal/${peer}/ca/root.pem" \
-    "https://${naam}:${poort}/v1/contracts" 2>"$ERRLOG"
+  fsc_manager_contracts "$ENVDIR" "$1" "$(fsc_component_adres "$2" manager)"
 }
 
 for magazijn in $MAGAZIJNEN; do

--- a/demo/environment/federatie/smoke-federatie.sh
+++ b/demo/environment/federatie/smoke-federatie.sh
@@ -226,7 +226,13 @@ done
 # De router opent zijn poort uit de gemounte haproxy-config en postgres drukt zijn bind uit als
 # `listen_addresses=` zonder poort; beide ontsnappen dus aan de extractie uit de overlays.
 VOOR_INFRA=$FOUTEN
-if ! ROUTER_BINDS="$(binds_uit "${HERE}/haproxy.federatie.cfg")" || [ -z "$ROUTER_BINDS" ]; then
+# Alleen de `bind`-regels: `binds_uit` grept élk adres in het bestand, en dat zijn ook de
+# `server s1 <adres>`-backends. Die horen bij de peers, niet bij de router — zonder dit filter zou
+# een liggende inway hier als "de router luistert niet" gemeld worden, en dubbel geteld bovenop de
+# terechte melding uit de peer-lus.
+if ! ROUTER_BINDS="$(grep -E '^[[:space:]]*bind[[:space:]]' "${HERE}/haproxy.federatie.cfg" \
+                       | grep -oE "${FED_RE#^}[0-9]+\.[0-9]+:[0-9]+" | sort -u)" \
+   || [ -z "$ROUTER_BINDS" ]; then
   fout "geen ${FED_PREFIX}-bind leesbaar uit haproxy.federatie.cfg — deze assert meet niets"
 else
   for bind in $ROUTER_BINDS; do
@@ -256,8 +262,12 @@ ok_tenzij "$VOOR_ONBEKEND" "geen onbekende luisteraar binnen ${FED_PREFIX}."
 # rood op gaan zou de assert op termijn versoepeld krijgen. TCP-only; de componenten zijn HTTP/TLS.
 VOOR_BUITEN=$FOUTEN
 # `LISTENERS` leeg is hierboven al gemeld; hier alleen de OK onderdrukken, niet dubbel tellen.
+# Regelgewijs lezen en niet `for adres in $BUITEN`: dat splitst op spaties én globt, en `ss` schrijft
+# een IPv6-wildcard als `*:8080` — bash vervangt dat dan door bestandsnamen uit de huidige map, en
+# juist deze negatieve assert zou daardoor stil verzwakken.
 BUITEN="$(printf '%s\n' "$LISTENERS" | grep -vE "$LOOPBACK_RE" || true)"
-for adres in $BUITEN; do
+while IFS= read -r adres; do
+  [ -n "$adres" ] || continue
   poort="${adres##*:}"
 
   for bind in $VERWACHT_BINDS; do
@@ -266,7 +276,10 @@ for adres in $BUITEN; do
       break
     fi
   done
-done
+done <<EOF
+$BUITEN
+EOF
+
 if [ -n "$LISTENERS" ]; then
   ok_tenzij "$VOOR_BUITEN" "geen federatie-poort luistert buiten loopback (TCP)"
 fi

--- a/demo/environment/federatie/smoke-keten.sh
+++ b/demo/environment/federatie/smoke-keten.sh
@@ -148,7 +148,9 @@ if fsc_zet_upstream "$ENVDIR" magazijn-a "${MAGAZIJN_A_UPSTREAM:-http://127.0.0.
   # De probe gaat door de outway naar `/q/health` — een pad dat het echte magazijn met JSON
   # beantwoordt en de echo-stub met zijn vaste tekst. Zo meten we de keten zelf en niet wat de
   # controller denkt te weten.
-  GRANT="$(sed -n 's/^MAGAZIJN_A_GRANT_HASH=//p' "$(cd "${ENVDIR}/.." && pwd)/generated/fsc-grants.env" 2>/dev/null || true)"
+  # Via de lib-functie en niet met een kale `sed`: het bestand draagt compose-escaping, dus de
+  # dollars staan er verdubbeld in.
+  GRANT="$(fsc_compose_env_lees "$(cd "${ENVDIR}/.." && pwd)/generated/fsc-grants.env" MAGAZIJN_A_GRANT_HASH || true)"
   OUTWAY="http://$(fsc_component_adres "$(fsc_peer_waarde NET "$UITVRAAG")" outway):8443"
   POGING=1
   DOOR=0
@@ -181,11 +183,35 @@ fi
 # dus een rij in beide txlogs. Stond de nulmeting ervóór, dan telde die rij als "nieuw" en kon
 # assert 2 nooit rood worden — ook niet als de uitvraag rechtstreeks met het magazijn praat, wat
 # precies het geval is dat deze smoke moet uitsluiten.
-if [ "$TXLOG_LEESBAAR" -eq 1 ] && VOOR="$(gedeelde_txids)"; then
-  VOOR_OK=1
-else
-  VOOR_OK=0
-  VOOR=""
+# En pas nemen als de txlogs tot stilstand zijn gekomen. De inway/outway schrijven hun record
+# out-of-band via de txlog-API, dus de rij van de probe hierboven kan ná de nulmeting landen en dan
+# als "nieuw" meetellen — dezelfde vals-groen, alleen via een race in plaats van via de ordening.
+VOOR_OK=0
+VOOR=""
+
+if [ "$TXLOG_LEESBAAR" -eq 1 ]; then
+  STABIEL=0
+  POGING=1
+
+  while [ "$POGING" -le "$KETEN_POGINGEN" ]; do
+    HUIDIG="$(gedeelde_txids)" || break
+
+    if [ "$POGING" -gt 1 ] && [ "$HUIDIG" = "$VORIG" ]; then
+      STABIEL=1
+      break
+    fi
+
+    VORIG="$HUIDIG"
+    sleep "$KETEN_WACHT"
+    POGING=$((POGING + 1))
+  done
+
+  if [ "$STABIEL" -eq 1 ]; then
+    VOOR="$HUIDIG"
+    VOOR_OK=1
+  else
+    echo "WAARSCHUWING: de txlogs kwamen niet tot stilstand binnen ${KETEN_POGINGEN} metingen" >&2
+  fi
 fi
 
 # --- 1. Data-pad ---------------------------------------------------------------------------------

--- a/demo/environment/federatie/smoke-keten.sh
+++ b/demo/environment/federatie/smoke-keten.sh
@@ -34,6 +34,10 @@ UITVRAAG_URL="${UITVRAAG_URL:-http://127.0.0.1:8086/api/v1}"
 MAGAZIJN_A_DIRECT="${MAGAZIJN_A_DIRECT:-http://127.0.0.1:8090/api/v1}"
 MAGAZIJN_B_DIRECT="${MAGAZIJN_B_DIRECT:-http://127.0.0.1:8091/api/v1}"
 OPHAAL_TIMEOUT="${OPHAAL_TIMEOUT:-60}"
+# Ruimte voor de inway om een gewijzigde upstream op te pikken; elke poging is een volledige
+# ophaling, dus dit is geen vaste wachttijd maar een bovengrens.
+KETEN_POGINGEN="${KETEN_POGINGEN:-5}"
+KETEN_WACHT="${KETEN_WACHT:-3}"
 
 # Testgegevens. Elke run een VERSE ontvanger, en niet een vaste test-BSN: de uitvraag houdt een
 # sessiecache per ontvanger, dus bij een tweede run zou `_ophalen` uit die cache serveren zonder het
@@ -108,13 +112,29 @@ if PROJECT="$(fsc_compose_project "${ENVDIR}/${GASTHEER}/deploy/local/docker-com
       2>"$ERRLOG" | sort -u
   }
 
+  # Eerst opvangen in variabelen, dan pas vergelijken. In een process substitution is de exitstatus
+  # onzichtbaar: een gestopte postgres of een psql-fout levert dan lege uitvoer met exitcode 0, en
+  # de assert hieronder zou "de uitvraag ging buiten de outway om" melden terwijl het logboek
+  # simpelweg onleesbaar was.
   gedeelde_txids() {
-    comm -12 <(txids "fsc_txlog_$(fsc_peer_var "$UITVRAAG")" out) \
-             <(txids "fsc_txlog_$(fsc_peer_var magazijn-a)" in)
+    local uit in
+    uit="$(txids "fsc_txlog_$(fsc_peer_var "$UITVRAAG")" out)" || {
+      echo "WAARSCHUWING: txlog van ${UITVRAAG} niet leesbaar: $(fsc_last_error)" >&2
+      return 1
+    }
+    in="$(txids "fsc_txlog_$(fsc_peer_var magazijn-a)" in)" || {
+      echo "WAARSCHUWING: txlog van magazijn-a niet leesbaar: $(fsc_last_error)" >&2
+      return 1
+    }
+
+    comm -12 <(printf '%s\n' "$uit") <(printf '%s\n' "$in")
   }
 
-  VOOR="$(gedeelde_txids || true)"
+  # Mislukt de nulmeting, dan mag assert 2 niet "alles is nieuw" concluderen: dat zou juist
+  # vals-groen zijn op een transactie uit een eerdere run.
+  if VOOR="$(gedeelde_txids)"; then VOOR_OK=1; else VOOR_OK=0; VOOR=""; fi
 else
+  VOOR_OK=0
   VOOR=""
 fi
 
@@ -122,11 +142,40 @@ fi
 # gebruiker laten: `smoke-federatie.sh` publiceert de dienst met de echo-stub als upstream, dus wie
 # die smoke ná het instellen draait, zet 'm ongemerkt terug. De publicatie is idempotent.
 echo "== 0. inway wijst naar het echte magazijn =="
-if FSC_CONTROLLER="https://controller.magazijn-a.fsc-test.local:9444" \
-   FSC_MANAGER="https://manager.magazijn-a.fsc-test.local:9443" \
-   FSC_UPSTREAM_URL="${MAGAZIJN_A_UPSTREAM:-http://127.0.0.1:8090}" \
-     "${ENVDIR}/magazijn-a/deploy/local/publish-service.sh" >/dev/null 2>"$ERRLOG"; then
-  ok "upstream van de inway staat op ${MAGAZIJN_A_UPSTREAM:-http://127.0.0.1:8090}"
+if fsc_zet_upstream "$ENVDIR" magazijn-a "${MAGAZIJN_A_UPSTREAM:-http://127.0.0.1:8090}" \
+     >/dev/null 2>"$ERRLOG"; then
+  # De dienstwijziging propageert asynchroon naar de inway; de eerste calls erna komen nog bij de
+  # vórige upstream uit. Hier uitwachten en niet in assert 1: die mag maar één keer ophalen, want
+  # daarna serveert de sessiecache en meet een tweede poging niets meer.
+  #
+  # De probe gaat door de outway naar `/q/health` — een pad dat het echte magazijn met JSON
+  # beantwoordt en de echo-stub met zijn vaste tekst. Zo meten we de keten zelf en niet wat de
+  # controller denkt te weten.
+  GRANT="$(sed -n 's/^MAGAZIJN_A_GRANT_HASH=//p' "$(cd "${ENVDIR}/.." && pwd)/generated/fsc-grants.env" 2>/dev/null || true)"
+  OUTWAY="http://$(fsc_component_adres "$(fsc_peer_waarde NET "$UITVRAAG")" outway):8443"
+  POGING=1
+  DOOR=0
+
+  if ! fsc_grant_bruikbaar "$GRANT"; then
+    fout "geen bruikbaar grant-hash in demo/generated/fsc-grants.env — draai contracts/fbs-contracten.sh"
+  else
+    while [ "$POGING" -le "$KETEN_POGINGEN" ]; do
+      if curl -sS --noproxy '*' --max-time 10 -H "Fsc-Grant-Hash: ${GRANT}" \
+           "${OUTWAY}/q/health" 2>"$ERRLOG" | grep -q '"status"'; then
+        DOOR=1
+        break
+      fi
+
+      [ "$POGING" -lt "$KETEN_POGINGEN" ] && sleep "$KETEN_WACHT"
+      POGING=$((POGING + 1))
+    done
+
+    if [ "$DOOR" -eq 1 ]; then
+      ok "upstream van de inway staat op ${MAGAZIJN_A_UPSTREAM:-http://127.0.0.1:8090} (na ${POGING} poging(en))"
+    else
+      fout "de inway levert na ${KETEN_POGINGEN} pogingen nog niet het echte magazijn — upstream niet doorgedrongen"
+    fi
+  fi
 else
   fout "kon de upstream van magazijn-a niet zetten: $(fsc_last_error)"
 fi
@@ -140,6 +189,9 @@ if [ "$CODE" != "201" ] && [ "$CODE" != "200" ]; then
 else
   ok "bericht '${MERK}' aangeleverd bij magazijn-a (HTTP ${CODE})"
 
+  # Eén ophaling, bewust. Herproberen kan niet: de eerste ophaling vult de sessiecache voor deze
+  # ontvanger, en elke volgende komt daaruit zonder het magazijn nog te bellen. Een tweede poging
+  # zou dus niets nieuws meten en assert 2 juist rood maken.
   if ! ophalen; then
     fout "ophalen bij de uitvraag mislukte: $(fsc_last_error)"
   else
@@ -160,8 +212,11 @@ fi
 echo "== 2. verantwoording in beide txlogs =="
 if [ -z "${PROJECT:-}" ]; then
   fout "projectnaam van de gastheer niet af te leiden — deze assert heeft niets gemeten"
+elif [ "$VOOR_OK" -ne 1 ]; then
+  fout "de nulmeting op de txlogs mislukte — deze assert heeft niets gemeten"
+elif ! NA="$(gedeelde_txids)"; then
+  fout "de txlogs zijn na afloop niet leesbaar — deze assert heeft niets gemeten"
 else
-  NA="$(gedeelde_txids || true)"
   NIEUW="$(comm -13 <(printf '%s\n' "$VOOR") <(printf '%s\n' "$NA") | grep -c . || true)"
 
   if [ "${NIEUW:-0}" -gt 0 ]; then

--- a/demo/environment/federatie/smoke-keten.sh
+++ b/demo/environment/federatie/smoke-keten.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Smoke: bewijst dat de FBS-keten écht door FSC loopt — berichtenuitvraag haalt een bericht op bij
+# berichtenmagazijn-a via outway -> router -> inway, in plaats van rechtstreeks.
+#
+#   1. data-pad — een bericht dat alleen in de database van magazijn-a bestaat, komt via de
+#      uitvraag terug. Een 200 op zichzelf zegt niets: de inhoud moet uniek zijn voor deze run,
+#      anders kan een oud bericht uit de cache of een stub de assert groen houden;
+#   2. verantwoording — dezelfde transactie staat in beide txlogs, uitgaand bij de uitvraag-peer en
+#      inkomend bij het magazijn. Dit onderscheidt "door de keten" van "toevallig hetzelfde
+#      antwoord": ging de call rechtstreeks, dan groeit geen van beide logboeken;
+#   3. het niet-FSC-pad blijft werken — magazijn-b loopt rechtstreeks en mag hier niet door sneuvelen.
+#
+# Voorwaarden:
+#   - de federatie draait en het contract staat  -> ./federatie.sh up && contracts/fbs-contracten.sh
+#   - magazijn-a's inway wijst naar het ECHTE magazijn, niet naar de stub:
+#       FSC_UPSTREAM_URL=http://127.0.0.1:8090 ../magazijn-a/deploy/local/publish-service.sh
+#   - de demo-stack draait met de uitvraag door de outway:
+#       MODUS=hostnet MAGAZIJN_A_URL=http://127.20.1.5:8443 demo/podman-up.sh
+#
+# Linux + podman: gebruikt `podman` en `curl`.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ENVDIR="$(cd "${HERE}/.." && pwd)"
+
+# shellcheck source=../lib/fsc-harness.sh
+. "${ENVDIR}/lib/fsc-harness.sh"
+# shellcheck source=peers.env
+. "${HERE}/peers.env"
+
+fsc_errlog_init
+
+UITVRAAG_URL="${UITVRAAG_URL:-http://127.0.0.1:8086/api/v1}"
+MAGAZIJN_A_DIRECT="${MAGAZIJN_A_DIRECT:-http://127.0.0.1:8090/api/v1}"
+MAGAZIJN_B_DIRECT="${MAGAZIJN_B_DIRECT:-http://127.0.0.1:8091/api/v1}"
+OPHAAL_TIMEOUT="${OPHAAL_TIMEOUT:-60}"
+
+# Testgegevens. Elke run een VERSE ontvanger, en niet een vaste test-BSN: de uitvraag houdt een
+# sessiecache per ontvanger, dus bij een tweede run zou `_ophalen` uit die cache serveren zonder het
+# magazijn ooit te bellen. Assert 1 blijft dan groen terwijl de keten stuk kan zijn, en assert 2
+# ziet geen nieuwe transactie. De BSN moet door de elfproef komen, anders weigert het magazijn hem
+# en leest dat als een ketenfout.
+nieuwe_bsn() {
+  local cijfers som i c laatste
+
+  while :; do
+    cijfers=""; som=0
+
+    for i in 9 8 7 6 5 4 3 2; do
+      # Eerste cijfer nooit 0: een BSN met een voorloopnul is negen tekens lang maar wordt door
+      # sommige parsers als achtcijferig gelezen.
+      if [ "$i" -eq 9 ]; then c=$((RANDOM % 9 + 1)); else c=$((RANDOM % 10)); fi
+      cijfers="${cijfers}${c}"
+      som=$((som + c * i))
+    done
+
+    # Het negende cijfer telt met gewicht -1; bestaat er geen passend cijfer 0-9, dan opnieuw.
+    for laatste in 0 1 2 3 4 5 6 7 8 9; do
+      if [ $(( (som - laatste) % 11 )) -eq 0 ]; then
+        printf '%s%s' "$cijfers" "$laatste"
+        return 0
+      fi
+    done
+  done
+}
+
+BSN="${KETEN_BSN:-$(nieuwe_bsn)}"
+AFZENDER_OIN="$(fsc_peer_waarde OIN magazijn-a)"
+
+FOUTEN=0
+fout() { echo "FAIL: $*" >&2; FOUTEN=$((FOUTEN + 1)); }
+ok()   { echo "OK: $*"; }
+
+command -v curl >/dev/null 2>&1 || { echo "FAIL: 'curl' is vereist." >&2; exit 1; }
+
+# Uniek per run: zonder dat kan een bericht uit een eerdere run, of uit de sessiecache, deze smoke
+# groen houden terwijl de keten stuk is.
+MERK="ketensmoke-$$-$(od -An -N4 -tu4 < /dev/urandom | tr -d ' ')"
+
+aanleveren() {  # <magazijn-basis-url> <onderwerp>
+  curl -sS -o /dev/null -w '%{http_code}' --noproxy '*' --max-time 20 \
+    -X POST "$1/berichten" -H 'Content-Type: application/json' \
+    -d "{\"afzender\":\"${AFZENDER_OIN}\",\"ontvanger\":{\"type\":\"BSN\",\"waarde\":\"${BSN}\"},\"onderwerp\":\"$2\",\"inhoud\":\"$2\"}" \
+    2>"$ERRLOG"
+}
+
+# ophalen: vult de sessiecache van de uitvraag uit de magazijnen. Dit is de call die door de outway
+# gaat; `_ophalen` is een SSE-stream, dus we lezen 'm met een harde timeout leeg.
+ophalen() {
+  curl -sS -o /dev/null --noproxy '*' --max-time "$OPHAAL_TIMEOUT" \
+    -H "X-Ontvanger: BSN:${BSN}" -H 'Accept: text/event-stream' \
+    "${UITVRAAG_URL}/berichten/_ophalen" 2>"$ERRLOG"
+}
+
+berichten() {
+  curl -sS --noproxy '*' --max-time 20 -H "X-Ontvanger: BSN:${BSN}" \
+    "${UITVRAAG_URL}/berichten" 2>"$ERRLOG"
+}
+
+# De txlog-meting hieronder telt alleen transacties die DEZE run veroorzaakt. Een eerdere
+# smoke-contract-run laat namelijk ook een gedeelde transactie achter; zonder nulmeting zou deze
+# smoke groen blijven terwijl de uitvraag rechtstreeks naar het magazijn ging.
+if PROJECT="$(fsc_compose_project "${ENVDIR}/${GASTHEER}/deploy/local/docker-compose.yaml")"; then
+  txids() {  # <db> <richting>
+    podman exec "${PROJECT}-postgres-1" psql -U postgres -d "$1" -tA \
+      -c "SELECT transaction_id FROM transactionlog.records
+          WHERE direction = '$2' AND service_name = '${MAGAZIJN_DIENST}' AND grant_hash IS NOT NULL" \
+      2>"$ERRLOG" | sort -u
+  }
+
+  gedeelde_txids() {
+    comm -12 <(txids "fsc_txlog_$(fsc_peer_var "$UITVRAAG")" out) \
+             <(txids "fsc_txlog_$(fsc_peer_var magazijn-a)" in)
+  }
+
+  VOOR="$(gedeelde_txids || true)"
+else
+  VOOR=""
+fi
+
+# --- 1. Data-pad ---------------------------------------------------------------------------------
+echo "== 1. bericht uit magazijn-a via de FSC-keten =="
+CODE="$(aanleveren "$MAGAZIJN_A_DIRECT" "$MERK")" || CODE=""
+
+if [ "$CODE" != "201" ] && [ "$CODE" != "200" ]; then
+  fout "aanleveren bij magazijn-a gaf HTTP ${CODE:-<geen>}: $(fsc_last_error) — draait de demo-stack?"
+else
+  ok "bericht '${MERK}' aangeleverd bij magazijn-a (HTTP ${CODE})"
+
+  if ! ophalen; then
+    fout "ophalen bij de uitvraag mislukte: $(fsc_last_error)"
+  else
+    LIJST="$(berichten)" || LIJST=""
+
+    if printf '%s' "$LIJST" | grep -qF "$MERK"; then
+      ok "de uitvraag levert het bericht van magazijn-a terug"
+    else
+      fout "het bericht '${MERK}' zit niet in de uitvraag-lijst — kwam de keten niet rond? $(fsc_last_error)"
+    fi
+  fi
+fi
+
+# --- 2. Verantwoording ---------------------------------------------------------------------------
+# Zelfde meting als smoke-contract.sh, maar nu over verkeer dat de ÁPPLICATIE veroorzaakte in
+# plaats van een handmatige curl. Ging de uitvraag rechtstreeks naar het magazijn, dan staat er
+# niets in de txlogs en valt dat hier op.
+echo "== 2. verantwoording in beide txlogs =="
+if [ -z "${PROJECT:-}" ]; then
+  fout "projectnaam van de gastheer niet af te leiden — deze assert heeft niets gemeten"
+else
+  NA="$(gedeelde_txids || true)"
+  NIEUW="$(comm -13 <(printf '%s\n' "$VOOR") <(printf '%s\n' "$NA") | grep -c . || true)"
+
+  if [ "${NIEUW:-0}" -gt 0 ]; then
+    ok "${NIEUW} nieuwe transactie(s) in beide txlogs, uitgaand bij ${UITVRAAG} en inkomend bij magazijn-a"
+  else
+    fout "geen NIEUWE gedeelde transactie-id — de uitvraag ging buiten de outway om (of het ophalen leverde niets op)"
+  fi
+fi
+
+# --- 3. Het niet-FSC-pad ------------------------------------------------------------------------
+# magazijn-b loopt rechtstreeks. Zonder deze assert zou een omzetting die alle magazijnen door FSC
+# dwingt (of het rechtstreekse pad sloopt) hier ongemerkt doorheen komen.
+echo "== 3. magazijn-b blijft rechtstreeks werken =="
+CODE_B="$(aanleveren "$MAGAZIJN_B_DIRECT" "${MERK}-b")" || CODE_B=""
+
+if [ "$CODE_B" = "201" ] || [ "$CODE_B" = "200" ]; then
+  ok "magazijn-b neemt een bericht aan buiten FSC om (HTTP ${CODE_B})"
+else
+  fout "magazijn-b gaf HTTP ${CODE_B:-<geen>}: $(fsc_last_error)"
+fi
+
+echo
+if [ "$FOUTEN" -eq 0 ]; then
+  echo "== KETEN-SMOKE GROEN =="
+else
+  echo "== KETEN-SMOKE ROOD: ${FOUTEN} bevinding(en) ==" >&2
+  exit 1
+fi

--- a/demo/environment/federatie/smoke-keten.sh
+++ b/demo/environment/federatie/smoke-keten.sh
@@ -130,12 +130,9 @@ if PROJECT="$(fsc_compose_project "${ENVDIR}/${GASTHEER}/deploy/local/docker-com
     comm -12 <(printf '%s\n' "$uit") <(printf '%s\n' "$in")
   }
 
-  # Mislukt de nulmeting, dan mag assert 2 niet "alles is nieuw" concluderen: dat zou juist
-  # vals-groen zijn op een transactie uit een eerdere run.
-  if VOOR="$(gedeelde_txids)"; then VOOR_OK=1; else VOOR_OK=0; VOOR=""; fi
+  TXLOG_LEESBAAR=1
 else
-  VOOR_OK=0
-  VOOR=""
+  TXLOG_LEESBAAR=0
 fi
 
 # De inway moet naar het ECHTE magazijn wijzen. Dat hier afdwingen en niet als voorwaarde aan de
@@ -178,6 +175,17 @@ if fsc_zet_upstream "$ENVDIR" magazijn-a "${MAGAZIJN_A_UPSTREAM:-http://127.0.0.
   fi
 else
   fout "kon de upstream van magazijn-a niet zetten: $(fsc_last_error)"
+fi
+
+# Nulmeting NA stap 0, niet ervoor: die probe gaat zelf door de outway naar de inway en schrijft
+# dus een rij in beide txlogs. Stond de nulmeting ervóór, dan telde die rij als "nieuw" en kon
+# assert 2 nooit rood worden — ook niet als de uitvraag rechtstreeks met het magazijn praat, wat
+# precies het geval is dat deze smoke moet uitsluiten.
+if [ "$TXLOG_LEESBAAR" -eq 1 ] && VOOR="$(gedeelde_txids)"; then
+  VOOR_OK=1
+else
+  VOOR_OK=0
+  VOOR=""
 fi
 
 # --- 1. Data-pad ---------------------------------------------------------------------------------

--- a/demo/environment/federatie/smoke-keten.sh
+++ b/demo/environment/federatie/smoke-keten.sh
@@ -118,6 +118,19 @@ else
   VOOR=""
 fi
 
+# De inway moet naar het ECHTE magazijn wijzen. Dat hier afdwingen en niet als voorwaarde aan de
+# gebruiker laten: `smoke-federatie.sh` publiceert de dienst met de echo-stub als upstream, dus wie
+# die smoke ná het instellen draait, zet 'm ongemerkt terug. De publicatie is idempotent.
+echo "== 0. inway wijst naar het echte magazijn =="
+if FSC_CONTROLLER="https://controller.magazijn-a.fsc-test.local:9444" \
+   FSC_MANAGER="https://manager.magazijn-a.fsc-test.local:9443" \
+   FSC_UPSTREAM_URL="${MAGAZIJN_A_UPSTREAM:-http://127.0.0.1:8090}" \
+     "${ENVDIR}/magazijn-a/deploy/local/publish-service.sh" >/dev/null 2>"$ERRLOG"; then
+  ok "upstream van de inway staat op ${MAGAZIJN_A_UPSTREAM:-http://127.0.0.1:8090}"
+else
+  fout "kon de upstream van magazijn-a niet zetten: $(fsc_last_error)"
+fi
+
 # --- 1. Data-pad ---------------------------------------------------------------------------------
 echo "== 1. bericht uit magazijn-a via de FSC-keten =="
 CODE="$(aanleveren "$MAGAZIJN_A_DIRECT" "$MERK")" || CODE=""

--- a/demo/environment/lib/fsc-harness.sh
+++ b/demo/environment/lib/fsc-harness.sh
@@ -140,6 +140,31 @@ fsc_zet_upstream() {
     "$1/$2/deploy/local/publish-service.sh"
 }
 
+# fsc_compose_env_waarde <waarde>: waarde zoals hij in een `env_file` van docker compose moet staan.
+#
+# Compose interpoleert een env_file: `$NAAM` wordt vervangen door een variabele uit de omgeving, en
+# een onbekende naam door niets. FSC-grant-hashes hebben de vorm `$1$<n>$<base64url>`, dus het deel
+# ná de derde `$` wordt opgeslokt zodra het met een letter of underscore begint — 53 van de 64
+# base64url-tekens. Gemeten in een container: `$1$4$k4rwlWTsCM_j89Fc3nrbnQa9-KB43` komt aan als
+# `$1$4-KB43`, en de outway antwoordt dan 400 UNKNOWN_GRANT_HASH_IN_HEADER.
+#
+# Verdubbelen is compose' eigen escape voor een letterlijke `$`. Dat maakt het bestand
+# compose-specifiek: lees het niet met `set -a; . bestand`, want dan houd je de dubbele tekens.
+fsc_compose_env_waarde() {
+  printf '%s' "${1//\$/\$\$}"
+}
+
+# fsc_compose_env_lees <bestand> <naam>: de ONGE-escapete waarde van `naam` uit een compose-env_file.
+#
+# Tegenhanger van fsc_compose_env_waarde. Wie zo'n bestand met `sed`/`grep` uitleest krijgt de
+# verdubbelde dollars mee en stuurt die door — bij een grant-hash levert dat een 400 op de outway,
+# terwijl het bestand er goed uitziet. Altijd via deze functie lezen.
+fsc_compose_env_lees() {
+  local waarde
+  waarde="$(sed -n "s/^$2=//p" "$1" 2>/dev/null | head -n1)" || return 1
+  printf '%s' "${waarde//\$\$/\$}"
+}
+
 # fsc_grant_bruikbaar <hash>: is dit een echt grant-hash?
 #
 # fsc_grant_hash levert bij een mislukking de string `unknown` in plaats van een lege waarde, zodat

--- a/demo/environment/lib/fsc-harness.sh
+++ b/demo/environment/lib/fsc-harness.sh
@@ -188,6 +188,24 @@ fsc_peer_waarde() {
 # fsc_alle_peers: gastheer + gasten uit peers.env, in opstartvolgorde.
 fsc_alle_peers() { printf '%s %s' "$GASTHEER" "$GASTEN"; }
 
+# fsc_manager_contracts <envdir> <peer> <adres>: de contracten van een peer via zijn INTERNE
+# manager-API, met het internal-cert van diezelfde peer. De naam staat niet in /etc/hosts
+# (`extra_hosts` geldt alleen binnen containers), vandaar `--resolve` op het meegegeven adres.
+#
+# Hier en niet in één van de aanroepers, omdat zowel de contract-bootstrap als de smokes deze
+# lijst nodig hebben: twee kopieën zouden uiteen kunnen lopen in cert-pad of poort, en dan meet de
+# smoke iets anders dan de bootstrap doet.
+fsc_manager_contracts() {
+  local envdir="$1" peer="$2" adres="$3" naam="manager.$2.fsc-test.local"
+
+  curl -sS --fail-with-body --noproxy '*' \
+    --resolve "${naam}:9443:${adres}" \
+    --cert "${envdir}/${peer}/pki/internal/${peer}/manager/cert.pem" \
+    --key  "${envdir}/${peer}/pki/internal/${peer}/manager/key.pem" \
+    --cacert "${envdir}/${peer}/pki/internal/${peer}/ca/root.pem" \
+    "https://${naam}:9443/v1/contracts" 2>"$ERRLOG"
+}
+
 # fsc_component_adres <net> <component>: het adres van een component binnen het /24 van een peer,
 # bv. `fsc_component_adres 127.20.2 inway` -> `127.20.2.4`. De octetten liggen vast en zijn voor
 # élke peer gelijk, zodat een adres af te lezen is zonder de overlay erbij te halen.

--- a/demo/environment/lib/fsc-harness.sh
+++ b/demo/environment/lib/fsc-harness.sh
@@ -126,6 +126,20 @@ fsc_grant_hash() {
     | ($g[0] // "unknown")' 2>/dev/null || echo unknown
 }
 
+# fsc_zet_upstream <envdir> <peer> <upstream-url>: publiceer de dienst van die peer (opnieuw) met
+# deze upstream achter de inway. Idempotent — bestaat de dienst al met dezelfde upstream, dan doet
+# publish-service.sh niets.
+#
+# Elke smoke die over het data-pad iets beweert, hoort dit zelf te zetten in plaats van het als
+# voorwaarde op te schrijven: smoke-contract.sh toetst de echo van de stub, smoke-keten.sh het
+# échte magazijn, en wie ze na elkaar draait zou anders de ene de andere zien omgooien.
+fsc_zet_upstream() {
+  FSC_CONTROLLER="https://controller.$2.fsc-test.local:9444" \
+  FSC_MANAGER="https://manager.$2.fsc-test.local:9443" \
+  FSC_UPSTREAM_URL="$3" \
+    "$1/$2/deploy/local/publish-service.sh"
+}
+
 # fsc_grant_bruikbaar <hash>: is dit een echt grant-hash?
 #
 # fsc_grant_hash levert bij een mislukking de string `unknown` in plaats van een lege waarde, zodat

--- a/demo/environment/lib/fsc-harness.sh
+++ b/demo/environment/lib/fsc-harness.sh
@@ -126,6 +126,17 @@ fsc_grant_hash() {
     | ($g[0] // "unknown")' 2>/dev/null || echo unknown
 }
 
+# fsc_grant_bruikbaar <hash>: is dit een echt grant-hash?
+#
+# fsc_grant_hash levert bij een mislukking de string `unknown` in plaats van een lege waarde, zodat
+# een aanroeper die 'm alleen toont iets leesbaars afdrukt. Een kale `[ -n "$hash" ]` is daardoor
+# geen geldige controle: die slaagt óók op de sentinel, en dan reist `Fsc-Grant-Hash: unknown` mee
+# naar de outway, die er een 400 op geeft. Vandaar één predicaat in plaats van de vergelijking op
+# elke plek los over te typen.
+fsc_grant_bruikbaar() {
+  [ -n "${1:-}" ] && [ "$1" != unknown ]
+}
+
 # --- contract-matching (gedeeld door contracts/bootstrap.sh en federatie/smoke-contract.sh) ----
 # Eén matcher voor "is dit contract geldig en van toepassing op deze serviceConnection", zodat
 # beide scripts niet elk hun eigen (en dus potentieel afwijkende) criteria hanteren.

--- a/demo/environment/lib/test-federatie-helpers.sh
+++ b/demo/environment/lib/test-federatie-helpers.sh
@@ -90,6 +90,32 @@ else
   ok "grant_bruikbaar verwerpt een ontbrekend argument"
 fi
 
+# --- fsc_compose_env_waarde ---------------------------------------------------------------------
+# Een kale `$` in een env_file wordt door compose als variabele-verwijzing gelezen; bij een
+# grant-hash (`$1$<n>$<base64url>`) verdwijnt daardoor het hele middenstuk en antwoordt de outway
+# 400. Gemeten in een container: `$1$4$k4rw…` kwam aan als `$1$4-KB43`.
+[ "$(fsc_compose_env_waarde '$1$4$k4rwlWTsCM_j89Fc3nrbnQa9-KB43')" = '$$1$$4$$k4rwlWTsCM_j89Fc3nrbnQa9-KB43' ] \
+  && ok "compose_env_waarde verdubbelt elke dollar in een grant-hash" \
+  || fout "compose_env_waarde verdubbelt de dollars niet (compose vreet dan het hash op)"
+
+[ "$(fsc_compose_env_waarde 'geen-dollars-hier')" = 'geen-dollars-hier' ] \
+  && ok "compose_env_waarde laat een waarde zonder dollars ongemoeid" \
+  || fout "compose_env_waarde muteert een waarde zonder dollars"
+
+[ "$(fsc_compose_env_waarde '')" = '' ] \
+  && ok "compose_env_waarde levert leeg op leeg" || fout "compose_env_waarde muteert een lege waarde"
+
+# Heen en terug: wat de schrijffunctie erin zet, moet de leesfunctie er ongeschonden uit halen.
+# Zonder die symmetrie stuurt een lezer de verdubbelde dollars door en krijgt hij een 400.
+printf 'MAGAZIJN_A_GRANT_HASH=%s\n' "$(fsc_compose_env_waarde '$1$3$_AKXojkq-Nn07')" > "$WERK/grants.env"
+[ "$(fsc_compose_env_lees "$WERK/grants.env" MAGAZIJN_A_GRANT_HASH)" = '$1$3$_AKXojkq-Nn07' ] \
+  && ok "compose_env_lees haalt eruit wat compose_env_waarde erin zette" \
+  || fout "compose_env_waarde/-lees zijn niet symmetrisch (de lezer stuurt dan dubbele dollars door)"
+
+[ -z "$(fsc_compose_env_lees "$WERK/grants.env" BESTAAT_NIET)" ] \
+  && ok "compose_env_lees levert leeg voor een onbekende naam" \
+  || fout "compose_env_lees levert niet-leeg voor een onbekende naam"
+
 # --- fsc_compose_project ------------------------------------------------------------------------
 printf 'name: fsc-magazijna\nservices:\n  x: {}\n' > "$WERK/goed.yaml"
 [ "$(fsc_compose_project "$WERK/goed.yaml")" = "fsc-magazijna" ] \

--- a/demo/environment/lib/test-federatie-helpers.sh
+++ b/demo/environment/lib/test-federatie-helpers.sh
@@ -66,6 +66,30 @@ else
   ok "component_adres faalt hard op een leeg net"
 fi
 
+# --- fsc_grant_bruikbaar ------------------------------------------------------------------------
+# De sentinel is het hele punt: fsc_grant_hash geeft `unknown` terug in plaats van leeg, en een
+# aanroeper die op leegte toetst schrijft die string door naar de Fsc-Grant-Hash-header.
+fsc_grant_bruikbaar '$1$3$abc' \
+  && ok "grant_bruikbaar accepteert een echt hash" || fout "grant_bruikbaar verwerpt een echt hash"
+
+if fsc_grant_bruikbaar unknown; then
+  fout "grant_bruikbaar accepteert de sentinel 'unknown' (die belandt dan op de header)"
+else
+  ok "grant_bruikbaar verwerpt de sentinel 'unknown'"
+fi
+
+if fsc_grant_bruikbaar ""; then
+  fout "grant_bruikbaar accepteert een lege waarde"
+else
+  ok "grant_bruikbaar verwerpt een lege waarde"
+fi
+
+if fsc_grant_bruikbaar; then
+  fout "grant_bruikbaar accepteert een ontbrekend argument"
+else
+  ok "grant_bruikbaar verwerpt een ontbrekend argument"
+fi
+
 # --- fsc_compose_project ------------------------------------------------------------------------
 printf 'name: fsc-magazijna\nservices:\n  x: {}\n' > "$WERK/goed.yaml"
 [ "$(fsc_compose_project "$WERK/goed.yaml")" = "fsc-magazijna" ] \

--- a/demo/environment/logius/deploy/local/publish-service.sh
+++ b/demo/environment/logius/deploy/local/publish-service.sh
@@ -19,7 +19,10 @@ GROUP_ID="moza-fbs-test"
 # overrulebaar, met de standalone-waarde als default. Geprefixt met FSC_ omdat een kale `MANAGER=`
 # in iemands shell anders stilzwijgend een mTLS-call mét het internal-cert van deze peer naar een
 # vreemd endpoint zou sturen.
-STUB_URL="${FSC_STUB_URL:-http://stub-upstream:8080}"
+# De dienst wijst naar de upstream die de inway fronter. In de kale harness is dat de
+# http-echo-stub; zodra de echte applicatie erachter hangt, is het die. FSC_STUB_URL blijft als
+# oude naam werken zodat bestaande aanroepen niet stilvallen.
+UPSTREAM_URL="${FSC_UPSTREAM_URL:-${FSC_STUB_URL:-http://stub-upstream:8080}}"
 
 # shellcheck disable=SC2034  # gelezen door fsc_tb() uit de caller-scope (lib/fsc-harness.sh).
 CERT=/pki/internal/logius/manager/cert.pem
@@ -41,14 +44,14 @@ case "$MANAGER" in
   *) echo "FAIL: FSC_MANAGER moet met https:// beginnen: '${MANAGER}'" >&2; exit 2 ;;
 esac
 
-# STUB_URL gaat ongeëscaped een handgebouwde JSON-body in (CreateService, hieronder). Een
+# UPSTREAM_URL gaat ongeëscaped een handgebouwde JSON-body in (CreateService, hieronder). Een
 # aanhalingsteken zou daar uit de string breken en velden kunnen toevoegen.
-case "$STUB_URL" in
+case "$UPSTREAM_URL" in
   http://*|https://*) ;;
-  *) echo "FAIL: FSC_STUB_URL moet met http:// of https:// beginnen: '${STUB_URL}'" >&2; exit 2 ;;
+  *) echo "FAIL: FSC_UPSTREAM_URL moet met http:// of https:// beginnen: '${UPSTREAM_URL}'" >&2; exit 2 ;;
 esac
-case "$STUB_URL" in
-  *'"'*|*'\'*) echo "FAIL: FSC_STUB_URL bevat een aanhalingsteken of backslash." >&2; exit 2 ;;
+case "$UPSTREAM_URL" in
+  *'"'*|*'\'*) echo "FAIL: FSC_UPSTREAM_URL bevat een aanhalingsteken of backslash." >&2; exit 2 ;;
 esac
 
 # Vang curl-/toolbox-stderr op i.p.v. weg te gooien: een mTLS-/netwerk-/dode-container-fout
@@ -77,7 +80,7 @@ if fsc_tb "$CONTROLLER/v1/services" | grep -q "\"$SERVICE_NAME\""; then
   echo "  bestaat al, skip create."
 else
   fsc_tb -X POST "$CONTROLLER/v1/services" -H 'Content-Type: application/json' \
-     -d "{\"name\":\"$SERVICE_NAME\",\"endpoint_url\":\"$STUB_URL\",\"inway_address\":\"$INWAY_ADDR\"}"
+     -d "{\"name\":\"$SERVICE_NAME\",\"endpoint_url\":\"$UPSTREAM_URL\",\"inway_address\":\"$INWAY_ADDR\"}"
   echo "  aangemaakt."
 fi
 

--- a/demo/environment/logius/deploy/local/publish-service.sh
+++ b/demo/environment/logius/deploy/local/publish-service.sh
@@ -76,8 +76,19 @@ done
 echo "  inway_address=$INWAY_ADDR"
 
 echo "publish: $SERVICE_NAME aanmaken (idempotent)..."
-if fsc_tb "$CONTROLLER/v1/services" | grep -q "\"$SERVICE_NAME\""; then
-  echo "  bestaat al, skip create."
+BESTAAND="$(fsc_tb "$CONTROLLER/v1/services" || true)"
+if printf '%s' "$BESTAAND" | grep -q "\"$SERVICE_NAME\""; then
+  # Bestaat al — maar met wélke upstream? Zonder deze controle wisselt een run met een andere
+  # FSC_UPSTREAM_URL stilzwijgend niets, en blijft de inway naar de oude upstream wijzen terwijl
+  # het script "klaar" meldt. Dat kost je een half uur zoeken in de verkeerde hoek.
+  if printf '%s' "$BESTAAND" | grep -q "\"endpoint_url\":\"$UPSTREAM_URL\""; then
+    echo "  bestaat al met dezelfde upstream, skip create."
+  else
+    echo "  bestaat al maar met een andere upstream; bijwerken naar ${UPSTREAM_URL}..."
+    fsc_tb -X PUT "$CONTROLLER/v1/services/$SERVICE_NAME" -H 'Content-Type: application/json' \
+       -d "{\"name\":\"$SERVICE_NAME\",\"endpoint_url\":\"$UPSTREAM_URL\",\"inway_address\":\"$INWAY_ADDR\"}"
+    echo "  bijgewerkt."
+  fi
 else
   fsc_tb -X POST "$CONTROLLER/v1/services" -H 'Content-Type: application/json' \
      -d "{\"name\":\"$SERVICE_NAME\",\"endpoint_url\":\"$UPSTREAM_URL\",\"inway_address\":\"$INWAY_ADDR\"}"

--- a/demo/environment/logius/deploy/local/publish-service.sh
+++ b/demo/environment/logius/deploy/local/publish-service.sh
@@ -10,7 +10,15 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 source "$HERE/../../../lib/fsc-harness.sh"
 
 # Zet $HAVE_JQ; de vergelijking van de bestaande upstream leest de controller-JSON met jq.
+#
+# Meteen hard falen en niet pas bij de vergelijking: die tak wordt alleen geraakt als de dienst al
+# bestaat, dus zonder deze controle slaagt de eerste run op een machine zonder jq en faalt elke
+# volgende — een verschil dat je aan het script niet ziet.
 fsc_have_jq
+[ "$HAVE_JQ" -eq 1 ] || {
+  echo "FAIL: jq is vereist; dit script vergelijkt de bestaande upstream met de controller-JSON." >&2
+  exit 1
+}
 
 # shellcheck disable=SC2034  # gelezen door fsc_tb() uit de caller-scope (lib/fsc-harness.sh).
 COMPOSE=(docker compose -f "$HERE/docker-compose.yaml")
@@ -87,13 +95,8 @@ if printf '%s' "$BESTAAND" | grep -q "\"$SERVICE_NAME\""; then
   #
   # Met jq en niet met grep: een grep-patroon over JSON breekt zodra het antwoord met spaties wordt
   # opgemaakt, en de URL zou als regex worden gelezen (een punt matcht dan elk teken).
-  if [ "$HAVE_JQ" -eq 1 ]; then
-    HUIDIGE_URL="$(printf '%s' "$BESTAAND" \
-      | jq -r --arg n "$SERVICE_NAME" '.services[]? | select(.name == $n) | .endpoint_url' 2>/dev/null || true)"
-  else
-    echo "FAIL: jq is vereist om de bestaande upstream te vergelijken." >&2
-    exit 1
-  fi
+  HUIDIGE_URL="$(printf '%s' "$BESTAAND" \
+    | jq -r --arg n "$SERVICE_NAME" '.services[]? | select(.name == $n) | .endpoint_url' 2>/dev/null || true)"
 
   if [ "$HUIDIGE_URL" = "$UPSTREAM_URL" ]; then
     echo "  bestaat al met dezelfde upstream, skip create."

--- a/demo/environment/logius/deploy/local/publish-service.sh
+++ b/demo/environment/logius/deploy/local/publish-service.sh
@@ -9,6 +9,9 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=../../../lib/fsc-harness.sh
 source "$HERE/../../../lib/fsc-harness.sh"
 
+# Zet $HAVE_JQ; de vergelijking van de bestaande upstream leest de controller-JSON met jq.
+fsc_have_jq
+
 # shellcheck disable=SC2034  # gelezen door fsc_tb() uit de caller-scope (lib/fsc-harness.sh).
 COMPOSE=(docker compose -f "$HERE/docker-compose.yaml")
 SERVICE_NAME="profiel-service"
@@ -81,10 +84,21 @@ if printf '%s' "$BESTAAND" | grep -q "\"$SERVICE_NAME\""; then
   # Bestaat al — maar met wélke upstream? Zonder deze controle wisselt een run met een andere
   # FSC_UPSTREAM_URL stilzwijgend niets, en blijft de inway naar de oude upstream wijzen terwijl
   # het script "klaar" meldt. Dat kost je een half uur zoeken in de verkeerde hoek.
-  if printf '%s' "$BESTAAND" | grep -q "\"endpoint_url\":\"$UPSTREAM_URL\""; then
+  #
+  # Met jq en niet met grep: een grep-patroon over JSON breekt zodra het antwoord met spaties wordt
+  # opgemaakt, en de URL zou als regex worden gelezen (een punt matcht dan elk teken).
+  if [ "$HAVE_JQ" -eq 1 ]; then
+    HUIDIGE_URL="$(printf '%s' "$BESTAAND" \
+      | jq -r --arg n "$SERVICE_NAME" '.services[]? | select(.name == $n) | .endpoint_url' 2>/dev/null || true)"
+  else
+    echo "FAIL: jq is vereist om de bestaande upstream te vergelijken." >&2
+    exit 1
+  fi
+
+  if [ "$HUIDIGE_URL" = "$UPSTREAM_URL" ]; then
     echo "  bestaat al met dezelfde upstream, skip create."
   else
-    echo "  bestaat al maar met een andere upstream; bijwerken naar ${UPSTREAM_URL}..."
+    echo "  bestaat al met upstream ${HUIDIGE_URL:-<onbekend>}; bijwerken naar ${UPSTREAM_URL}..."
     fsc_tb -X PUT "$CONTROLLER/v1/services/$SERVICE_NAME" -H 'Content-Type: application/json' \
        -d "{\"name\":\"$SERVICE_NAME\",\"endpoint_url\":\"$UPSTREAM_URL\",\"inway_address\":\"$INWAY_ADDR\"}"
     echo "  bijgewerkt."

--- a/demo/environment/magazijn-a/deploy/local/publish-service.sh
+++ b/demo/environment/magazijn-a/deploy/local/publish-service.sh
@@ -19,7 +19,10 @@ GROUP_ID="moza-fbs-test"                 # = GROUP_ID env-var op de manager; als
 # overrulebaar, met de standalone-waarde als default. Geprefixt met FSC_ omdat een kale `MANAGER=`
 # in iemands shell anders stilzwijgend een mTLS-call mét het internal-cert van deze peer naar een
 # vreemd endpoint zou sturen.
-STUB_URL="${FSC_STUB_URL:-http://stub-upstream:8080}"
+# De dienst wijst naar de upstream die de inway fronter. In de kale harness is dat de
+# http-echo-stub; zodra de echte applicatie erachter hangt, is het die. FSC_STUB_URL blijft als
+# oude naam werken zodat bestaande aanroepen niet stilvallen.
+UPSTREAM_URL="${FSC_UPSTREAM_URL:-${FSC_STUB_URL:-http://stub-upstream:8080}}"
 
 # shellcheck disable=SC2034  # gelezen door fsc_tb() uit de caller-scope (lib/fsc-harness.sh).
 CERT=/pki/internal/magazijn-a/manager/cert.pem
@@ -41,14 +44,14 @@ case "$MANAGER" in
   *) echo "FAIL: FSC_MANAGER moet met https:// beginnen: '${MANAGER}'" >&2; exit 2 ;;
 esac
 
-# STUB_URL gaat ongeëscaped een handgebouwde JSON-body in (CreateService, hieronder). Een
+# UPSTREAM_URL gaat ongeëscaped een handgebouwde JSON-body in (CreateService, hieronder). Een
 # aanhalingsteken zou daar uit de string breken en velden kunnen toevoegen.
-case "$STUB_URL" in
+case "$UPSTREAM_URL" in
   http://*|https://*) ;;
-  *) echo "FAIL: FSC_STUB_URL moet met http:// of https:// beginnen: '${STUB_URL}'" >&2; exit 2 ;;
+  *) echo "FAIL: FSC_UPSTREAM_URL moet met http:// of https:// beginnen: '${UPSTREAM_URL}'" >&2; exit 2 ;;
 esac
-case "$STUB_URL" in
-  *'"'*|*'\'*) echo "FAIL: FSC_STUB_URL bevat een aanhalingsteken of backslash." >&2; exit 2 ;;
+case "$UPSTREAM_URL" in
+  *'"'*|*'\'*) echo "FAIL: FSC_UPSTREAM_URL bevat een aanhalingsteken of backslash." >&2; exit 2 ;;
 esac
 
 # Vang curl-/toolbox-stderr op i.p.v. weg te gooien: een mTLS-/netwerk-/dode-container-fout
@@ -77,7 +80,7 @@ if fsc_tb "$CONTROLLER/v1/services" | grep -q "\"$SERVICE_NAME\""; then
   echo "  bestaat al, skip create."
 else
   fsc_tb -X POST "$CONTROLLER/v1/services" -H 'Content-Type: application/json' \
-     -d "{\"name\":\"$SERVICE_NAME\",\"endpoint_url\":\"$STUB_URL\",\"inway_address\":\"$INWAY_ADDR\"}"
+     -d "{\"name\":\"$SERVICE_NAME\",\"endpoint_url\":\"$UPSTREAM_URL\",\"inway_address\":\"$INWAY_ADDR\"}"
   echo "  aangemaakt."
 fi
 

--- a/demo/environment/magazijn-a/deploy/local/publish-service.sh
+++ b/demo/environment/magazijn-a/deploy/local/publish-service.sh
@@ -9,6 +9,9 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=../../../lib/fsc-harness.sh
 source "$HERE/../../../lib/fsc-harness.sh"
 
+# Zet $HAVE_JQ; de vergelijking van de bestaande upstream leest de controller-JSON met jq.
+fsc_have_jq
+
 # shellcheck disable=SC2034  # gelezen door fsc_tb() uit de caller-scope (lib/fsc-harness.sh).
 COMPOSE=(docker compose -f "$HERE/docker-compose.yaml")
 SERVICE_NAME="berichtenmagazijn"
@@ -81,10 +84,21 @@ if printf '%s' "$BESTAAND" | grep -q "\"$SERVICE_NAME\""; then
   # Bestaat al — maar met wélke upstream? Zonder deze controle wisselt een run met een andere
   # FSC_UPSTREAM_URL stilzwijgend niets, en blijft de inway naar de oude upstream wijzen terwijl
   # het script "klaar" meldt. Dat kost je een half uur zoeken in de verkeerde hoek.
-  if printf '%s' "$BESTAAND" | grep -q "\"endpoint_url\":\"$UPSTREAM_URL\""; then
+  #
+  # Met jq en niet met grep: een grep-patroon over JSON breekt zodra het antwoord met spaties wordt
+  # opgemaakt, en de URL zou als regex worden gelezen (een punt matcht dan elk teken).
+  if [ "$HAVE_JQ" -eq 1 ]; then
+    HUIDIGE_URL="$(printf '%s' "$BESTAAND" \
+      | jq -r --arg n "$SERVICE_NAME" '.services[]? | select(.name == $n) | .endpoint_url' 2>/dev/null || true)"
+  else
+    echo "FAIL: jq is vereist om de bestaande upstream te vergelijken." >&2
+    exit 1
+  fi
+
+  if [ "$HUIDIGE_URL" = "$UPSTREAM_URL" ]; then
     echo "  bestaat al met dezelfde upstream, skip create."
   else
-    echo "  bestaat al maar met een andere upstream; bijwerken naar ${UPSTREAM_URL}..."
+    echo "  bestaat al met upstream ${HUIDIGE_URL:-<onbekend>}; bijwerken naar ${UPSTREAM_URL}..."
     fsc_tb -X PUT "$CONTROLLER/v1/services/$SERVICE_NAME" -H 'Content-Type: application/json' \
        -d "{\"name\":\"$SERVICE_NAME\",\"endpoint_url\":\"$UPSTREAM_URL\",\"inway_address\":\"$INWAY_ADDR\"}"
     echo "  bijgewerkt."

--- a/demo/environment/magazijn-a/deploy/local/publish-service.sh
+++ b/demo/environment/magazijn-a/deploy/local/publish-service.sh
@@ -76,8 +76,19 @@ done
 echo "  inway_address=$INWAY_ADDR"
 
 echo "publish: $SERVICE_NAME aanmaken (idempotent)..."
-if fsc_tb "$CONTROLLER/v1/services" | grep -q "\"$SERVICE_NAME\""; then
-  echo "  bestaat al, skip create."
+BESTAAND="$(fsc_tb "$CONTROLLER/v1/services" || true)"
+if printf '%s' "$BESTAAND" | grep -q "\"$SERVICE_NAME\""; then
+  # Bestaat al — maar met wélke upstream? Zonder deze controle wisselt een run met een andere
+  # FSC_UPSTREAM_URL stilzwijgend niets, en blijft de inway naar de oude upstream wijzen terwijl
+  # het script "klaar" meldt. Dat kost je een half uur zoeken in de verkeerde hoek.
+  if printf '%s' "$BESTAAND" | grep -q "\"endpoint_url\":\"$UPSTREAM_URL\""; then
+    echo "  bestaat al met dezelfde upstream, skip create."
+  else
+    echo "  bestaat al maar met een andere upstream; bijwerken naar ${UPSTREAM_URL}..."
+    fsc_tb -X PUT "$CONTROLLER/v1/services/$SERVICE_NAME" -H 'Content-Type: application/json' \
+       -d "{\"name\":\"$SERVICE_NAME\",\"endpoint_url\":\"$UPSTREAM_URL\",\"inway_address\":\"$INWAY_ADDR\"}"
+    echo "  bijgewerkt."
+  fi
 else
   fsc_tb -X POST "$CONTROLLER/v1/services" -H 'Content-Type: application/json' \
      -d "{\"name\":\"$SERVICE_NAME\",\"endpoint_url\":\"$UPSTREAM_URL\",\"inway_address\":\"$INWAY_ADDR\"}"

--- a/demo/environment/magazijn-a/deploy/local/publish-service.sh
+++ b/demo/environment/magazijn-a/deploy/local/publish-service.sh
@@ -10,7 +10,15 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 source "$HERE/../../../lib/fsc-harness.sh"
 
 # Zet $HAVE_JQ; de vergelijking van de bestaande upstream leest de controller-JSON met jq.
+#
+# Meteen hard falen en niet pas bij de vergelijking: die tak wordt alleen geraakt als de dienst al
+# bestaat, dus zonder deze controle slaagt de eerste run op een machine zonder jq en faalt elke
+# volgende — een verschil dat je aan het script niet ziet.
 fsc_have_jq
+[ "$HAVE_JQ" -eq 1 ] || {
+  echo "FAIL: jq is vereist; dit script vergelijkt de bestaande upstream met de controller-JSON." >&2
+  exit 1
+}
 
 # shellcheck disable=SC2034  # gelezen door fsc_tb() uit de caller-scope (lib/fsc-harness.sh).
 COMPOSE=(docker compose -f "$HERE/docker-compose.yaml")
@@ -87,13 +95,8 @@ if printf '%s' "$BESTAAND" | grep -q "\"$SERVICE_NAME\""; then
   #
   # Met jq en niet met grep: een grep-patroon over JSON breekt zodra het antwoord met spaties wordt
   # opgemaakt, en de URL zou als regex worden gelezen (een punt matcht dan elk teken).
-  if [ "$HAVE_JQ" -eq 1 ]; then
-    HUIDIGE_URL="$(printf '%s' "$BESTAAND" \
-      | jq -r --arg n "$SERVICE_NAME" '.services[]? | select(.name == $n) | .endpoint_url' 2>/dev/null || true)"
-  else
-    echo "FAIL: jq is vereist om de bestaande upstream te vergelijken." >&2
-    exit 1
-  fi
+  HUIDIGE_URL="$(printf '%s' "$BESTAAND" \
+    | jq -r --arg n "$SERVICE_NAME" '.services[]? | select(.name == $n) | .endpoint_url' 2>/dev/null || true)"
 
   if [ "$HUIDIGE_URL" = "$UPSTREAM_URL" ]; then
     echo "  bestaat al met dezelfde upstream, skip create."

--- a/demo/podman-prepare.sh
+++ b/demo/podman-prepare.sh
@@ -33,7 +33,12 @@ trap 'rm -f "$REGISTER.tmp" "$PROXIES.tmp"' EXIT
 # zijn eigen invoerbestand kan lezen én erin schrijven.
 sed 's|http://magazijn-stubs:8080|http://127.0.0.1:8092|g' "$REGISTER" > "$REGISTER.tmp"
 
-sed -e 's|"berichtenmagazijn-a:8090"|"127.0.0.1:8090"|' \
+# `listen` gaat mee van 0.0.0.0 naar 127.0.0.1: in een gedeelde netns bindt een wildcard op élke
+# interface van de machine, en achter deze proxies zitten Redis en de magazijn-API's. Bovendien
+# botst een wildcard-bind met elke specifieke bind op dezelfde poort — bijvoorbeeld van een
+# FSC-federatie die in dezelfde netns draait.
+sed -e 's|"listen": "0\.0\.0\.0:|"listen": "127.0.0.1:|g' \
+    -e 's|"berichtenmagazijn-a:8090"|"127.0.0.1:8090"|' \
     -e 's|"berichtenmagazijn-b:8090"|"127.0.0.1:8091"|' \
     -e 's|"redis:6379"|"127.0.0.1:6379"|' \
     -e 's|"profiel-service:8080"|"127.0.0.1:8089"|' \
@@ -87,8 +92,8 @@ fi
 # Een listen-adres op een containernaam laadt Toxiproxy niet (`Failed to populate proxies`), en dan
 # staat er een gezonde proxy-loze Toxiproxy die elke naïeve probe groen laat.
 if grep -o '"listen": *"[^"]*"' "$PROXIES.tmp" |
-   grep -vE '"listen": *"(0\.0\.0\.0|127\.0\.0\.1):[0-9]+"' >&2; then
-    echo "FOUT: bovenstaande toxiproxy-listen-adressen zijn geen IP:poort." >&2
+   grep -vE '"listen": *"127\.0\.0\.1:[0-9]+"' >&2; then
+    echo "FOUT: bovenstaande toxiproxy-listen-adressen staan niet op 127.0.0.1." >&2
     exit 1
 fi
 

--- a/demo/podman-up.sh
+++ b/demo/podman-up.sh
@@ -19,7 +19,8 @@
 #   DEMO_HOST=10.0.0.5 demo/podman-up.sh
 #
 # DEMO_HOST is het adres waarop je de demo benadert (voor de CORS-allowlist van de uitvraag);
-# default localhost.
+# default localhost. De poorten zelf blijven op loopback — zie DEMO_BIND in compose.yaml, en de
+# toelichting bij de laatste controle onderaan dit script.
 set -euo pipefail
 
 WORTEL="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -380,10 +381,15 @@ wacht_op "console"             demo-console        curl -sSf --max-time 3 http:/
 # (migraties, vier tegelijk verbindende clients) en is sinds de vorige controle niet meer bekeken.
 vereis_draaiend "${INFRA[@]}" "${SERVICES[@]}"
 
-# Alle probes hierboven lopen over 127.0.0.1; is de demo op een ander adres aangekondigd, dan is
-# dát het adres dat moet werken (firewall, of hostnet in een VM waar niets naar buiten komt).
+# Bewust GEEN probe op $DEMO_HOST: het bedieningspaneel bindt altijd op loopback (geen
+# authenticatie, en POST /api/demo/legen doet een TRUNCATE op beide magazijn-databases). Een probe
+# op een ander adres zou dus per definitie aflopen op een timeout en de start laten falen terwijl
+# de stack gezond draait. DEMO_HOST stuurt alleen de CORS-allowlist en de URL's hieronder; om er
+# van een andere machine bij te kunnen heb je een tunnel nodig, bijvoorbeeld
+# `ssh -L 8095:127.0.0.1:8095 <host>`.
 if [ "$DEMO_HOST" != "localhost" ]; then
-    wacht_op "console op $DEMO_HOST" demo-console curl -sSf --max-time 3 "http://${DEMO_HOST}:8095/"
+    echo "Let op: het bedieningspaneel luistert alleen op 127.0.0.1. DEMO_HOST zet de CORS-allowlist;"
+    echo "       tunnel poort 8095 (en 8086) als je er vanaf ${DEMO_HOST} bij wilt."
 fi
 
 echo

--- a/demo/podman-up.sh
+++ b/demo/podman-up.sh
@@ -28,6 +28,19 @@ cd "$WORTEL"
 
 export DEMO_HOST="${DEMO_HOST:-localhost}"
 
+# DEMO_BIND stuurt op welk hostadres compose publiceert (zie compose.yaml). Alleen loopback of de
+# wildcard: elke controle in dit script gaat over 127.0.0.1, en dat adres blijft bij beide
+# bereikbaar. Bij een specifiek adres (`DEMO_BIND=10.0.0.5`) zouden die probes 180 seconden lang
+# aflopen en de start laten falen terwijl de stack gezond draait.
+case "${DEMO_BIND:-127.0.0.1}" in
+    127.0.0.1|0.0.0.0) ;;
+    *)
+        echo "FOUT: DEMO_BIND='${DEMO_BIND}' wordt niet ondersteund; gebruik 127.0.0.1 (default) of 0.0.0.0." >&2
+        echo "      De controles in dit script gaan over 127.0.0.1; een specifiek adres laat ze aflopen." >&2
+        exit 2
+        ;;
+esac
+
 # Doorgeven aan compose én aan de generator vanaf één plek; beide hebben hun eigen default.
 export DEMO_MAGAZIJN_STUBS="${DEMO_MAGAZIJN_STUBS:-12}"
 
@@ -393,5 +406,11 @@ if [ "$DEMO_HOST" != "localhost" ]; then
 fi
 
 echo
-echo "Draait ($MODUS). Bedieningspaneel: http://${DEMO_HOST}:8095/"
-echo "                 Berichtenbox:    http://${DEMO_HOST}:8095/berichtenbox.html"
+# Bewust de loopback-URL en niet ${DEMO_HOST}: het bedieningspaneel bindt alleen op 127.0.0.1, dus
+# een kopieerbare regel met een ander adres wijst naar iets dat niet bestaat.
+echo "Draait ($MODUS). Bedieningspaneel: http://127.0.0.1:8095/"
+echo "                 Berichtenbox:    http://127.0.0.1:8095/berichtenbox.html"
+
+if [ "$DEMO_HOST" != "localhost" ]; then
+    echo "                 (vanaf ${DEMO_HOST}: tunnel eerst 8095 en 8086 naar deze machine)"
+fi

--- a/docs/demo-runbook.md
+++ b/docs/demo-runbook.md
@@ -121,10 +121,16 @@ Forceren kan met `MODUS=bridge` of `MODUS=hostnet`. Buiten Linux wordt `hostnet`
 automatisch gekozen: podman draait daar in een VM, dus de gedeelde namespace is die van de VM en
 zonder gepubliceerde poorten komt er niets door naar je werkplek.
 
-In `hostnet` delen alle containers één netwerknamespace. De zes Toxiproxy-proxy-listeners, die in
-`bridge` alleen intern bestonden, staan dan open op elk adres van de machine. Draai deze modus dus
-alleen op een vertrouwd netwerk. (De poorten die `compose.yaml` publiceert, waaronder alle drie de
-Postgres-instanties, binden ook in `bridge` al op alle interfaces.)
+In `hostnet` delen alle containers één netwerknamespace: de zes Toxiproxy-proxy-listeners, die in
+`bridge` alleen intern bestonden, zijn dan ook op de machine zelf zichtbaar. Ze binden — net als
+alle andere services in deze modus — op `127.0.0.1`, dus ze zijn niet van buiten de machine
+bereikbaar. Een CI-job (`demo-stack-op-loopback`) bewaakt dat: elke listener in de gerenderde merge
+moet op loopback staan, anders faalt de build.
+
+Dat is geen detail van deze modus maar de eis die hem werkbaar maakt. In een gedeelde namespace is
+een wildcard-bind (`0.0.0.0`) de hele machine — Redis zonder wachtwoord, drie PostgreSQL-instanties
+met demo-credentials — en botst hij bovendien met elke specifieke bind op dezelfde poort, zoals die
+van een FSC-federatie die in dezelfde namespace draait.
 
 Botst een van die poorten met iets dat al draait, dan hangt het van de poort af hoe dat zich
 uit. Een service die zelf niet kan binden stopt, en het script meldt welke container dat is mét

--- a/docs/demo-runbook.md
+++ b/docs/demo-runbook.md
@@ -84,6 +84,26 @@ demo/podman-up.sh                        # kiest zelf de werkbare netwerkmodus
 DEMO_HOST=10.0.0.5 demo/podman-up.sh     # ander adres dan localhost in de CORS-allowlist
 ```
 
+De stack luistert standaard **alleen op `127.0.0.1`**: zonder die grens staan Redis (zonder
+wachtwoord), drie PostgreSQL-instanties met demo-credentials en de WireMock-admin-API's op elke
+interface van de machine — op een kantoor- of thuisnetwerk dus voor het hele subnet.
+
+Wil je de demo aan iemand anders tonen, dan zet je hem bewust open, en heb je **beide** variabelen
+nodig: `DEMO_BIND` voor de poorten en `DEMO_HOST` voor de CORS-allowlist.
+
+```bash
+DEMO_BIND=0.0.0.0 DEMO_HOST=10.0.0.5 demo/podman-up.sh
+```
+
+Twee beperkingen daarbij:
+
+- **`DEMO_BIND` geldt alleen in bridge-modus.** In `hostnet` publiceert compose geen poorten en
+  binden de containers zelf; die staan vast op loopback, want in een gedeelde netns is een
+  wildcard-bind de hele machine — en botst hij bovendien met elke specifieke bind van een
+  FSC-federatie in dezelfde netns.
+- **Het bedieningspaneel blijft altijd op loopback** (`demo-console`, poort 8095): het heeft geen
+  authenticatie en zijn `POST /api/demo/legen` doet een TRUNCATE op beide magazijn-databases.
+
 Het script zoekt de podman-API-socket (start hem zo nodig), kiest een compose-implementatie en
 controleert dat die de gestapelde bestanden aankan, controleert dat de drie demo-images gebouwd
 zijn, genereert de stub-artefacten, en controleert na elke start dat elke container draait. Redis,

--- a/docs/demo-runbook.md
+++ b/docs/demo-runbook.md
@@ -95,6 +95,10 @@ nodig: `DEMO_BIND` voor de poorten en `DEMO_HOST` voor de CORS-allowlist.
 DEMO_BIND=0.0.0.0 DEMO_HOST=10.0.0.5 demo/podman-up.sh
 ```
 
+`DEMO_BIND` kent maar twee waarden: `127.0.0.1` (default) en `0.0.0.0`. Een specifiek adres wordt
+geweigerd, omdat elke controle in `podman-up.sh` over 127.0.0.1 loopt en anders afloopt op een
+timeout terwijl de stack gezond draait.
+
 Twee beperkingen daarbij:
 
 - **`DEMO_BIND` geldt alleen in bridge-modus.** In `hostnet` publiceert compose geen poorten en

--- a/docs/plans/2026-08-13-b2-implementatieplan.md
+++ b/docs/plans/2026-08-13-b2-implementatieplan.md
@@ -1,6 +1,6 @@
 # B2 implementatieplan: de FBS-keten lokaal door FSC
 
-**Status:** Concept
+**Status:** Uitgevoerd
 
 **Doel:** `berichtenuitvraag` haalt bij magazijn-a op via outway → router → inway →
 `berichtenmagazijn-a`, lokaal, met bewijs dat de data uit dat magazijn komt en dat de transactie in

--- a/docs/plans/2026-08-13-b2-implementatieplan.md
+++ b/docs/plans/2026-08-13-b2-implementatieplan.md
@@ -1,0 +1,183 @@
+# B2 implementatieplan: de FBS-keten lokaal door FSC
+
+**Status:** Concept
+
+**Doel:** `berichtenuitvraag` haalt bij magazijn-a op via outway → router → inway →
+`berichtenmagazijn-a`, lokaal, met bewijs dat de data uit dat magazijn komt en dat de transactie in
+beide txlogs staat.
+
+**Spec:** `docs/plans/2026-08-13-b2-lokale-fsc-keten-uitvraag-magazijn.md`
+
+**Aanpak:** Bedrading, geen applicatiecode. De FSC-laag komt uit #197 (adres per component) en #200
+(contract + grant-hash); de FBS-laag uit `compose.yaml`. Wat ontbreekt is dat ze op één machine
+naast elkaar kunnen draaien en dat de drie koppelpunten (inway-upstream, outway-URL, grant-hash)
+gezet worden.
+
+**Stack:** bash, docker/podman compose, OpenFSC v2.5.2, Quarkus.
+
+## Globale randvoorwaarden
+
+- Federatie op `127.20.0.0/16`, één adres per component, standaardpoorten. Demo-stack op
+  `127.0.0.1`.
+- De outway spreekt **plain HTTP** op zijn listener — vastgesteld uit `smoke-contract.sh` van #200
+  (`OUTWAY="http://127.0.0.1:$((CONS_BLOK + 40))"`). Lokaal wordt dat `http://127.20.1.5:8443`.
+- Elke shell-wijziging blijft door `shellcheck -x -S warning`.
+- Geen enkele listener buiten loopback, in beide stacks.
+
+## Volgorde en afhankelijkheden
+
+Taak 1 is een enabler op de branch van #200; taak 2 t/m 5 staan op `feature/b2-lokale-fsc-keten`,
+die daarna op #200 gerebased wordt.
+
+---
+
+### Taak 1: #200 naar het adresmodel
+
+**Waarom:** #200 staat op de oude #197 en rekent op tien plekken met `BLOK`. Zonder deze stap kan
+B2 niet draaien, want de contract-bootstrap levert het grant-hash.
+
+**Bestanden:**
+- Rebase: `feature/782-fsc-contract-magazijn-uitvraag` op `feature/fsc-lokale-federatie-harness`
+- Wijzig: `demo/environment/federatie/contracts/fbs-contracten.sh` (regels 31–72)
+- Wijzig: `demo/environment/federatie/smoke-contract.sh` (regels 41–186)
+
+**Stappen:**
+
+- [ ] 1.1 Rebase de #200-branch op de nieuwe #197-kop. Conflicten in `peers.env`, de twee
+      `compose/*.yaml`, `haproxy.federatie.cfg`, `smoke-federatie.sh`, `merge-guard.sh` en
+      `fsc-harness-overlays.yml` lost je op ten gunste van **onze** kant (het adresmodel); de
+      bestanden die alleen #200 toevoegt (`contracts/*`, `smoke-contract.sh`) neem je ongewijzigd
+      over.
+- [ ] 1.2 In `fbs-contracten.sh`: `fsc_peer_waarde BLOK` → `fsc_peer_waarde NET`, en de
+      manager-URL's `…:$((BLOK + 1))` → `…:9443`. De variabelen heten dan `CONS_NET`/`PROV_NET` en
+      worden alleen nog gebruikt voor de foutmelding bij een ontbrekende peer.
+- [ ] 1.3 In `smoke-contract.sh`: `OUTWAY="http://127.0.0.1:$((CONS_BLOK + 40))"` →
+      `OUTWAY="http://$(fsc_component_adres "$CONS_NET" outway):8443"`. De helper `manager_json`
+      krijgt het net in plaats van het blok: `poort=9443`, en
+      `--resolve "${naam}:9443:$(fsc_component_adres "$net" manager)"`.
+- [ ] 1.4 De `--resolve "${INWAY_NAAM}:443:127.0.0.1"` op regel 137 → `${ADRES_ROUTER}`.
+- [ ] 1.5 Verifiëren: `shellcheck -x -S warning` schoon; `federatie.sh up`;
+      `contracts/fbs-contracten.sh`; `smoke-contract.sh` groen; `smoke-federatie.sh` groen.
+- [ ] 1.6 Committen en pushen naar de #200-branch.
+
+---
+
+### Taak 2: loopback-discipline voor de demo-stack
+
+**Waarom:** de blokkade. De demo-stack bindt wildcard; dat botst met élke specifieke bind van de
+federatie op dezelfde poort (`Failed to bind to /0.0.0.0:8081`). En het zet Redis en PostgreSQL op
+alle interfaces van de machine.
+
+**Bestanden:**
+- Wijzig: `compose.yaml` — elke `ports:`-publicatie krijgt het `127.0.0.1:`-voorvoegsel
+- Wijzig: `compose.podman-hostnet.yaml` — expliciet bind-adres per service
+- Wijzig: `.github/workflows/fsc-harness-overlays.yml` — derde job op de demo-merge
+
+**Stappen:**
+
+- [ ] 2.1 In `compose.yaml` elke publicatie van `"<poort>:<poort>"` naar
+      `"127.0.0.1:<poort>:<poort>"`. Dat zijn: redis, magazijn-a, magazijn-b, profiel-service,
+      aanmeld-stub, notificatie-stub, postgres-uitvraag, postgres-a, postgres-b,
+      berichtenmagazijn-a, berichtenmagazijn-b, toxiproxy, magazijn-stubs, berichtenuitvraag.
+      `demo-console` staat al goed.
+- [ ] 2.2 In `compose.podman-hostnet.yaml` per service een expliciet bind-adres:
+      - wiremocks (`magazijn-a`, `magazijn-b`, `profiel-service`, `aanmeld-stub`,
+        `notificatie-stub`, `magazijn-stubs`): `--bind-address 127.0.0.1` aan `command` toevoegen;
+      - Quarkus (`berichtenmagazijn-a/-b`, `berichtenuitvraag`, `demo-console`):
+        `QUARKUS_HTTP_HOST: 127.0.0.1`;
+      - `redis`: `command: ["redis-server", "--bind", "127.0.0.1", "--port", "<poort>"]`;
+      - `postgres-a/-b/-uitvraag`: `-c listen_addresses=127.0.0.1` aan `command`;
+      - `toxiproxy`: luisteradres in `demo/generated/proxies.json` (gegenereerd door
+        `demo/podman-prepare.sh`) op `127.0.0.1`.
+- [ ] 2.3 Verifiëren dat de merge schoon is:
+      `docker compose -f compose.yaml -f compose.podman.yaml -f compose.podman-hostnet.yaml config
+      --format json | .github/scripts/merge-guard.sh "demo (hostnet-merge)"`. De guard eist
+      `network_mode: host` op élke service; klopt dat niet voor de demo-stack, dan draai je alleen
+      de listener-checks — zie stap 2.4.
+- [ ] 2.4 Als `merge-guard.sh` niet één-op-één past op de demo-merge (andere eisen: geen `/pki`,
+      geen `!reset`-verplichting), splits dan de listener-checks (`env_lek`, `bind_lek`, `pg_lek`,
+      `pg_mist`) af naar een aanroepbare modus `--alleen-listeners`, en gebruik die voor de
+      demo-merge. Niet dupliceren: één script blijft de bron.
+- [ ] 2.5 Job toevoegen aan `.github/workflows/fsc-harness-overlays.yml` die die controle op de
+      demo-merge draait. Pad-filter uitbreiden met `compose*.yaml`.
+- [ ] 2.6 Runtime-bewijs: demo-stack omhoog, dan van een niet-loopback-adres van de host
+      controleren dat niets meer bereikbaar is (vóór deze taak waren `:6379` en `:8082` dat wél).
+- [ ] 2.7 Committen.
+
+---
+
+### Taak 3: de inway wijst naar het echte magazijn
+
+**Bestanden:**
+- Wijzig: `demo/environment/magazijn-a/deploy/local/publish-service.sh` (regel ~22)
+
+**Stappen:**
+
+- [ ] 3.1 `STUB_URL="${FSC_STUB_URL:-http://stub-upstream:8080}"` hernoemen naar
+      `UPSTREAM_URL="${FSC_UPSTREAM_URL:-${FSC_STUB_URL:-http://stub-upstream:8080}}"`. De oude
+      variabele blijft als fallback werken, zodat `smoke-federatie.sh` (die hem zet) niet stilvalt.
+- [ ] 3.2 Dezelfde hernoeming in `logius/deploy/local/publish-service.sh`, zodat de twee peers niet
+      uit elkaar lopen.
+- [ ] 3.3 `shellcheck` schoon; `smoke-federatie.sh` nog steeds groen (die gebruikt de oude naam).
+- [ ] 3.4 Committen.
+
+---
+
+### Taak 4: de uitvraag door de outway
+
+**Bestanden:**
+- Wijzig: `demo/environment/federatie/contracts/fbs-contracten.sh` — grant-hash wegschrijven
+- Wijzig: `compose.podman-hostnet.yaml` — `MAGAZIJN_A_URL` + `MAGAZIJN_A_GRANT_HASH`
+- Wijzig: `demo/generated/`-generatie in `demo/podman-prepare.sh`
+
+**Stappen:**
+
+- [ ] 4.1 `fbs-contracten.sh` schrijft per magazijn een regel naar
+      `demo/generated/fsc-grants.env`: `MAGAZIJN_A_GRANT_HASH=<hash>`. Bestaand bestand wordt
+      overschreven, niet aangevuld — anders stapelen hashes uit eerdere runs zich op.
+- [ ] 4.2 `compose.podman-hostnet.yaml`: `berichtenuitvraag` krijgt
+      `env_file: [demo/generated/fsc-grants.env]` en `MAGAZIJN_A_URL: http://127.20.1.5:8443`.
+      Ontbreekt het bestand, dan moet compose niet fataal falen: `required: false` op de `env_file`.
+- [ ] 4.3 Toxiproxy-upstream voor magazijn-a naar de outway laten wijzen in
+      `demo/generated/proxies.json`, zodat de storing-knop blijft werken en de FSC-keten erachter
+      zit.
+- [ ] 4.4 Verifiëren: beide stacks omhoog, `curl` op de uitvraag levert berichten van magazijn-a.
+- [ ] 4.5 Committen.
+
+---
+
+### Taak 5: ketensmoke
+
+**Bestanden:**
+- Maak: `demo/environment/federatie/smoke-keten.sh`
+
+**Stappen:**
+
+- [ ] 5.1 Assert 1 — ophalen levert data uit de database van magazijn-a: een bericht via `psql` in
+      `postgres-a` zetten met een herkenbare inhoud, dat ophalen via de uitvraag, en op die inhoud
+      matchen. Een 200 van de stub kan die inhoud niet hebben.
+- [ ] 5.2 Assert 2 — dezelfde `Fsc-Transaction-Id` in beide txlogs: uitgaand bij logius, inkomend
+      bij magazijn-a, via de txlog-API op `9443` per peer.
+- [ ] 5.3 Assert 3 — grant-hash leegmaken en herstarten laat de call niet meer door de outway
+      (verwacht `400 UNKNOWN_GRANT_HASH_IN_HEADER` of een lege grant → geen FSC-headers → de outway
+      weigert).
+- [ ] 5.4 Assert 4 — magazijn-b blijft rechtstreeks werken.
+- [ ] 5.5 `shellcheck` schoon, smoke groen, opnemen in de `harness-scripts`-job.
+- [ ] 5.6 Committen en de branch pushen.
+
+---
+
+## Verificatie van het geheel
+
+1. `federatie.sh up` + `smoke-federatie.sh` groen.
+2. `contracts/fbs-contracten.sh` + `smoke-contract.sh` groen.
+3. Demo-stack omhoog naast de federatie, `smoke-keten.sh` groen.
+4. `merge-guard.sh` groen op alle merges: twee standalone, twee federatie, één demo.
+5. `shellcheck` + de bash-unittests groen.
+6. Van buiten loopback is niets van beide stacks bereikbaar.
+
+## Reviewrondes
+
+Na de implementatie: reviewrondes tot er geen hoge bevindingen meer zijn, met de
+`pr-review-toolkit`-agents en `/code-review`. Hoge bevindingen worden direct opgelost, medium in
+overleg, laag genoteerd.

--- a/docs/plans/2026-08-13-b2-lokale-fsc-keten-uitvraag-magazijn.md
+++ b/docs/plans/2026-08-13-b2-lokale-fsc-keten-uitvraag-magazijn.md
@@ -1,0 +1,133 @@
+# B2: de FBS-keten lokaal door FSC
+
+**Status:** Concept
+
+## Context
+
+Na #197 (federatie-harness) en #200 (contract uitvraag↔magazijn) staat de FSC-laag lokaal
+compleet: twee peers, één directory, een wederzijds ondertekend contract, en een bewezen data-pad
+outway → router → inway. Achter die inway zit alleen nog een `stub-upstream` (http-echo).
+
+De FBS-applicatie draait er los naast, in `compose.yaml`: `berichtenuitvraag` haalt rechtstreeks op
+bij `berichtenmagazijn-a` en `-b`. Die twee werelden raken elkaar nergens.
+
+Deze stap verbindt ze: de uitvraag haalt bij magazijn-a op **door de FSC-keten**, met de echte
+`berichtenmagazijn` als upstream van de inway.
+
+## Wat er níét voor nodig is
+
+Applicatiecode. `MagazijnRouter` hangt al een `FscOutwayHeadersFilter` aan een magazijn zodra dat
+een `grantHash` heeft:
+
+```
+magazijnen."00000000000000100000".url=${MAGAZIJN_A_URL}
+magazijnen."00000000000000100000".grantHash=${MAGAZIJN_A_GRANT_HASH:}
+```
+
+Leeg = rechtstreeks; gevuld = `Fsc-Grant-Hash` + `Fsc-Transaction-Id` op elke call. Hetzelfde
+patroon bestaat al voor `berichtenmagazijn → profiel-service`. Dit is dus bedrading, geen bouwwerk.
+
+## Ontwerp
+
+### 1. Loopback-discipline voor de demo-stack
+
+**Dit is de blokkade, en hij is empirisch vastgesteld.** De demo-stack bindt in hostnet-modus
+wildcard, niet op een adres:
+
+```
+FatalStartupException: java.io.IOException: Failed to bind to /0.0.0.0:8081
+```
+
+Een wildcard-bind botst met élke specifieke bind op dezelfde poort. De federatie heeft `:8081` op
+zeven component-adressen (monitoring), dus `0.0.0.0:8081` kan er niet bij. Dat de rest wél opkwam
+was toeval: `8082` gebruikt de federatie niet meer, en de demo-postgres pakte `[::]:5432` naast de
+federatie op IPv4.
+
+Elke demo-service krijgt daarom een expliciet bind-adres op `127.0.0.1`:
+
+| Service | Waar |
+|---|---|
+| wiremocks (`magazijn-a/-b`, stubs) | `--bind-address 127.0.0.1` |
+| Quarkus-services | `QUARKUS_HTTP_HOST=127.0.0.1` (staat nu op `0.0.0.0`) |
+| redis | `--bind 127.0.0.1` |
+| postgres | `-c listen_addresses=127.0.0.1` |
+| toxiproxy | listen-adres in `demo/generated/proxies.json` |
+
+Dat lost niet alleen de botsing op. Zonder deze stap staat de demo-stack op álle interfaces van de
+machine — geverifieerd: `172.20.0.2:6379` (Redis, zonder auth) en `:8082` waren van buiten loopback
+bereikbaar. Op een ontwikkelmachine aan een kantoornetwerk is dat Redis zonder wachtwoord en
+PostgreSQL met demo-credentials voor het hele subnet. De FSC-harnessen hebben hier een CI-guard
+tegen (`.github/scripts/merge-guard.sh`); de demo-stack heeft er geen.
+
+Merk op dat dit breder is dan hostnet: `compose.yaml` publiceert `"6379:6379"`, `"5432:5432"` enz.,
+en dat is bij zowel Docker als podman `0.0.0.0`. Alleen `demo-console` staat op `127.0.0.1:8095`.
+Het voorstel is dus om élke publicatie in `compose.yaml` op `127.0.0.1:` te zetten, en de
+hostnet-overlay expliciet te laten binden.
+
+**Guard erachter,** anders rot het terug: de bestaande `merge-guard.sh` accepteert al elk `127.x`
+en toetst precies dit. Hij hoeft alleen op de demo-merge losgelaten te worden — een derde job in
+`fsc-harness-overlays.yml`, of een eigen workflow als die naam te misleidend wordt.
+
+### 2. De inway wijst naar het echte magazijn
+
+`magazijn-a/deploy/local/publish-service.sh` registreert de dienst met een `endpoint_url`. Die
+wijst nu naar `stub-upstream`; hij moet naar `berichtenmagazijn-a` wijzen — in de demo-stack onder
+hostnet is dat `http://127.0.0.1:8090`.
+
+Het adres komt uit `FSC_STUB_URL`, dat al overrulebaar is. De naam dekt de lading dan niet meer;
+hernoemen naar `FSC_UPSTREAM_URL` met de oude als fallback, of accepteren dat de variabele breder is
+dan zijn naam suggereert. Voorkeur: hernoemen, het is één plek per peer.
+
+### 3. De uitvraag door de outway
+
+Twee env-vars op `berichtenuitvraag` in de demo-stack:
+
+- `MAGAZIJN_A_URL` → de outway van logius. Lokaal `127.20.1.5:8443`.
+- `MAGAZIJN_A_GRANT_HASH` → het grant-hash uit de bootstrap van #200.
+
+`MAGAZIJN_B_URL` blijft ongemoeid. Dat is opzet: één magazijn door FSC, één rechtstreeks, naast
+elkaar in dezelfde demo. Dat toont het verschil en houdt een werkend vergelijkingspad over als de
+FSC-keten stuk is.
+
+**Toxiproxy blijft waar hij staat.** De uitvraag praat nu via `127.0.0.1:18090` naar toxiproxy, die
+doorzet naar het magazijn; dat is de storing-knop van de demo. Voor magazijn-a wordt de *upstream*
+van die proxy de outway, zodat de storing-knop blijft werken en de FSC-keten er achter zit.
+
+**Het koppelpunt is het grant-hash.** Compose kan dat niet uit een draaiende manager halen, dus de
+bootstrap van #200 schrijft het naar een gegenereerd env-bestand (`demo/generated/`, waar de
+toxiproxy-definities ook al staan) dat de demo-stack inleest. Zonder dat bestand blijft de var leeg
+en valt de uitvraag terug op rechtstreeks — dezelfde degradatie die de config al kent.
+
+### 4. Bewijs
+
+Eén smoke die de keten aantoont en kán falen:
+
+| Assert | Wat het uitsluit |
+|---|---|
+| een bericht ophalen via `berichtenuitvraag` levert data die aantoonbaar uit de database van `berichtenmagazijn-a` komt | een 200 die net zo goed van de stub had kunnen komen |
+| dezelfde `Fsc-Transaction-Id` in beide txlogs, uitgaand bij logius en inkomend bij magazijn-a | dat de call buiten FSC om ging |
+| grant-hash leegmaken → de call komt niet door de outway | dat de FSC-headers decoratief zijn |
+| magazijn-b blijft rechtstreeks werken | dat de omzetting het niet-FSC-pad sloopt |
+
+## Verificatie
+
+- Beide stacks tegelijk omhoog onder rootless podman, `smoke-federatie.sh` én de nieuwe ketensmoke
+  groen.
+- `merge-guard.sh` op de demo-merge: alle listeners op loopback.
+- Negatieve controle: van buiten loopback is niets van de demo-stack meer bereikbaar.
+
+## Scope-grens
+
+Eén magazijn (magazijn-a) door FSC. Magazijn-b, de profiel-stub en de notificatie-stub blijven
+rechtstreeks; die hebben eigen issues (#730, #784). De isolatie-kanttekening uit #197 blijft
+onverkort gelden: onder FSC bestaat hier geen grens tussen de peers, dus hier valt geen
+autorisatie-eigenschap mee te bewijzen.
+
+## Open punten
+
+- **Spreekt de outway plain HTTP of TLS op zijn listener?** Dat bepaalt of `MAGAZIJN_A_URL`
+  `http://` of `https://` wordt, en of er een CA-bundel bij moet. Op ZAD staat er een https-ingress
+  voor; lokaal is de listener kaal. Eén call tegen de draaiende outway beslist dit — eerste stap
+  van de uitvoering.
+- **Volgorde ten opzichte van #200.** Deze stap heeft het grant-hash uit die bootstrap nodig. Hij
+  stapelt dus op #200, niet ernaast.

--- a/docs/plans/2026-08-13-b2-lokale-fsc-keten-uitvraag-magazijn.md
+++ b/docs/plans/2026-08-13-b2-lokale-fsc-keten-uitvraag-magazijn.md
@@ -1,6 +1,6 @@
 # B2: de FBS-keten lokaal door FSC
 
-**Status:** Concept
+**Status:** Uitgevoerd
 
 ## Context
 

--- a/services/berichtenuitvraag/src/main/resources/application.properties
+++ b/services/berichtenuitvraag/src/main/resources/application.properties
@@ -142,10 +142,16 @@ magazijnen."00000000000000100000".url=${MAGAZIJN_A_URL}
 magazijnen."00000000000000100000".naam=Magazijn A
 # FSC-outway-routering: aanwezig → Fsc-Grant-Hash/-Transaction-Id op elke call naar dit
 # magazijn (zie FscOutwayHeadersFilter); lege default (geen env-var) → geen header, magazijn
-# blijft direct/zonder outway bereikbaar. Magazijn B heeft nog geen outway-contract.
+# blijft direct/zonder outway bereikbaar.
+#
+# Elk magazijn krijgt deze sleutel, ook als er (nog) geen contract voor is. Ontbreekt hij, dan
+# levert de contract-bootstrap wel een MAGAZIJN_<X>_GRANT_HASH maar bindt niets die waarde: het
+# magazijn wordt dan zónder Fsc-Grant-Hash aangeroepen, dus buiten de FSC-keten om, terwijl alles
+# groen meldt. Een leeg gelaten env-var is hier de veilige uitkomst, een ontbrekende sleutel niet.
 magazijnen."00000000000000100000".grantHash=${MAGAZIJN_A_GRANT_HASH:}
 magazijnen."00000001823288444000".url=${MAGAZIJN_B_URL}
 magazijnen."00000001823288444000".naam=Magazijn B
+magazijnen."00000001823288444000".grantHash=${MAGAZIJN_B_GRANT_HASH:}
 %test.magazijnen."00000000000000100000".url=http://localhost:8081
 %test.magazijnen."00000001823288444000".url=http://localhost:8082
 

--- a/services/berichtenuitvraag/src/main/resources/application.properties
+++ b/services/berichtenuitvraag/src/main/resources/application.properties
@@ -52,7 +52,7 @@ quarkus.jackson.serialization-inclusion=non_null
 
 # Redis — backing store van de in-process sessiecache (fbs-berichtensessiecache).
 # Dev/prod: compose Redis, geen Dev Services; tests schakelen Dev Services per profiel in.
-%dev.quarkus.redis.hosts=redis://localhost:6379
+%dev.quarkus.redis.hosts=${REDIS_HOSTS:redis://localhost:6379}
 # Geen %prod-default: ontbreekt REDIS_HOSTS, dan faalt de start met een duidelijke melding
 # over de missende var i.p.v. stil naar localhost te verbinden (consistent met de fail-fast
 # van REDIS_PASSWORD/DB_* hieronder; een localhost-fallback gaf juist een verwarrende
@@ -190,7 +190,7 @@ berichtensessiecache.magazijn-circuit.open-seconds=30
 # client op JVM-default trust-store; ProfielServiceEndpointValidator dwingt
 # wel https:// af in prod/staging/acceptatie, maar niet de certificaat-keten.
 quarkus.rest-client.profiel-service.url=${PROFIEL_SERVICE_URL}
-%dev.quarkus.rest-client.profiel-service.url=http://localhost:8089
+%dev.quarkus.rest-client.profiel-service.url=${PROFIEL_SERVICE_URL:http://localhost:8089}
 %test.quarkus.rest-client.profiel-service.url=http://localhost:8089
 # Time-outs op de Profiel-Service-call (waarde in milliseconden). Vaste Quarkus
 # RestClient-sleutels: de naam draagt geen `-ms`-suffix zoals onze eigen properties,
@@ -318,8 +318,8 @@ logboekdataverwerking.clickhouse.table=logboek_dataverwerkingen
 %dev.logboekdataverwerking.postgresql.username=${LDV_POSTGRES_USERNAME:ldv}
 %dev.logboekdataverwerking.postgresql.password=${LDV_POSTGRES_PASSWORD:ldv}
 %dev.logboekdataverwerking.clickhouse.endpoint=${LDV_CLICKHOUSE_ENDPOINT:http://localhost:8123}
-%dev.logboekdataverwerking.clickhouse.username=ldv
-%dev.logboekdataverwerking.clickhouse.password=ldv
+%dev.logboekdataverwerking.clickhouse.username=${CLICKHOUSE_USERNAME:ldv}
+%dev.logboekdataverwerking.clickhouse.password=${CLICKHOUSE_PASSWORD:ldv}
 %test.logboekdataverwerking.postgresql.url=jdbc:postgresql://localhost:5434/ldv_logging
 %test.logboekdataverwerking.postgresql.username=ldv
 %test.logboekdataverwerking.postgresql.password=ldv

--- a/services/berichtenuitvraag/src/main/resources/application.properties
+++ b/services/berichtenuitvraag/src/main/resources/application.properties
@@ -247,8 +247,13 @@ profiel.resolver.cache.max-size=10000
 # %dev: twee lokaal-draaiende berichtenmagazijn-instances. Magazijn A op de
 # default-poort (8090); magazijn B start je in een tweede terminal op 8091 met:
 #     ./mvnw quarkus:dev -pl services/berichtenmagazijn -Dquarkus.http.port=8091
-%dev.magazijnen."00000000000000100000".url=http://localhost:8090
-%dev.magazijnen."00000001823288444000".url=http://localhost:8091
+#
+# MAGAZIJN_A_URL/MAGAZIJN_B_URL blijven ook hier leidend als ze gezet zijn. Zonder die fallback
+# overrulet een %dev-regel de omgeving, en dan wijst het magazijn-adres stilzwijgend naar
+# localhost terwijl de omgeving iets anders zegt — bijvoorbeeld een FSC-outway. Dat is niet te
+# zien aan het gedrag: het ophalen slaagt gewoon, alleen langs de verkeerde weg.
+%dev.magazijnen."00000000000000100000".url=${MAGAZIJN_A_URL:http://localhost:8090}
+%dev.magazijnen."00000001823288444000".url=${MAGAZIJN_B_URL:http://localhost:8091}
 
 # Begrensde timeouts op de magazijn-REST-client van MagazijnRouter
 # (bijlage-download + patch/verwijder) zodat een hangende magazijn-connectie een

--- a/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/ApplicationPropertiesTest.kt
+++ b/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/ApplicationPropertiesTest.kt
@@ -27,4 +27,27 @@ class ApplicationPropertiesTest {
             properties.getProperty(ProfielFscOutwayHeadersFilter.CONFIG_KEY),
         )
     }
+
+    /**
+     * De `%dev`-magazijn-URL's moeten hun env-var respecteren. Stond er een kale `localhost`-waarde,
+     * dan overrulet het dev-profiel de omgeving en praat de uitvraag met het magazijn naast de deur
+     * terwijl `MAGAZIJN_A_URL` naar een FSC-outway wijst. Dat is aan het gedrag niet te zien: het
+     * ophalen slaagt, alleen loopt het verkeer buiten de keten om en blijft het transactielogboek
+     * leeg.
+     */
+    @Test
+    fun `dev-magazijn-URLs laten de omgeving voorgaan op de localhost-default`() {
+        val properties = Properties().apply {
+            File("src/main/resources/application.properties").inputStream().use { load(it) }
+        }
+
+        assertEquals(
+            "\${MAGAZIJN_A_URL:http://localhost:8090}",
+            properties.getProperty("%dev.magazijnen.\"00000000000000100000\".url"),
+        )
+        assertEquals(
+            "\${MAGAZIJN_B_URL:http://localhost:8091}",
+            properties.getProperty("%dev.magazijnen.\"00000001823288444000\".url"),
+        )
+    }
 }

--- a/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/ApplicationPropertiesTest.kt
+++ b/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/ApplicationPropertiesTest.kt
@@ -60,6 +60,41 @@ class ApplicationPropertiesTest {
     }
 
     /**
+     * Een `%dev`-override mag de env-var van de basissleutel niet doodslaan.
+     *
+     * Leest de basissleutel `${VAR}` en zet `%dev` er een kale waarde tegenover, dan wint die kale
+     * waarde onder `QUARKUS_PROFILE=dev` — en dat is aan het gedrag niet te zien: de service start,
+     * het verkeer gaat alleen naar het verkeerde adres. Zo liepen de magazijn-URL's langs de
+     * FSC-outway heen en Redis/Profiel langs Toxiproxy. Deze test dekt de hele klasse: elke
+     * `%dev`-sleutel die een env-var-gestuurde basissleutel overschrijft, moet diezelfde var noemen.
+     */
+    @Test
+    fun `dev-overrides slaan de env-var van hun basissleutel niet dood`() {
+        val properties = Properties().apply {
+            File("src/main/resources/application.properties").inputStream().use { load(it) }
+        }
+
+        val envVar = Regex("""\$\{([A-Z0-9_]+)[:}]""")
+        val overtreders = properties.stringPropertyNames()
+            .filter { it.startsWith("%dev.") }
+            .mapNotNull { devSleutel ->
+                val basis = devSleutel.removePrefix("%dev.")
+                val basisVar = envVar.find(properties.getProperty(basis) ?: "")?.groupValues?.get(1)
+                    ?: return@mapNotNull null
+                val devWaarde = properties.getProperty(devSleutel) ?: ""
+
+                if (devWaarde.contains("\${$basisVar")) null else "$devSleutel (basis leest \$$basisVar)"
+            }
+            .sorted()
+
+        assertEquals(
+            emptyList<String>(),
+            overtreders,
+            "deze %dev-overrides negeren de env-var van hun basissleutel; het verkeer gaat dan stil naar het verkeerde adres",
+        )
+    }
+
+    /**
      * De `%dev`-magazijn-URL's moeten hun env-var respecteren. Stond er een kale `localhost`-waarde,
      * dan overrulet het dev-profiel de omgeving en praat de uitvraag met het magazijn naast de deur
      * terwijl `MAGAZIJN_A_URL` naar een FSC-outway wijst. Dat is aan het gedrag niet te zien: het

--- a/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/ApplicationPropertiesTest.kt
+++ b/services/berichtenuitvraag/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenuitvraag/ApplicationPropertiesTest.kt
@@ -2,6 +2,7 @@ package nl.rijksoverheid.moz.fbs.berichtenuitvraag
 
 import nl.rijksoverheid.moz.fbs.common.fsc.ProfielFscOutwayHeadersFilter
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.io.File
 import java.util.Properties
@@ -25,6 +26,36 @@ class ApplicationPropertiesTest {
         assertEquals(
             "\${PROFIEL_SERVICE_GRANT_HASH:}",
             properties.getProperty(ProfielFscOutwayHeadersFilter.CONFIG_KEY),
+        )
+    }
+
+    /**
+     * Elk geconfigureerd magazijn moet een `grantHash`-sleutel hebben, ook zonder contract.
+     *
+     * Ontbreekt hij, dan levert de contract-bootstrap wel een `MAGAZIJN_<X>_GRANT_HASH` maar bindt
+     * niets die waarde: dat magazijn wordt zónder `Fsc-Grant-Hash` aangeroepen — dus buiten de
+     * FSC-keten om — terwijl zowel de bootstrap als het ophalen groen melden. Een lege env-var is
+     * de veilige uitkomst; een ontbrekende sleutel is onzichtbaar.
+     */
+    @Test
+    fun `elk magazijn met een url heeft ook een grantHash-sleutel`() {
+        val properties = Properties().apply {
+            File("src/main/resources/application.properties").inputStream().use { load(it) }
+        }
+
+        val urlSleutel = Regex("""^magazijnen\."(\d+)"\.url$""")
+        val oins = properties.stringPropertyNames()
+            .mapNotNull { urlSleutel.find(it)?.groupValues?.get(1) }
+            .toSortedSet()
+
+        assertTrue(oins.isNotEmpty(), "geen enkel magazijn in application.properties — deze test meet niets")
+
+        val zonderGrantHash = oins.filter { properties.getProperty("""magazijnen."$it".grantHash""") == null }
+
+        assertEquals(
+            emptyList<String>(),
+            zonderGrantHash,
+            "magazijn(en) zonder grantHash-sleutel: die worden buiten de FSC-keten om aangeroepen",
         )
     }
 


### PR DESCRIPTION
> **Gestapeld op #200** (contract uitvraag↔magazijn). Hertargeten op `main` zodra die gemerged is.
> Derde van vier: A federatie-harness (#197, gemerged) → B contract (#200) → **C deze** →
> D ZAD-transport (nog te doen).

## Aanleiding

Na #197 en #200 staat de FSC-laag lokaal compleet: twee peers, één directory, een wederzijds
ondertekend contract en een bewezen data-pad outway → router → inway. Achter die inway zat alleen
nog een `stub-upstream` (http-echo), en de FBS-applicatie draaide er los naast: `berichtenuitvraag`
haalde rechtstreeks op bij `berichtenmagazijn-a`.

Deze PR verbindt ze. De uitvraag haalt bij magazijn-a op **door de FSC-keten**, met het echte
magazijn als upstream van de inway — lokaal, zonder ZAD-ronde per poging.

## Wat er in zit

Geen applicatielogica: `MagazijnRouter` hing al een `FscOutwayHeadersFilter` aan een magazijn met
een `grantHash`. Wat ontbrak was de bedrading, en die bleek op vier plekken stil de verkeerde kant
op te wijzen.

**1. De demo-stack bindt op loopback.** Dit was de blokkade. De stack publiceerde kaal
(`"6379:6379"`), en dat is bij Docker én podman `0.0.0.0`; onder de hostnet-overlay bonden de
containers zelf wildcard. Gemeten op een ontwikkelmachine: Redis (zonder wachtwoord) en de
WireMock-admin-API's waren bereikbaar op het niet-loopback-adres van de host.

Een wildcard-bind botst bovendien met élke specifieke bind op dezelfde poort, dus de federatie en
de demo-stack konden niet samen in één netns:

```
FatalStartupException: java.io.IOException: Failed to bind to /0.0.0.0:8081
```

`compose.yaml` publiceert nu op `${DEMO_BIND:-127.0.0.1}`, de hostnet-overlay geeft elke service
een expliciet bind-adres, en een CI-job draait de bestaande `merge-guard.sh` op de demo-merge. Die
bleek zonder aanpassing te passen: 15/15 services, alle listeners op loopback.

**2. De inway wijst naar het echte magazijn.** `FSC_UPSTREAM_URL` vervangt `FSC_STUB_URL` (oude
naam blijft werken), en `publish-service.sh` wérkt een gewijzigde upstream nu bij in plaats van
"bestaat al, skip create" te melden terwijl de inway naar de oude bleef wijzen.

**3. De uitvraag door de outway.** `fbs-contracten.sh` leidt het grant-hash af — niet het
contract-hash, daar antwoordt de outway `400` op — en schrijft `demo/generated/fsc-grants.env`, dat
de demo-stack optioneel inleest. `MAGAZIJN_A_URL` is overrulebaar; de default (rechtstreeks via
toxiproxy) blijft werken, en magazijn-b blijft bewust buiten FSC als vergelijkingspad.

**4. Twee bugs die het verkeer stil buiten de keten hielden.** De `%dev`-regels in
`application.properties` overrulden `MAGAZIJN_A_URL` met een kale localhost-waarde: het ophalen
slaagde gewoon, alleen langs de verkeerde weg en met een leeg transactielogboek. En
`compose.podman-hostnet.yaml` liet `berichtenuitvraag` wachten op `postgres-uitvraag:
service_healthy` terwijl die overlay elke healthcheck reset — de service kon onder hostnet dus
nooit starten. Beide met een test respectievelijk een `depends_on`-override afgedekt.

## Bewijs

`smoke-keten.sh`, drie asserts die elk iets uitsluiten:

| Assert | Wat het uitsluit |
|---|---|
| een bericht dat alleen in magazijn-a bestaat komt via de uitvraag terug | een 200 die net zo goed van de stub had kunnen komen |
| een **nieuwe** gedeelde transactie in beide txlogs | dat de call buiten de outway om ging |
| magazijn-b werkt rechtstreeks door | dat de omzetting het niet-FSC-pad sloopt |

Die tweede assert is de eigenlijke, en hij is getoetst op falen: met de demo-stack op het
rechtstreekse pad gaat hij terecht rood.

Twee dingen die de smoke anders vals-groen hadden gehouden. De uitvraag houdt een **sessiecache per
ontvanger**, dus een tweede ophaling komt uit Redis zonder het magazijn te bellen — vandaar per run
een verse, elfproef-geldige BSN. En een gewijzigde upstream **propageert asynchroon** naar de inway;
dat wachten kan niet in de assert zelf zitten (de eerste ophaling vult de cache), dus er zit een
probe door de outway vóór de eerste meting.

## Vier reviewrondes

Elke ronde vond fouten in het vorige fixwerk. De leerzaamste twee zaten in de asserts zelf:

- **De txlog-nulmeting stond vóór de probe** die zelf door outway → inway gaat en dus precies de
  rijen schrijft die de meting telt (gemeten: 54 → 55). Assert 2 kon daardoor nooit rood worden —
  het enige dat hij moest uitsluiten.
- **`federatie.sh status` sorteerde met `sort -u -t: -k2 -n`**, dat alleen de sleutel vergelijkt.
  Alle listeners op dezelfde poort vielen samen tot één regel en juist `0.0.0.0:8443` verdween,
  vóór de controle "NIET op loopback" eroverheen liep.

Verder onder meer: `fsc_grant_hash` levert bij een mislukking de sentinel `unknown` en niet leeg,
dus een guard op leegte vuurde nooit; de merge-guard toetste een verkeerde bind-waarde maar niet een
ontbrekende directive (`del(.services.redis.command)` bleef groen); en magazijn-b had geen
`grantHash`-sleutel, waardoor het bij uitbreiding zonder `Fsc-Grant-Hash` benaderd zou worden
terwijl alles groen meldt.

## Beperkingen

- **Eén magazijn door FSC.** Magazijn-b, de profiel-stub en de notificatie-stub blijven
  rechtstreeks; die hebben eigen issues (#730, #784).
- **De storing-knop van de demo werkt niet op het FSC-pad.** Toxiproxy blijft vóór het
  rechtstreekse pad staan; in FSC-modus loopt magazijn-a er niet doorheen.
- **De isolatie-kanttekening uit #197 geldt onverkort**: onder FSC bestaat hier geen grens tussen de
  peers, dus hiermee valt geen autorisatie-eigenschap te bewijzen.
- **Dit pad geldt lokaal; op ZAD ligt het anders.** Daar isoleert de tenant-baseline-NetworkPolicy
  per **deployment**, dus de app in `test` kan de outway-ClusterIP in `fsc-logius` niet bereiken,
  ook al delen ze het project. De uitvraag moet er buitenlangs, via de publieke outway-route, en die
  is als enige van de drie niet `ssl-passthrough` maar edge-terminated. **TODO:** netwerkpolicies
  zijn op ZAD niet configureerbaar; hetzelfde bleek al bij een ander ticket en daarvoor wordt een
  issue aangemaakt waar dit geval bij hoort. Tot dan is buitenlangs een bewuste tussenoplossing.
  Zie #200 voor de volledige meting.
- **Vier reviewbevindingen bewust laten liggen**, elk met reden: verweesde half-getekende contracten
  bij een timeout in `bootstrap.sh` (raakt de idempotentie-logica van #200 en verdient een eigen
  ronde), `vereis_draaiend` gebruikt een compose-v2-vlag terwijl het script naar v1 kan terugvallen,
  `run-smokes.sh` geeft valse FAIL's tegen een federatie-stack, en Redis krijgt in hostnet geen
  SIGTERM doorgestuurd waardoor `down` de stop-timeout uitzit.

🤖 Gegenereerd met [Claude Code](https://claude.com/claude-code)

