### PR TITLE
Contract-bootstrap op ZAD: gesplitst per peer (#782)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -191,17 +191,28 @@ jobs:
           #
           # deploy.yml zelf, .github/actions/ en de zad-actions staan er bewust NIET bij: die
           # bepalen de uitrol, dus juist daar is een preview het bewijs dat de wijziging klopt.
-          # demo-console en demo/ horen erbij: die module wordt door geen enkele deploy uitgerold
-          # (de images zijn berichtenuitvraag en berichtenmagazijn), en test.yml scoopt er zijn
-          # tests al apart op.
+          # demo-console en demo/ horen erbij: die mappen worden grotendeels door geen enkele deploy
+          # uitgerold, en test.yml scoopt er zijn tests al apart op. Uitzondering: de twee mappen
+          # waaruit het contract-bootstrap-image komt — zie `image_bronnen` hieronder.
           niet_deploybaar='(^docs/|\.md$|^bruno/|^demo/|^services/demo-console/|^\.clusterfuzzlite/|^\.github/workflows/(test|detekt|codeql|scorecard|architecture|pin-consistency|cflite_pr|cflite_batch|cflite_cron|fsc-harness-overlays|fuzz-base-image)\.yml$)'
+
+          # Uitzondering op `^demo/`: het contract-bootstrap-image wordt uit deze twee mappen
+          # gebouwd (zie build-contract-bootstrap), dus dáár is `demo/` wél een gedeployd image.
+          # Zonder deze regel zou een PR die alleen die scripts of de Dockerfile raakt de build
+          # overslaan, en zou het image pas ná de merge naar main voor het eerst gebouwd worden.
+          image_bronnen='^demo/environment/(lib/|federatie/contracts/)'
 
           # Herestring in plaats van een pipe: `grep -q` sluit de pipe bij de eerste match, en
           # met `pipefail` zou die SIGPIPE als "niets te deployen" doorgaan. `grep` geeft 1 bij
           # geen match en 2 bij een echte fout; alleen 1 mag tot overslaan leiden, want een
           # overgeslagen deploy rapporteert `skipped` en telt als succes in de required checks.
           rc=0
-          grep -qvE "$niet_deploybaar" <<<"$files" || rc=$?
+
+          # De `.md`-uitsluiting geldt ook hier: het runbook staat in dezelfde map als de scripts,
+          # maar zit niet in het image.
+          if ! grep -E "$image_bronnen" <<<"$files" | grep -qvE '\.md$'; then
+            grep -qvE "$niet_deploybaar" <<<"$files" || rc=$?
+          fi
 
           case "$rc" in
             0)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -191,28 +191,20 @@ jobs:
           #
           # deploy.yml zelf, .github/actions/ en de zad-actions staan er bewust NIET bij: die
           # bepalen de uitrol, dus juist daar is een preview het bewijs dat de wijziging klopt.
-          # demo-console en demo/ horen erbij: die mappen worden grotendeels door geen enkele deploy
-          # uitgerold, en test.yml scoopt er zijn tests al apart op. Uitzondering: de twee mappen
-          # waaruit het contract-bootstrap-image komt — zie `image_bronnen` hieronder.
+          # demo-console en demo/ horen erbij: die module wordt door geen enkele deploy uitgerold
+          # (de images zijn berichtenuitvraag en berichtenmagazijn), en test.yml scoopt er zijn
+          # tests al apart op. Het contract-bootstrap-image komt óók uit demo/, maar wordt alleen
+          # op push naar main uitgerold; op een PR bouwt en draait `fsc-harness-overlays.yml` hem,
+          # dus een uitzondering hier zou de hele deploy-keten (twee jib-images, de stubs en drie
+          # previews) openzetten voor een wijziging die daar niets mee te maken heeft.
           niet_deploybaar='(^docs/|\.md$|^bruno/|^demo/|^services/demo-console/|^\.clusterfuzzlite/|^\.github/workflows/(test|detekt|codeql|scorecard|architecture|pin-consistency|cflite_pr|cflite_batch|cflite_cron|fsc-harness-overlays|fuzz-base-image)\.yml$)'
-
-          # Uitzondering op `^demo/`: het contract-bootstrap-image wordt uit deze twee mappen
-          # gebouwd (zie build-contract-bootstrap), dus dáár is `demo/` wél een gedeployd image.
-          # Zonder deze regel zou een PR die alleen die scripts of de Dockerfile raakt de build
-          # overslaan, en zou het image pas ná de merge naar main voor het eerst gebouwd worden.
-          image_bronnen='^demo/environment/(lib/|federatie/contracts/)'
 
           # Herestring in plaats van een pipe: `grep -q` sluit de pipe bij de eerste match, en
           # met `pipefail` zou die SIGPIPE als "niets te deployen" doorgaan. `grep` geeft 1 bij
           # geen match en 2 bij een echte fout; alleen 1 mag tot overslaan leiden, want een
           # overgeslagen deploy rapporteert `skipped` en telt als succes in de required checks.
           rc=0
-
-          # De `.md`-uitsluiting geldt ook hier: het runbook staat in dezelfde map als de scripts,
-          # maar zit niet in het image.
-          if ! grep -E "$image_bronnen" <<<"$files" | grep -qvE '\.md$'; then
-            grep -qvE "$niet_deploybaar" <<<"$files" || rc=$?
-          fi
+          grep -qvE "$niet_deploybaar" <<<"$files" || rc=$?
 
           case "$rc" in
             0)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -342,6 +342,36 @@ jobs:
           docker build -t "$IMG" wiremock/externe-stubs
           docker push "$IMG"
 
+  # De contract-bootstrap draait op ZAD als component náást de manager van zijn eigen peer: de
+  # interne manager-API heeft daar geen route en de tenant-baseline-NetworkPolicy laat alleen
+  # verkeer binnen hetzelfde deployment toe. Eén image, twee rollen — welke, leest het entrypoint
+  # uit FSC_ROL in de component-env.
+  build-contract-bootstrap:
+    if: github.event_name == 'push' || (github.event.action != 'closed' && needs.changes.outputs.run == 'true')
+    needs: [meta, changes]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: build-contract-bootstrap-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Build + push contract-bootstrap
+        env:
+          OWNER: ${{ needs.meta.outputs.owner }}
+          TAG: ${{ needs.meta.outputs.tag }}
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "$GHCR_TOKEN" | docker login "$REGISTRY" -u "$GHCR_USER" --password-stdin
+          IMG="$REGISTRY/$OWNER/fbs-fsc-contract-bootstrap:$TAG"
+          # Context is demo/environment/ en niet de contracts-map: de scripts leunen op ../../lib.
+          docker build -f demo/environment/federatie/contracts/Dockerfile -t "$IMG" demo/environment
+          docker push "$IMG"
+
   # De vier toetsende workflows draaien als aangeroepen (`workflow_call`) job ín deze workflow,
   # zodat de deploy er met `needs:` aan kan hangen. Vóór #173 draaiden ze zelfstandig en wachtte
   # een `gate`-job er in een poll-lus op: ~461 s per run een runner die niets deed dan `sleep 15`.
@@ -668,9 +698,9 @@ jobs:
           # Expliciete lijst, bewust niet afgeleid uit alle org-packages: de prefix `pr-<n>-`
           # is niet uniek binnen de organisatie, dus een brede sweep zou images van een
           # gelijkgenummerde PR in een andere repo kunnen wissen. Houd deze lijst in sync met
-          # de `build`-matrix en `build-externe-stubs`; een vergeten package laat weesversies
-          # achter.
-          for pkg in fbs-berichtenuitvraag fbs-berichtenmagazijn fbs-externe-stubs; do
+          # de `build`-matrix, `build-externe-stubs` en `build-contract-bootstrap`; een vergeten
+          # package laat weesversies achter.
+          for pkg in fbs-berichtenuitvraag fbs-berichtenmagazijn fbs-externe-stubs fbs-fsc-contract-bootstrap; do
             if ! versions=$(gh api --paginate "orgs/$ORG/packages/container/$pkg/versions?per_page=100"); then
               echo "::warning::Kon de versies van $pkg niet ophalen — images van deze PR blijven mogelijk staan."
               fail=1
@@ -714,10 +744,11 @@ jobs:
       && needs.meta.result == 'success'
       && needs.build.result == 'success'
       && needs.build-externe-stubs.result == 'success'
+      && needs.build-contract-bootstrap.result == 'success'
       && needs.gate.result == 'success'
       && github.event_name == 'push'
       && github.ref == 'refs/heads/main'
-    needs: [meta, build, build-externe-stubs, gate]
+    needs: [meta, build, build-externe-stubs, build-contract-bootstrap, gate]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # Eén ZAD-taak tegelijk op de `test`-deployment van dit project; twee snel opeenvolgende merges
@@ -761,7 +792,8 @@ jobs:
               {"name": "logius-fscctl", "image": "ghcr.io/minbzk/moza-fsc-testnet-controller-migrate:v2.5.2"},
               {"name": "logius-fscoutway", "image": "docker.io/federatedserviceconnectivity/outway:v2.5.2"},
               {"name": "logius-fscinway", "image": "docker.io/federatedserviceconnectivity/inway:v2.5.2"},
-              {"name": "logius-fsctxlog", "image": "ghcr.io/minbzk/moza-fsc-testnet-txlog-migrate:v2.5.2"}
+              {"name": "logius-fsctxlog", "image": "ghcr.io/minbzk/moza-fsc-testnet-txlog-migrate:v2.5.2"},
+              {"name": "logius-fscbootstrap", "image": "${{ env.REGISTRY }}/${{ needs.meta.outputs.owner }}/fbs-fsc-contract-bootstrap:${{ needs.meta.outputs.tag }}"}
             ]
 
   deploy-test-externe-stubs:
@@ -804,10 +836,11 @@ jobs:
       && needs.meta.result == 'success'
       && needs.build.result == 'success'
       && needs.build-externe-stubs.result == 'success'
+      && needs.build-contract-bootstrap.result == 'success'
       && needs.gate.result == 'success'
       && github.event_name == 'push'
       && github.ref == 'refs/heads/main'
-    needs: [meta, build, build-externe-stubs, gate]
+    needs: [meta, build, build-externe-stubs, build-contract-bootstrap, gate]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # Dekt ook de tweede stap (deployment `fsc-magazijna`) — die hoort bij hetzelfde project.
@@ -847,5 +880,6 @@ jobs:
               {"name": "magazijna-fscmgr", "image": "ghcr.io/minbzk/moza-fsc-testnet-manager-migrate:v2.5.2"},
               {"name": "magazijna-fscctl", "image": "ghcr.io/minbzk/moza-fsc-testnet-controller-migrate:v2.5.2"},
               {"name": "magazijna-fscinway", "image": "docker.io/federatedserviceconnectivity/inway:v2.5.2"},
-              {"name": "magazijna-fsctxlog", "image": "ghcr.io/minbzk/moza-fsc-testnet-txlog-migrate:v2.5.2"}
+              {"name": "magazijna-fsctxlog", "image": "ghcr.io/minbzk/moza-fsc-testnet-txlog-migrate:v2.5.2"},
+              {"name": "magazijna-fscbootstrap", "image": "${{ env.REGISTRY }}/${{ needs.meta.outputs.owner }}/fbs-fsc-contract-bootstrap:${{ needs.meta.outputs.tag }}"}
             ]

--- a/.github/workflows/fsc-harness-overlays.yml
+++ b/.github/workflows/fsc-harness-overlays.yml
@@ -35,8 +35,9 @@ on:
 
 # LET OP: `pull_request`, niet `pull_request_target`, en read-only zonder secrets. Beide jobs
 # `source`n demo/environment/federatie/peers.env respectievelijk renderen compose-bestanden uit de
-# PR — dat is PR-gestuurde uitvoering. Dat is alleen aanvaardbaar zolang deze workflow geen
-# schrijfrechten, geen secrets en geen cache heeft. Wijzig geen van drieën.
+# PR — dat is PR-gestuurde uitvoering, net als de bash-unittests en de docker build/run in
+# `harness-scripts`. Dat is alleen aanvaardbaar zolang deze workflow geen schrijfrechten, geen
+# secrets en geen cache heeft. Wijzig geen van drieën.
 permissions:
   contents: read
 
@@ -326,3 +327,47 @@ jobs:
           fi
 
           exit "$fail"
+
+      - name: Contract-bootstrap-image bouwt en draait onder een willekeurige UID
+        # Het image draait op ZAD als component; zonder deze stap blijkt een verkeerd COPY-pad, een
+        # ontbrekend pakket of een rechtenprobleem pas daar. OpenShift start containers onder een
+        # willekeurige UID in groep 0 — dat is de aanname waar de hele opstelling op rust, dus die
+        # wordt hier expliciet uitgeoefend en niet alleen in de Dockerfile opgeschreven.
+        run: |
+          set -euo pipefail
+
+          docker build -f demo/environment/federatie/contracts/Dockerfile \
+            -t fbs-fsc-contract-bootstrap:ci demo/environment
+
+          echo "== gereedschap en leesbaarheid onder UID 12345, groep 0 =="
+          docker run --rm -u 12345:0 --entrypoint sh fbs-fsc-contract-bootstrap:ci -c '
+            set -eu
+            command -v bash curl jq openssl >/dev/null
+            test -r /opt/fsc/lib/fsc-contract.sh
+            test -r /opt/fsc/lib/fsc-harness.sh
+            test -x /opt/fsc/contracts/zad-lus.sh
+            test -x /opt/fsc/contracts/bootstrap-consumer.sh
+            test -x /opt/fsc/contracts/bootstrap-provider.sh'
+
+          # De twee scripts die met béíde managers praten horen niet in het image: op ZAD kan dat
+          # niet en een operator die ze daar aantreft, gaat ze gebruiken.
+          echo "== bootstrap.sh en fbs-contracten.sh zitten er NIET in =="
+          docker run --rm -u 12345:0 --entrypoint sh fbs-fsc-contract-bootstrap:ci -c '
+            ! test -e /opt/fsc/contracts/bootstrap.sh && ! test -e /opt/fsc/contracts/fbs-contracten.sh'
+
+          # Exit 2 = "configuratie deugt niet". Daar stopt de lus op, en dat maakt er een zichtbare
+          # crashloop van in plaats van een pod die draait en niets doet.
+          echo "== configuratiefouten eindigen op 2 =="
+          for geval in "" "FSC_ROL=onzin"; do
+            rc=0
+            if [ -n "$geval" ]; then
+              docker run --rm -u 12345:0 -e "$geval" fbs-fsc-contract-bootstrap:ci || rc=$?
+            else
+              docker run --rm -u 12345:0 fbs-fsc-contract-bootstrap:ci || rc=$?
+            fi
+
+            if [ "$rc" -ne 2 ]; then
+              echo "::error::verwachtte exit 2 voor '${geval:-<geen env>}', kreeg ${rc}"
+              exit 1
+            fi
+          done

--- a/demo/environment/.dockerignore
+++ b/demo/environment/.dockerignore
@@ -1,0 +1,9 @@
+# Build-context voor federatie/contracts/Dockerfile is deze hele map, omdat de scripts op ../../lib
+# leunen. Sleutelmateriaal hoort daar niet in: `pki/issue.sh` laat op een ontwikkelmachine private
+# keys achter onder pki/out en pki/internal, en die zouden anders bij elke lokale build de
+# container-daemon en de build-cache in gaan. In CI bestaan ze niet (ze staan niet in git), dus daar
+# verandert dit niets.
+*/pki/out/
+*/pki/internal/
+*/pki/ca/
+*/pki/zad-upload/

--- a/demo/environment/federatie/README.md
+++ b/demo/environment/federatie/README.md
@@ -159,21 +159,46 @@ magazijn, zodat de uitvraag-outway `berichtenmagazijn` bij elk van hen mag ophal
 ```bash
 ./federatie/contracts/fbs-contracten.sh   # één contract per magazijn uit MAGAZIJNEN
 ./federatie/smoke-contract.sh             # bewijst contract, data-pad, afdwinging en verantwoording
+./federatie/smoke-contract-split.sh       # bewijst dat de twee helften los werken en convergeren
 ```
 
 Een magazijn toevoegen is één naam in `MAGAZIJNEN`.
 
-`contracts/bootstrap.sh` eronder is generiek — alle peers, adressen en certificaten komen uit env —
-en is **idempotent zonder lokale state**. De generieke variant in `moza-fsc-testnet` onthoudt de
-content-hash in een bestand; dat werkt op een ontwikkelmachine, maar niet in een deploy waar elke
-job met een lege schijf start: daar maakt elke run er nóg een geldig contract bij. Deze variant
-leidt het bestaan af uit de contracten zelf — service, provider, consumer-outway en thumbprint
-samen vormen de identiteit — zodat een herhaalde run overal een no-op is.
+### Twee helften
+
+De bootstrap bestaat uit twee losse scripts: `contracts/bootstrap-consumer.sh` dient het contract in
+bij de manager van de consumer, `contracts/bootstrap-provider.sh` tekent het bij die van de
+provider. Elk praat met precies één manager.
+
+Dat is geen stijlkeuze. Op ZAD isoleert de tenant-baseline-NetworkPolicy per deployment en heeft de
+manager-internal-API geen route, dus één proces dat beide managers aanspreekt bestaat daar niet. Het
+contract kruist in plaats daarvan via de FSC-mesh. Zie `contracts/zad-runbook.md`.
+
+`contracts/bootstrap.sh` is de lokale aanroeper van diezelfde twee helften — niet een aparte,
+eenvoudigere variant. Wat hier lokaal getoetst wordt, is dus de code die op ZAD draait. De scheiding
+wordt daarbij afgedwongen en niet alleen afgesproken: elke helft start met `env -u` op de adres- en
+certificaat-variabelen van de overkant.
+
+De provider-helft krijgt geen hash mee maar besluit zelf of hij tekent, en dat is een
+autorisatiebesluit: hij tekent alleen een contract met **precies één** grant, van type
+`GRANT_TYPE_SERVICE_CONNECTION`, voor een eigen dienst uit `FSC_DIENSTEN` en een consumer uit
+`FSC_CONSUMERS`. De eis "precies één" staat er omdat een contract een lijst grants draagt: wie
+alleen toetst of er één passende grant in zit, tekent een meegestuurde tweede mee.
+
+### Idempotentie
+
+De bootstrap is **idempotent zonder lokale state**. De generieke variant in `moza-fsc-testnet`
+onthoudt de content-hash in een bestand; dat werkt op een ontwikkelmachine, maar niet in een deploy
+waar elke job met een lege schijf start: daar maakt elke run er nóg een geldig contract bij. Deze
+variant leidt het bestaan af uit de contracten zelf — service, provider, consumer-outway en
+thumbprint samen vormen de identiteit — zodat een herhaalde run overal een no-op is. Op ZAD is
+herhaling geen randgeval maar de normale werking: beide componenten draaien in een lus.
 
 De provider tekent niet vanzelf: `AUTO_SIGN_GRANTS` dekt alleen (delegated)servicePublication, dus
 de accept is een expliciete `PUT`. Landt de accept-handtekening daarna niet bij de consumer (die
 push is best-effort, met begrensde backoff en zonder cron-retry), dan blijft het contract daar
-`proposed` en ziet de outway de grant nooit; het script forceert dan de her-distributie.
+`proposed` en ziet de outway de grant nooit; de provider-helft stuurt daarom na elke accept één keer
+na, en `bootstrap.sh` forceert de her-distributie als het contract alsnog niet geldig wordt.
 
 ## De FBS-applicatie door de keten
 

--- a/demo/environment/federatie/contracts/Dockerfile
+++ b/demo/environment/federatie/contracts/Dockerfile
@@ -2,23 +2,30 @@
 #
 # Waarom een component en geen CI-stap: de interne manager-API heeft op ZAD geen route en de
 # tenant-baseline-NetworkPolicy laat alleen verkeer binnen hetzelfde deployment toe. Alleen een pod
-# náást de manager kan hem bereiken. En omdat ZAD geen component-args toestaat, leest het
-# entrypoint zijn rol uit env in plaats van uit een argument.
+# náást de manager kan hem bereiken. En omdat ZAD geen component-args toestaat, leest het entrypoint
+# zijn rol uit env in plaats van uit een argument. Zie contracts/zad-runbook.md.
 #
 # Build-context is demo/environment/ (niet deze map): de scripts leunen op ../../lib.
 FROM docker.io/library/alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce
 
-# bash — de scripts gebruiken arrays en `read -a`; curl — de manager-API; jq — de idempotentie leest
-# contract-JSON; openssl — de outway-thumbprint uit een certificaat; ca-certificates — voor de
-# publieke trust store. De manager-API zelf loopt op de interne PKI, die als CA-bestand meekomt.
-RUN apk add --no-cache bash curl jq openssl ca-certificates
+# bash — de scripts gebruiken arrays; curl — de manager-API; jq — de idempotentie leest contract-JSON;
+# openssl — de outway-thumbprint uit een certificaat, alleen nodig als FSC_OUTWAY_THUMBPRINT niet
+# gezet is. Géén ca-certificates: elke call geeft zijn eigen --cacert mee (de interne PKI), dus de
+# publieke trust store wordt nergens geraadpleegd.
+RUN apk add --no-cache bash curl jq openssl
 
-COPY lib/ /opt/fsc/lib/
-COPY federatie/contracts/ /opt/fsc/contracts/
+# Alleen wat draait. De hele map kopiëren zou ook de fixture-tests meenemen en, erger, `bootstrap.sh`
+# en `fbs-contracten.sh` uitvoerbaar in de pod zetten — twee scripts die hier niets te zoeken hebben
+# omdat ze met beide managers tegelijk praten.
+#
+# ZAD/OpenShift start containers onder een willekeurige UID in groep 0, vandaar groep-0-eigendom en
+# leesrechten voor die groep.
+COPY --chown=1001:0 lib/fsc-harness.sh lib/fsc-contract.sh /opt/fsc/lib/
+COPY --chown=1001:0 federatie/contracts/bootstrap-consumer.sh \
+                    federatie/contracts/bootstrap-provider.sh \
+                    federatie/contracts/zad-lus.sh /opt/fsc/contracts/
 
-# ZAD/OpenShift start containers onder een willekeurige UID in groep 0. Bestanden dus groep-0-eigen
-# en groepsrechten gelijk aan de eigenaarsrechten, anders kan die UID de scripts niet lezen.
-RUN chgrp -R 0 /opt/fsc && chmod -R g=u /opt/fsc && chmod +x /opt/fsc/contracts/*.sh
+RUN chmod -R g=u /opt/fsc && chmod 0755 /opt/fsc/contracts/*.sh
 
 USER 1001
 ENV FSC_LIBDIR=/opt/fsc/lib

--- a/demo/environment/federatie/contracts/Dockerfile
+++ b/demo/environment/federatie/contracts/Dockerfile
@@ -1,0 +1,26 @@
+# Image voor de contract-bootstrap als ZAD-component: één per peer, in de deployment van díé peer.
+#
+# Waarom een component en geen CI-stap: de interne manager-API heeft op ZAD geen route en de
+# tenant-baseline-NetworkPolicy laat alleen verkeer binnen hetzelfde deployment toe. Alleen een pod
+# náást de manager kan hem bereiken. En omdat ZAD geen component-args toestaat, leest het
+# entrypoint zijn rol uit env in plaats van uit een argument.
+#
+# Build-context is demo/environment/ (niet deze map): de scripts leunen op ../../lib.
+FROM docker.io/library/alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce
+
+# bash — de scripts gebruiken arrays en `read -a`; curl — de manager-API; jq — de idempotentie leest
+# contract-JSON; openssl — de outway-thumbprint uit een certificaat; ca-certificates — voor de
+# publieke trust store. De manager-API zelf loopt op de interne PKI, die als CA-bestand meekomt.
+RUN apk add --no-cache bash curl jq openssl ca-certificates
+
+COPY lib/ /opt/fsc/lib/
+COPY federatie/contracts/ /opt/fsc/contracts/
+
+# ZAD/OpenShift start containers onder een willekeurige UID in groep 0. Bestanden dus groep-0-eigen
+# en groepsrechten gelijk aan de eigenaarsrechten, anders kan die UID de scripts niet lezen.
+RUN chgrp -R 0 /opt/fsc && chmod -R g=u /opt/fsc && chmod +x /opt/fsc/contracts/*.sh
+
+USER 1001
+ENV FSC_LIBDIR=/opt/fsc/lib
+
+ENTRYPOINT ["/opt/fsc/contracts/zad-lus.sh"]

--- a/demo/environment/federatie/contracts/bootstrap-consumer.sh
+++ b/demo/environment/federatie/contracts/bootstrap-consumer.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# De consumer-helft van de contract-bootstrap: dien een ServiceConnectionGrant in bij de EIGEN
+# manager en stel vast of hij geldig is geworden. Raakt de manager van de provider niet aan — daar
+# is geen adres, cert of CA voor, dus dat kan ook niet per ongeluk terugsluipen.
+#
+# Stroom:
+#   1. bereken de SPKI-SHA256-thumbprint van het GROUP-cert van de eigen outway (of neem hem uit
+#      env). Dat is waarmee de outway zich naar de provider-inway identificeert, en hij is stabiel
+#      bij cert-rotatie binnen hetzelfde sleutelpaar;
+#   2. staat er al een contract voor deze combinatie? Geldig en door de provider getekend: klaar.
+#      Wel ingediend maar nog niet getekend: wachten is aan de provider-helft;
+#   3. anders `POST /v1/contracts` op de eigen manager. Die tekent server-side namens ons en synct
+#      het contract via de mesh naar de provider.
+#
+# Uitgangen: 0 = contract geldig, 3 = ingediend maar nog niet getekend, 1 = fout, 2 = configuratie.
+# De 3 is geen fout: in de gesplitste opzet draaien de helften onafhankelijk, dus "de provider is
+# nog niet langsgeweest" is de normale tussenstand. De aanroeper (lokaal bootstrap.sh, op ZAD de
+# lus) draait gewoon opnieuw.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LIBDIR="${FSC_LIBDIR:-$(cd "${HERE}/../../lib" && pwd)}"
+
+# shellcheck source=../../lib/fsc-harness.sh
+. "${LIBDIR}/fsc-harness.sh"
+# shellcheck source=../../lib/fsc-contract.sh
+. "${LIBDIR}/fsc-contract.sh"
+
+fsc_errlog_init
+fsc_have_jq
+
+CONSUMER_OIN="$(fsc_env_vereist FSC_CONSUMER_OIN 'de OIN van deze peer')"
+PROVIDER_OIN="$(fsc_env_vereist FSC_PROVIDER_OIN 'de OIN van de aanbiedende peer')"
+SERVICE_NAME="$(fsc_env_vereist FSC_SERVICE_NAME 'de dienst die we willen afnemen')"
+GROUP_ID="${FSC_GROUP_ID:-moza-fbs-test}"
+
+MANAGER="$(fsc_env_vereist FSC_CONSUMER_MANAGER 'https://<eigen-manager>:9443')"
+CERT="$(fsc_env_vereist FSC_CONSUMER_CERT)"
+KEY="$(fsc_env_vereist FSC_CONSUMER_KEY)"
+CA="$(fsc_env_vereist FSC_CONSUMER_CA)"
+ADRES="${FSC_CONSUMER_ADRES:-}"
+
+fsc_contract_manager_ok "$MANAGER" || exit 2
+
+[ "$HAVE_JQ" -eq 1 ] || {
+  echo "FAIL: jq is vereist. De idempotentie leunt op het uitlezen van de contract-JSON; zonder jq" >&2
+  echo "  zou elke run een nieuw contract aanmaken in plaats van een bestaand te herkennen." >&2
+  exit 1
+}
+
+api() { fsc_contract_api "$MANAGER" "$CERT" "$KEY" "$CA" "$ADRES" "$@"; }
+
+# --- 1. Outway-thumbprint -----------------------------------------------------------------------
+# Uit env óf uit het certificaat. Op ZAD is env de weg: het group-cert van de outway hangt daar aan
+# het outway-component, en het aan een tweede component koppelen zou die identiteit verspreiden.
+THUMB="${FSC_OUTWAY_THUMBPRINT:-}"
+
+if [ -z "$THUMB" ]; then
+  OUTWAY_CERT="$(fsc_env_vereist FSC_OUTWAY_CERT 'of zet FSC_OUTWAY_THUMBPRINT rechtstreeks')"
+  command -v openssl >/dev/null 2>&1 || { echo "FAIL: openssl niet gevonden." >&2; exit 1; }
+
+  THUMB="$(fsc_outway_thumbprint "$OUTWAY_CERT")" || {
+    echo "FAIL: kon de outway-thumbprint niet berekenen uit ${OUTWAY_CERT}: $(fsc_last_error)" >&2
+    exit 1
+  }
+fi
+
+# Een meegegeven thumbprint gaat ongezien in de grant en bepaalt welke outway de dienst mag
+# afnemen; een typefout levert een contract op dat geldig heet en nooit werkt.
+case "$THUMB" in
+  [0-9a-f]*) [ "${#THUMB}" -eq 64 ] || { echo "FAIL: thumbprint is geen 64 hex-tekens: '${THUMB}'" >&2; exit 2; } ;;
+  *) echo "FAIL: thumbprint is geen 64 hex-tekens: '${THUMB}'" >&2; exit 2 ;;
+esac
+
+echo "consumer: outway public-key-thumbprint = ${THUMB}"
+
+# --- 2. Staat er al iets uit? -------------------------------------------------------------------
+eigen_contracten() {
+  local json
+  json="$(api "${MANAGER}/v1/contracts")" || {
+    echo "FAIL: kon de eigen contractenlijst niet ophalen: $(fsc_last_error)" >&2
+    return 1
+  }
+
+  # Met eigen melding: `fsc_contract_voor_combinatie` eindigt op `jq … 2>/dev/null`. Antwoordt de
+  # manager met 200 maar zonder geldige JSON (een proxy-foutpagina, een afgekapt antwoord), dan
+  # faalt deze pipeline onder `pipefail` en zou de aanroeper zonder deze tak zwijgend afbreken.
+  fsc_contract_voor_combinatie "$json" "$SERVICE_NAME" "$PROVIDER_OIN" "$CONSUMER_OIN" "$THUMB" | sort || {
+    echo "FAIL: de eigen contractenlijst is niet te lezen — geen geldige JSON?" >&2
+    return 1
+  }
+}
+
+# geldige_hashes <regels>: de hashes uit `<hash> <state> <getekend>`-regels die klaar zijn.
+geldige_hashes() {
+  printf '%s' "${1:-}" | awk '$2 == "contract_state_valid" && $3 == "ja" { print $1 }'
+}
+
+REGELS="$(eigen_contracten)" || exit 1
+GELDIG="$(geldige_hashes "$REGELS")"
+
+if [ -n "$GELDIG" ]; then
+  AANTAL="$(printf '%s\n' "$GELDIG" | grep -c .)"
+  HASH="$(printf '%s\n' "$GELDIG" | head -n1)"
+  echo "OK: er is al een geldig contract voor ${SERVICE_NAME} (${CONSUMER_OIN} -> ${PROVIDER_OIN})."
+  printf '%s\n' "$GELDIG" | sed 's/^/  contract: /'
+
+  if [ "$AANTAL" -gt 1 ]; then
+    # Kan ontstaan doordat de existence-check en de POST niet atomair zijn: twee gelijktijdige of
+    # herhaalde runs kunnen allebei posten. De outway gebruikt er sowieso maar één — het
+    # gesorteerd-eerste hash hierboven — maar de rest ruimt zichzelf hier op, zodat een volgende
+    # run weer bij één contract uitkomt.
+    echo "  WAARSCHUWING: ${AANTAL} geldige contracten voor dezelfde combinatie; trek de overtollige in." >&2
+    printf '%s\n' "$GELDIG" | tail -n +2 | while IFS= read -r dup; do
+      api -X PUT "${MANAGER}/v1/contracts/${dup}/revoke" -H 'Content-Type: application/json' >/dev/null \
+        && echo "  ingetrokken: ${dup}" >&2 \
+        || echo "  WARN: kon duplicaat ${dup} niet intrekken: $(fsc_last_error)" >&2
+    done
+  fi
+
+  echo "CONSUMER OK (bestaand contract ${HASH})."
+  exit 0
+fi
+
+if [ -n "$REGELS" ]; then
+  echo "consumer: contract is ingediend maar nog niet door de provider getekend:" >&2
+  printf '%s\n' "$REGELS" | sed 's/^/  /' >&2
+  echo "CONSUMER WACHT (provider-helft moet nog tekenen)."
+  exit 3
+fi
+
+# --- 3. Contract opstellen en indienen ----------------------------------------------------------
+IV="$(fsc_new_iv)"
+fsc_validity
+
+echo "consumer: serviceConnection-contract indienen bij de eigen manager..."
+# `service.type` is verplicht op een connection-grant (de publicatie-grant defaultte 'm, deze niet),
+# en `outway.identification` is sinds OpenFSC v2.0.0 een union met `type` als discriminator — de
+# platte v1-vorm wordt niet meer geaccepteerd. `fsc_version` zetten we niet zelf: de POST neemt
+# `createContractContent`, waar dat veld ontbreekt; de manager vult 'm en neemt 'm mee in de hash.
+#
+# Precies één grant, want dat is wat de provider-helft tekent: een contract met meer grants wordt
+# daar geweigerd in plaats van gedeeltelijk geaccepteerd.
+RESP="$(api -X POST "${MANAGER}/v1/contracts" -H 'Content-Type: application/json' -d "{
+  \"contract_content\": {
+    \"iv\": \"${IV}\",
+    \"group_id\": \"${GROUP_ID}\",
+    \"hash_algorithm\": \"HASH_ALGORITHM_SHA3_512\",
+    \"created_at\": ${NBF},
+    \"validity\": { \"not_before\": $((NBF - 60)), \"not_after\": ${NAF} },
+    \"grants\": [ {
+      \"type\": \"GRANT_TYPE_SERVICE_CONNECTION\",
+      \"service\": { \"type\": \"SERVICE_TYPE_SERVICE\", \"peer_id\": \"${PROVIDER_OIN}\", \"name\": \"${SERVICE_NAME}\" },
+      \"outway\": {
+        \"peer_id\": \"${CONSUMER_OIN}\",
+        \"identification\": {
+          \"type\": \"OUTWAY_IDENTIFICATION_TYPE_PUBLIC_KEY_THUMBPRINT\",
+          \"public_key_thumbprint\": \"${THUMB}\"
+        }
+      }
+    } ]
+  }
+}")" || { echo "FAIL: POST /v1/contracts geweigerd: ${RESP:-<leeg>} $(fsc_last_error)" >&2; exit 1; }
+
+HASH="$(printf '%s' "$RESP" | jq -r '.content_hash // empty' 2>/dev/null)" || HASH=""
+[ -n "$HASH" ] || { echo "FAIL: respons zonder content_hash (formaat geweigerd?): ${RESP}" >&2; exit 1; }
+
+echo "  eigen handtekening gezet; mesh-sync gestart; content_hash=${HASH}"
+
+# Hier niet wachten. De provider-helft is een los proces dat op dit moment nog niet langs is
+# geweest, dus elke seconde pollen levert gegarandeerd niets op; de aanroeper draait opnieuw.
+echo "CONSUMER WACHT (contract ${HASH} ingediend; provider-helft moet nog tekenen)."
+exit 3

--- a/demo/environment/federatie/contracts/bootstrap-consumer.sh
+++ b/demo/environment/federatie/contracts/bootstrap-consumer.sh
@@ -50,12 +50,13 @@ fsc_contract_manager_ok "$MANAGER" || exit 2
 
 api() { fsc_contract_api "$MANAGER" "$CERT" "$KEY" "$CA" "$ADRES" "$@"; }
 
-# De lijst is cursor-gepagineerd met een default van honderd, en bevat álles: publicatiecontracten,
+# De lijst is cursor-gepagineerd met een default van honderd en een maximum van duizend, en bevat
+# álles: publicatiecontracten,
 # ingetrokken en afgewezen contracten, van alle peers. In een langlevend deployment groeit dat
 # monotoon, en zodra ons eigen contract van pagina 1 valt zou de consumer elke ronde een nieuw
 # indienen. Een ruime limiet houdt de guard in fsc-contract.sh een vangrail in plaats van een
 # dagelijkse blokkade.
-CONTRACT_LIMIET="${FSC_CONTRACT_LIMIET:-1000}"
+CONTRACT_LIMIET="$(fsc_getal_vereist FSC_CONTRACT_LIMIET "${FSC_CONTRACT_LIMIET:-1000}")"
 
 # --- 1. Outway-thumbprint -----------------------------------------------------------------------
 # Uit env óf uit het certificaat. Op ZAD is env de weg: het group-cert van de outway hangt daar aan
@@ -112,6 +113,15 @@ GELDIG="$(geldige_hashes "$REGELS")"
 # `ontbreekt` betekent dat de manager het state-veld niet meestuurde — niet dat het contract
 # ongeldig is. Stil als "nog niet klaar" lezen zou hier eeuwig wachten opleveren op iets dat er al
 # staat, dus dat geval wordt gemeld.
+# Een afgewezen contract is het antwoord van de overkant op onze aanvraag. Het blijft in de lijst
+# staan, dus we dienen niet meteen opnieuw in — maar het moet wel blijken, anders wacht de operator
+# op iets dat nooit komt.
+if printf '%s' "$REGELS" | awk '$4 == "afgewezen" { gevonden = 1 } END { exit !gevonden }'; then
+  echo "WARN: de provider heeft minstens één van onze contracten AFGEWEZEN:" >&2
+  printf '%s\n' "$REGELS" | sed 's/^/  /' >&2
+  echo "  Kijk aan providerkant naar de WEIGER-regels; opnieuw indienen heeft pas zin na een fix." >&2
+fi
+
 if printf '%s' "$REGELS" | awk '$2 == "ontbreekt" { gevonden = 1 } END { exit !gevonden }'; then
   echo "WARN: de manager gaf voor minstens één contract geen state terug; die tellen hier niet als geldig." >&2
   printf '%s\n' "$REGELS" | sed 's/^/  /' >&2

--- a/demo/environment/federatie/contracts/bootstrap-consumer.sh
+++ b/demo/environment/federatie/contracts/bootstrap-consumer.sh
@@ -56,7 +56,7 @@ api() { fsc_contract_api "$MANAGER" "$CERT" "$KEY" "$CA" "$ADRES" "$@"; }
 # monotoon, en zodra ons eigen contract van pagina 1 valt zou de consumer elke ronde een nieuw
 # indienen. Een ruime limiet houdt de guard in fsc-contract.sh een vangrail in plaats van een
 # dagelijkse blokkade.
-CONTRACT_LIMIET="$(fsc_getal_vereist FSC_CONTRACT_LIMIET "${FSC_CONTRACT_LIMIET:-1000}")"
+CONTRACT_LIMIET="$(fsc_getal_hoogstens FSC_CONTRACT_LIMIET "${FSC_CONTRACT_LIMIET:-1000}" 1000)"
 
 # --- 1. Outway-thumbprint -----------------------------------------------------------------------
 # Uit env óf uit het certificaat. Op ZAD is env de weg: het group-cert van de outway hangt daar aan
@@ -101,7 +101,7 @@ eigen_contracten() {
   }
 }
 
-# geldige_hashes <regels>: de hashes uit `<hash> <state> <getekend>`-regels die klaar zijn.
+# geldige_hashes <regels>: de hashes uit `<hash> <state> <getekend> <afgewezen>`-regels die klaar zijn.
 geldige_hashes() {
   printf '%s' "${1:-}" | awk '$2 == "contract_state_valid" && $3 == "ja" { print $1 }'
 }

--- a/demo/environment/federatie/contracts/bootstrap-consumer.sh
+++ b/demo/environment/federatie/contracts/bootstrap-consumer.sh
@@ -50,6 +50,13 @@ fsc_contract_manager_ok "$MANAGER" || exit 2
 
 api() { fsc_contract_api "$MANAGER" "$CERT" "$KEY" "$CA" "$ADRES" "$@"; }
 
+# De lijst is cursor-gepagineerd met een default van honderd, en bevat álles: publicatiecontracten,
+# ingetrokken en afgewezen contracten, van alle peers. In een langlevend deployment groeit dat
+# monotoon, en zodra ons eigen contract van pagina 1 valt zou de consumer elke ronde een nieuw
+# indienen. Een ruime limiet houdt de guard in fsc-contract.sh een vangrail in plaats van een
+# dagelijkse blokkade.
+CONTRACT_LIMIET="${FSC_CONTRACT_LIMIET:-1000}"
+
 # --- 1. Outway-thumbprint -----------------------------------------------------------------------
 # Uit env óf uit het certificaat. Op ZAD is env de weg: het group-cert van de outway hangt daar aan
 # het outway-component, en het aan een tweede component koppelen zou die identiteit verspreiden.
@@ -79,7 +86,7 @@ echo "consumer: outway public-key-thumbprint = ${THUMB}"
 # --- 2. Staat er al iets uit? -------------------------------------------------------------------
 eigen_contracten() {
   local json
-  json="$(api "${MANAGER}/v1/contracts")" || {
+  json="$(api "${MANAGER}/v1/contracts?limit=${CONTRACT_LIMIET}")" || {
     echo "FAIL: kon de eigen contractenlijst niet ophalen: $(fsc_last_error)" >&2
     return 1
   }

--- a/demo/environment/federatie/contracts/bootstrap-consumer.sh
+++ b/demo/environment/federatie/contracts/bootstrap-consumer.sh
@@ -84,11 +84,11 @@ eigen_contracten() {
     return 1
   }
 
-  # Met eigen melding: `fsc_contract_voor_combinatie` eindigt op `jq … 2>/dev/null`. Antwoordt de
-  # manager met 200 maar zonder geldige JSON (een proxy-foutpagina, een afgekapt antwoord), dan
-  # faalt deze pipeline onder `pipefail` en zou de aanroeper zonder deze tak zwijgend afbreken.
+  # Met eigen melding, mét de reden erbij: de manager kan met 200 antwoorden en toch iets anders
+  # sturen dan een contractenlijst — een ander schema, een proxy-foutpagina, een afgekapt antwoord.
+  # "geen geldige JSON" zou daarbij vaak onwaar zijn en de operator de verkeerde kant op sturen.
   fsc_contract_voor_combinatie "$json" "$SERVICE_NAME" "$PROVIDER_OIN" "$CONSUMER_OIN" "$THUMB" | sort || {
-    echo "FAIL: de eigen contractenlijst is niet te lezen — geen geldige JSON?" >&2
+    echo "FAIL: de eigen contractenlijst is niet te lezen: $(fsc_last_error)" >&2
     return 1
   }
 }
@@ -128,6 +128,14 @@ if [ -n "$GELDIG" ]; then
     while IFS= read -r dup; do
       [ -n "$dup" ] || continue
 
+      # Het hash komt uit de respons en gaat een URL-pad in; een waarde met een schuine streep zou
+      # dat pad verleggen naar een ander endpoint.
+      if ! fsc_hash_ok "$dup"; then
+        echo "  FAIL: contract-hash met een onverwachte vorm overgeslagen: '${dup}'" >&2
+        REVOKE_FOUTEN=$((REVOKE_FOUTEN + 1))
+        continue
+      fi
+
       if uit="$(api -X PUT "${MANAGER}/v1/contracts/${dup}/revoke" -H 'Content-Type: application/json')"; then
         echo "  ingetrokken: ${dup}" >&2
       else
@@ -151,9 +159,12 @@ EOF
 fi
 
 if [ -n "$REGELS" ]; then
-  echo "consumer: contract is ingediend maar nog niet door de provider getekend:" >&2
+  # Bewust niet "de provider moet nog tekenen": de derde kolom kan `ja` zijn terwijl het contract
+  # hier nog niet geldig is — dan is de handtekening er wel maar de state nog niet, en zou die
+  # melding de operator naar de verkeerde helft sturen.
+  echo "consumer: contract is ingediend maar hier nog niet geldig:" >&2
   printf '%s\n' "$REGELS" | sed 's/^/  /' >&2
-  echo "CONSUMER WACHT (provider-helft moet nog tekenen)."
+  echo "CONSUMER WACHT (nog niet geldig bij ons)."
   exit 3
 fi
 

--- a/demo/environment/federatie/contracts/bootstrap-consumer.sh
+++ b/demo/environment/federatie/contracts/bootstrap-consumer.sh
@@ -45,7 +45,7 @@ fsc_contract_manager_ok "$MANAGER" || exit 2
 [ "$HAVE_JQ" -eq 1 ] || {
   echo "FAIL: jq is vereist. De idempotentie leunt op het uitlezen van de contract-JSON; zonder jq" >&2
   echo "  zou elke run een nieuw contract aanmaken in plaats van een bestaand te herkennen." >&2
-  exit 1
+  exit 2
 }
 
 api() { fsc_contract_api "$MANAGER" "$CERT" "$KEY" "$CA" "$ADRES" "$@"; }
@@ -57,7 +57,7 @@ THUMB="${FSC_OUTWAY_THUMBPRINT:-}"
 
 if [ -z "$THUMB" ]; then
   OUTWAY_CERT="$(fsc_env_vereist FSC_OUTWAY_CERT 'of zet FSC_OUTWAY_THUMBPRINT rechtstreeks')"
-  command -v openssl >/dev/null 2>&1 || { echo "FAIL: openssl niet gevonden." >&2; exit 1; }
+  command -v openssl >/dev/null 2>&1 || { echo "FAIL: openssl niet gevonden." >&2; exit 2; }
 
   THUMB="$(fsc_outway_thumbprint "$OUTWAY_CERT")" || {
     echo "FAIL: kon de outway-thumbprint niet berekenen uit ${OUTWAY_CERT}: $(fsc_last_error)" >&2
@@ -65,12 +65,14 @@ if [ -z "$THUMB" ]; then
   }
 fi
 
-# Een meegegeven thumbprint gaat ongezien in de grant en bepaalt welke outway de dienst mag
-# afnemen; een typefout levert een contract op dat geldig heet en nooit werkt.
-case "$THUMB" in
-  [0-9a-f]*) [ "${#THUMB}" -eq 64 ] || { echo "FAIL: thumbprint is geen 64 hex-tekens: '${THUMB}'" >&2; exit 2; } ;;
-  *) echo "FAIL: thumbprint is geen 64 hex-tekens: '${THUMB}'" >&2; exit 2 ;;
-esac
+# Een meegegeven thumbprint gaat ongezien in de grant en bepaalt welke outway de dienst mag afnemen;
+# een typefout levert een contract op dat geldig heet en nooit werkt. De waarde wordt bovendien
+# ongeëscaped in de JSON-body hieronder geïnterpoleerd, dus een aanhalingsteken erin zou de
+# contract-content herschrijven — vandaar een volledige vormcontrole en niet alleen de lengte.
+fsc_hex64 "$THUMB" || {
+  echo "FAIL: thumbprint is geen 64 lowercase hex-tekens: '${THUMB}'" >&2
+  exit 2
+}
 
 echo "consumer: outway public-key-thumbprint = ${THUMB}"
 
@@ -96,8 +98,17 @@ geldige_hashes() {
   printf '%s' "${1:-}" | awk '$2 == "contract_state_valid" && $3 == "ja" { print $1 }'
 }
 
+REVOKE_FOUTEN=0
 REGELS="$(eigen_contracten)" || exit 1
 GELDIG="$(geldige_hashes "$REGELS")"
+
+# `ontbreekt` betekent dat de manager het state-veld niet meestuurde — niet dat het contract
+# ongeldig is. Stil als "nog niet klaar" lezen zou hier eeuwig wachten opleveren op iets dat er al
+# staat, dus dat geval wordt gemeld.
+if printf '%s' "$REGELS" | awk '$2 == "ontbreekt" { gevonden = 1 } END { exit !gevonden }'; then
+  echo "WARN: de manager gaf voor minstens één contract geen state terug; die tellen hier niet als geldig." >&2
+  printf '%s\n' "$REGELS" | sed 's/^/  /' >&2
+fi
 
 if [ -n "$GELDIG" ]; then
   AANTAL="$(printf '%s\n' "$GELDIG" | grep -c .)"
@@ -107,15 +118,32 @@ if [ -n "$GELDIG" ]; then
 
   if [ "$AANTAL" -gt 1 ]; then
     # Kan ontstaan doordat de existence-check en de POST niet atomair zijn: twee gelijktijdige of
-    # herhaalde runs kunnen allebei posten. De outway gebruikt er sowieso maar één — het
-    # gesorteerd-eerste hash hierboven — maar de rest ruimt zichzelf hier op, zodat een volgende
-    # run weer bij één contract uitkomt.
-    echo "  WAARSCHUWING: ${AANTAL} geldige contracten voor dezelfde combinatie; trek de overtollige in." >&2
-    printf '%s\n' "$GELDIG" | tail -n +2 | while IFS= read -r dup; do
-      api -X PUT "${MANAGER}/v1/contracts/${dup}/revoke" -H 'Content-Type: application/json' >/dev/null \
-        && echo "  ingetrokken: ${dup}" >&2 \
-        || echo "  WARN: kon duplicaat ${dup} niet intrekken: $(fsc_last_error)" >&2
-    done
+    # herhaalde runs kunnen allebei posten. Ze zijn functioneel inwisselbaar — zelfde dienst, zelfde
+    # peers, zelfde outway — dus we houden er één aan en trekken de rest in. Welke dat is doet er
+    # niet toe zolang de keuze stabiel is over runs heen; vandaar gesorteerd en dan de eerste.
+    # `fbs-contracten.sh` leidt het grant-hash voor de `Fsc-Grant-Hash`-header uit datzelfde
+    # gesorteerd-eerste contract af, dus beide kanten komen bij hetzelfde uit.
+    echo "  ${AANTAL} geldige contracten voor dezelfde combinatie; de overtollige worden ingetrokken." >&2
+
+    while IFS= read -r dup; do
+      [ -n "$dup" ] || continue
+
+      if uit="$(api -X PUT "${MANAGER}/v1/contracts/${dup}/revoke" -H 'Content-Type: application/json')"; then
+        echo "  ingetrokken: ${dup}" >&2
+      else
+        # Geteld en niet alleen gemeld: blijft dit mislukken, dan groeit het aantal geldige
+        # contracten elke ronde door en is er niets dat dat rood maakt.
+        echo "  FAIL: kon duplicaat ${dup} niet intrekken: ${uit:-<leeg>} $(fsc_last_error)" >&2
+        REVOKE_FOUTEN=$((REVOKE_FOUTEN + 1))
+      fi
+    done <<EOF
+$(printf '%s\n' "$GELDIG" | tail -n +2)
+EOF
+
+    [ "$REVOKE_FOUTEN" -eq 0 ] || {
+      echo "FAIL: ${REVOKE_FOUTEN} duplicaat/duplicaten bleven staan." >&2
+      exit 1
+    }
   fi
 
   echo "CONSUMER OK (bestaand contract ${HASH})."

--- a/demo/environment/federatie/contracts/bootstrap-provider.sh
+++ b/demo/environment/federatie/contracts/bootstrap-provider.sh
@@ -11,8 +11,8 @@
 #   1  fout — een call mislukte, of een contract kon niet getekend worden
 #   2  configuratie deugt niet
 #   3  er is nog niets van een toegelaten consumer binnengekomen — wachten op de overkant
-#   4  er lagen contracten die de autorisatietoets niet haalden, en niets ervan mocht getekend
-#      (een eerder getekend contract dat de toets nu niet meer haalt wordt gemeld, niet geteld)
+#   4  er is niets getekend én er ligt iets dat aandacht vraagt: een contract dat de toets niet
+#      haalt, of een contract dat wij ooit tekenden en dat de toets nu niet meer haalt
 #
 # De 3 en de 4 zijn er omdat "niets gedaan" drie heel verschillende dingen kan betekenen. Zonder
 # die twee meldt een lege lijst hetzelfde als een gezonde ronde, en een verkeerd gezette allowlist
@@ -67,12 +67,12 @@ fsc_contract_manager_ok "$MANAGER" || exit 2
 
 api() { fsc_contract_api "$MANAGER" "$CERT" "$KEY" "$CA" "$ADRES" "$@"; }
 
-# De lijst is cursor-gepagineerd met een default van honderd, en bevat álles: publicatiecontracten,
-# ingetrokken en afgewezen contracten, van alle peers. In een langlevend deployment groeit dat
-# monotoon, en zodra ons eigen contract van pagina 1 valt zou de consumer elke ronde een nieuw
-# indienen. Een ruime limiet houdt de guard in fsc-contract.sh een vangrail in plaats van een
-# dagelijkse blokkade.
-CONTRACT_LIMIET="$(fsc_getal_vereist FSC_CONTRACT_LIMIET "${FSC_CONTRACT_LIMIET:-1000}")"
+# De lijst is cursor-gepagineerd met een default van honderd en een maximum van duizend, en bevat
+# álles: publicatiecontracten, ingetrokken en afgewezen contracten, van alle peers. In een langlevend
+# deployment groeit dat monotoon, en zodra ons eigen contract van pagina 1 valt zou de consumer elke
+# ronde een nieuw indienen. Een ruime limiet houdt de guard in fsc-contract.sh een vangrail in plaats
+# van een dagelijkse blokkade. Boven duizend geeft de manager een 400.
+CONTRACT_LIMIET="$(fsc_getal_hoogstens FSC_CONTRACT_LIMIET "${FSC_CONTRACT_LIMIET:-1000}" 1000)"
 
 DIENSTEN_JSON="$(fsc_lijst_naar_json FSC_DIENSTEN "$DIENSTEN")" || exit 2
 CONSUMERS_JSON="$(fsc_lijst_naar_json FSC_CONSUMERS "$CONSUMERS")" || exit 2
@@ -214,7 +214,7 @@ if [ -n "$AANDACHT" ] && [ "$GETEKEND" -eq 0 ]; then
 fi
 
 if [ "$GETEKEND" -gt 0 ]; then
-  echo "PROVIDER OK (${GETEKEND} contract(en) getekend${AFGEWEZEN:+, $(printf '%s\n' "$AFGEWEZEN" | grep -c .) geweigerd})."
+  echo "PROVIDER OK (${GETEKEND} contract(en) getekend${AFGEWEZEN:+, $(printf '%s\n' "$AFGEWEZEN" | grep -c .) geweigerd}${AANDACHT:+, $(printf '%s\n' "$AANDACHT" | grep -c .) met aandacht})."
   exit 0
 fi
 

--- a/demo/environment/federatie/contracts/bootstrap-provider.sh
+++ b/demo/environment/federatie/contracts/bootstrap-provider.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# De provider-helft van de contract-bootstrap: teken de binnengekomen ServiceConnectionGrants op de
+# EIGEN manager. Raakt de manager van de consumer niet aan — daar is geen adres, cert of CA voor,
+# dus dat kan ook niet per ongeluk terugsluipen.
+#
+# Vóór de splitsing was de accept een gerichte handeling: het script kende het hash dat het zelf net
+# had laten indienen. Hier kennen we dat hash niet en besluiten we per contract of we tekenen. Die
+# toets staat in fsc_contract_beoordeling(); lees daar waarom "precies één grant" de eis is en
+# waarom de thumbprint niet getoetst wordt.
+#
+# Uitgangen: 0 = niets meer te doen (alles getekend, of er was niets), 1 = fout, 2 = configuratie.
+# Geen aparte "nog niets binnen"-uitgang: een lege lijst is geen tussenstand maar gewoon niets te
+# doen. Of de consumer al ingediend heeft, is aan de consumer-helft om te melden.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LIBDIR="${FSC_LIBDIR:-$(cd "${HERE}/../../lib" && pwd)}"
+
+# shellcheck source=../../lib/fsc-harness.sh
+. "${LIBDIR}/fsc-harness.sh"
+# shellcheck source=../../lib/fsc-contract.sh
+. "${LIBDIR}/fsc-contract.sh"
+
+fsc_errlog_init
+fsc_have_jq
+
+PROVIDER_OIN="$(fsc_env_vereist FSC_PROVIDER_OIN 'de OIN van deze peer')"
+
+# Welke diensten wij aanbieden en welke consumers een contract van ons mogen krijgen. Beide
+# spaties-gescheiden. Dit is de autorisatiegrens: alles wat er niet in staat, tekenen we niet.
+DIENSTEN="$(fsc_env_vereist FSC_DIENSTEN 'spaties-gescheiden dienstnamen die deze peer aanbiedt')"
+CONSUMERS="$(fsc_env_vereist FSC_CONSUMERS 'spaties-gescheiden consumer-OINs die een contract mogen krijgen')"
+
+MANAGER="$(fsc_env_vereist FSC_PROVIDER_MANAGER 'https://<eigen-manager>:9443')"
+CERT="$(fsc_env_vereist FSC_PROVIDER_CERT)"
+KEY="$(fsc_env_vereist FSC_PROVIDER_KEY)"
+CA="$(fsc_env_vereist FSC_PROVIDER_CA)"
+ADRES="${FSC_PROVIDER_ADRES:-}"
+
+# Her-distributie van de accept-handtekening ook forceren voor contracten die we eerder al tekenden.
+# Uit by default: die push lukt normaal en elke ronde opnieuw pushen is een call per contract per
+# ronde, voor niets. Aan zetten is de knop voor een gestrande push (zie hieronder).
+FORCEER_DISTRIBUTIE="${FSC_FORCEER_DISTRIBUTIE:-0}"
+
+fsc_contract_manager_ok "$MANAGER" || exit 2
+
+[ "$HAVE_JQ" -eq 1 ] || {
+  echo "FAIL: jq is vereist. Zonder jq is niet vast te stellen wélk contract getekend mag worden," >&2
+  echo "  en blind tekenen zou elke aangeboden grant ondertekenen." >&2
+  exit 1
+}
+
+api() { fsc_contract_api "$MANAGER" "$CERT" "$KEY" "$CA" "$ADRES" "$@"; }
+
+# Woordsplitsing één keer, expliciet: `FSC_DIENSTEN=" "` komt langs de aanwezigheidscontrole
+# hierboven maar levert een lege lijst op, en een lege allowlist zou betekenen dat we niets meer
+# tekenen zonder dat iemand dat bedoeld heeft.
+read -r -a DIENSTEN_LIJST <<< "$DIENSTEN"
+read -r -a CONSUMERS_LIJST <<< "$CONSUMERS"
+
+[ "${#DIENSTEN_LIJST[@]}" -gt 0 ] || { echo "FAIL: FSC_DIENSTEN bevat geen enkele dienstnaam." >&2; exit 2; }
+[ "${#CONSUMERS_LIJST[@]}" -gt 0 ] || { echo "FAIL: FSC_CONSUMERS bevat geen enkele OIN." >&2; exit 2; }
+
+DIENSTEN_JSON="$(fsc_json_lijst "${DIENSTEN_LIJST[@]}")"
+CONSUMERS_JSON="$(fsc_json_lijst "${CONSUMERS_LIJST[@]}")"
+
+# --- De contracten ophalen en beoordelen ---------------------------------------------------------
+JSON="$(api "${MANAGER}/v1/contracts")" || {
+  echo "FAIL: kon de eigen contractenlijst niet ophalen: $(fsc_last_error)" >&2
+  exit 1
+}
+
+# Met eigen melding: `fsc_contract_beoordeling` eindigt op `jq … 2>/dev/null`. Antwoordt de manager
+# met 200 maar zonder geldige JSON (een proxy-foutpagina, een afgekapt antwoord), dan faalt deze
+# toekenning onder `pipefail` en zou het script zonder deze tak zwijgend afbreken.
+BEOORDELING="$(fsc_contract_beoordeling "$JSON" "$PROVIDER_OIN" "$DIENSTEN_JSON" "$CONSUMERS_JSON")" || {
+  echo "FAIL: de eigen contractenlijst is niet te lezen — geen geldige JSON?" >&2
+  exit 1
+}
+
+AFGEWEZEN="$(fsc_contract_regels "$BEOORDELING" WEIGER)"
+
+if [ -n "$AFGEWEZEN" ]; then
+  # Niet-tekenen is de stille uitkomst: zonder deze regels ziet een operator alleen dat er niets
+  # gebeurde, niet waarom. Geen fout — een contract dat wij niet tekenen, werkt niet, en dat is
+  # precies de bedoeling.
+  echo "provider: contracten die de toets niet halen en dus niet getekend worden:" >&2
+  printf '%s\n' "$AFGEWEZEN" | sed 's/^/  /' >&2
+fi
+
+# --- Tekenen -------------------------------------------------------------------------------------
+# `distribueer <hash> <consumer_oin>`: laat de accept-handtekening (opnieuw) naar de consumer sturen.
+#
+# De manager pusht die na de accept zelf, maar best-effort: begrensde backoff, geen cron-retry.
+# Strandt die push, dan blijft het contract bij de consumer `proposed` en ziet de outway de grant
+# nooit, terwijl het hier geldig heet. Vóór de splitsing merkte het script dat doordat het bij de
+# consumer keek; die kant is nu een ander proces op een andere manager. Deze helft kan het dus niet
+# waarnemen en stuurt daarom één keer na — goedkoop, en het dekt het geval dat de push tijdens de
+# accept mislukt. Strandt hij later alsnog, dan is FSC_FORCEER_DISTRIBUTIE=1 de knop.
+distribueer() {
+  local hash="$1" consumer="$2"
+  api -X PUT \
+    "${MANAGER}/v1/contracts/${hash}/distributions/${consumer}/DISTRIBUTION_ACTION_SUBMIT_ACCEPT_SIGNATURE/retry" \
+    -H 'Content-Type: application/json' >/dev/null \
+    || echo "  WARN: her-distributie van ${hash} naar ${consumer} gaf een fout: $(fsc_last_error)" >&2
+}
+
+GETEKEND=0
+FOUTEN=0
+
+while IFS=' ' read -r hash consumer; do
+  [ -n "$hash" ] || continue
+
+  echo "provider: tekenen ${hash} (consumer ${consumer})..."
+
+  if api -X PUT "${MANAGER}/v1/contracts/${hash}/accept" -H 'Content-Type: application/json' >/dev/null; then
+    GETEKEND=$((GETEKEND + 1))
+    distribueer "$hash" "$consumer"
+  else
+    echo "  FAIL: accept van ${hash} geweigerd: $(fsc_last_error)" >&2
+    FOUTEN=$((FOUTEN + 1))
+  fi
+done <<EOF
+$(fsc_contract_regels "$BEOORDELING" TEKEN)
+EOF
+
+if [ "$FORCEER_DISTRIBUTIE" = 1 ]; then
+  while IFS=' ' read -r hash consumer; do
+    [ -n "$hash" ] || continue
+
+    echo "provider: her-distributie forceren voor ${hash} (consumer ${consumer})..."
+    distribueer "$hash" "$consumer"
+  done <<EOF
+$(fsc_contract_regels "$BEOORDELING" GETEKEND)
+EOF
+fi
+
+if [ "$FOUTEN" -gt 0 ]; then
+  echo "PROVIDER ROOD: ${FOUTEN} van $((GETEKEND + FOUTEN)) contract(en) niet getekend." >&2
+  exit 1
+fi
+
+if [ "$GETEKEND" -gt 0 ]; then
+  echo "PROVIDER OK (${GETEKEND} contract(en) getekend)."
+else
+  echo "PROVIDER OK (niets te tekenen)."
+fi

--- a/demo/environment/federatie/contracts/bootstrap-provider.sh
+++ b/demo/environment/federatie/contracts/bootstrap-provider.sh
@@ -12,6 +12,7 @@
 #   2  configuratie deugt niet
 #   3  er is nog niets van een toegelaten consumer binnengekomen — wachten op de overkant
 #   4  er lagen contracten die de autorisatietoets niet haalden, en niets ervan mocht getekend
+#      (een eerder getekend contract dat de toets nu niet meer haalt wordt gemeld, niet geteld)
 #
 # De 3 en de 4 zijn er omdat "niets gedaan" drie heel verschillende dingen kan betekenen. Zonder
 # die twee meldt een lege lijst hetzelfde als een gezonde ronde, en een verkeerd gezette allowlist
@@ -38,8 +39,11 @@ CONSUMERS="$(fsc_env_vereist FSC_CONSUMERS 'consumer-OINs die een contract mogen
 
 GROUP_ID="${FSC_GROUP_ID:-moza-fbs-test}"
 
-# Bovengrens op de geldigheidsduur die een tegenpartij mag voorstellen. De consumer-helft vraagt tien
-# jaar; deze grens ligt er net boven, zodat hij die doorlaat maar een contract van honderd jaar niet.
+# Bovengrens op de RESTERENDE geldigheid (`not_after` min nu), niet op de vensterlengte: de vraag is
+# hoe lang een tegenpartij een claim op ons kan houden. De consumer-helft vraagt tien jaar; deze
+# grens ligt er ongeveer tien dagen boven, zodat een gewone aanvraag doorkomt maar een contract van
+# honderd jaar niet. Die tien dagen zijn tegelijk het volledige budget voor klokverschil tussen de
+# twee peers — wie deze waarde richting 315360000 bijstelt, haalt dat weg.
 MAX_GELDIGHEID="$(fsc_getal_vereist FSC_MAX_GELDIGHEID_SECONDEN "${FSC_MAX_GELDIGHEID_SECONDEN:-316224000}")"
 
 MANAGER="$(fsc_env_vereist FSC_PROVIDER_MANAGER 'https://<eigen-manager>:9443')"
@@ -63,11 +67,18 @@ fsc_contract_manager_ok "$MANAGER" || exit 2
 
 api() { fsc_contract_api "$MANAGER" "$CERT" "$KEY" "$CA" "$ADRES" "$@"; }
 
+# De lijst is cursor-gepagineerd met een default van honderd, en bevat álles: publicatiecontracten,
+# ingetrokken en afgewezen contracten, van alle peers. In een langlevend deployment groeit dat
+# monotoon, en zodra ons eigen contract van pagina 1 valt zou de consumer elke ronde een nieuw
+# indienen. Een ruime limiet houdt de guard in fsc-contract.sh een vangrail in plaats van een
+# dagelijkse blokkade.
+CONTRACT_LIMIET="${FSC_CONTRACT_LIMIET:-1000}"
+
 DIENSTEN_JSON="$(fsc_lijst_naar_json FSC_DIENSTEN "$DIENSTEN")" || exit 2
 CONSUMERS_JSON="$(fsc_lijst_naar_json FSC_CONSUMERS "$CONSUMERS")" || exit 2
 
 # --- De contracten ophalen en beoordelen ---------------------------------------------------------
-JSON="$(api "${MANAGER}/v1/contracts")" || {
+JSON="$(api "${MANAGER}/v1/contracts?limit=${CONTRACT_LIMIET}")" || {
   echo "FAIL: kon de eigen contractenlijst niet ophalen: $(fsc_last_error)" >&2
   exit 1
 }
@@ -80,6 +91,16 @@ BEOORDELING="$(fsc_contract_beoordeling \
 }
 
 AFGEWEZEN="$(fsc_contract_regels "$BEOORDELING" WEIGER)"
+
+# Contracten die wij ooit tekenden en die nu de toets niet meer halen. Geen besluit meer — het staat
+# er al — maar wel iets waar een operator van moet weten: doorgaans een gecorrigeerde allowlist of
+# een looptijd die inmiddels buiten de grens valt.
+AANDACHT="$(fsc_contract_regels "$BEOORDELING" AANDACHT)"
+
+if [ -n "$AANDACHT" ]; then
+  echo "provider: eerder getekende contracten die de toets nu niet meer halen:" >&2
+  printf '%s\n' "$AANDACHT" | sed 's/^/  /' >&2
+fi
 
 if [ -n "$AFGEWEZEN" ]; then
   # Niet-tekenen is de stille uitkomst: zonder deze regels ziet een operator alleen dat er niets
@@ -191,7 +212,11 @@ fi
 # Niets getekend en niets dat ons aangaat in de lijst: het contract van de consumer is hier nog niet.
 # Dat is wachten op de overkant en geen eindtoestand — de aanroeper hoort er kort op terug te komen
 # in plaats van naar het lange interval te gaan, anders duurt een verse bootstrap tot een uur.
-if [ -z "$(fsc_contract_regels "$BEOORDELING" GETEKEND)" ]; then
+# Alleen echt "nog niets binnen": geen getekend contract van ons, en ook geen contract dat ooit van
+# ons was. Zonder die tweede voorwaarde meldt een provider met een afgekeurd eigen contract elke
+# ronde dat er niets binnen is, terwijl het er wel ligt — en stuurt de lus de operator naar
+# WEIGER-regels die er niet zijn.
+if [ -z "$(fsc_contract_regels "$BEOORDELING" GETEKEND)" ] && [ -z "$AANDACHT" ]; then
   echo "PROVIDER WACHT (nog geen contract van een toegelaten consumer binnen)."
   exit 3
 fi

--- a/demo/environment/federatie/contracts/bootstrap-provider.sh
+++ b/demo/environment/federatie/contracts/bootstrap-provider.sh
@@ -3,14 +3,18 @@
 # EIGEN manager. Raakt de manager van de consumer niet aan — daar is geen adres, cert of CA voor,
 # dus dat kan ook niet per ongeluk terugsluipen.
 #
-# Vóór de splitsing was de accept een gerichte handeling: het script kende het hash dat het zelf net
-# had laten indienen. Hier kennen we dat hash niet en besluiten we per contract of we tekenen. Die
-# toets staat in fsc_contract_beoordeling(); lees daar waarom "precies één grant" de eis is en
-# waarom de thumbprint niet getoetst wordt.
+# Welk contract getekend mag worden, besluit `fsc_contract_beoordeling()`; lees daar waarom "precies
+# één grant" de eis is en waarom van de thumbprint wel het type maar niet de waarde telt.
 #
-# Uitgangen: 0 = niets meer te doen (alles getekend, of er was niets), 1 = fout, 2 = configuratie.
-# Geen aparte "nog niets binnen"-uitgang: een lege lijst is geen tussenstand maar gewoon niets te
-# doen. Of de consumer al ingediend heeft, is aan de consumer-helft om te melden.
+# Uitgangen:
+#   0  klaar — alles wat mocht is getekend, of er was niets
+#   1  fout — een call mislukte, of een contract kon niet getekend worden
+#   2  configuratie deugt niet
+#   4  er lagen contracten die de autorisatietoets niet haalden
+#
+# De 4 is er omdat "niets gedaan" twee heel verschillende dingen kan betekenen. Zonder die uitgang
+# meldt een verkeerd gezette allowlist precies hetzelfde als een gezonde ronde, en dan wacht de
+# consumer eeuwig terwijl dit component OK zegt.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
@@ -26,10 +30,16 @@ fsc_have_jq
 
 PROVIDER_OIN="$(fsc_env_vereist FSC_PROVIDER_OIN 'de OIN van deze peer')"
 
-# Welke diensten wij aanbieden en welke consumers een contract van ons mogen krijgen. Beide
-# spaties-gescheiden. Dit is de autorisatiegrens: alles wat er niet in staat, tekenen we niet.
-DIENSTEN="$(fsc_env_vereist FSC_DIENSTEN 'spaties-gescheiden dienstnamen die deze peer aanbiedt')"
-CONSUMERS="$(fsc_env_vereist FSC_CONSUMERS 'spaties-gescheiden consumer-OINs die een contract mogen krijgen')"
+# Welke diensten wij aanbieden en welke consumers een contract van ons mogen krijgen. Dit is de
+# autorisatiegrens: alles wat er niet in staat, tekenen we niet.
+DIENSTEN="$(fsc_env_vereist FSC_DIENSTEN 'dienstnamen die deze peer aanbiedt, gescheiden door witruimte')"
+CONSUMERS="$(fsc_env_vereist FSC_CONSUMERS 'consumer-OINs die een contract mogen krijgen, gescheiden door witruimte')"
+
+GROUP_ID="${FSC_GROUP_ID:-moza-fbs-test}"
+
+# Bovengrens op de geldigheidsduur die een tegenpartij mag voorstellen. De consumer-helft vraagt tien
+# jaar; deze grens ligt er net boven, zodat hij die doorlaat maar een contract van honderd jaar niet.
+MAX_GELDIGHEID="${FSC_MAX_GELDIGHEID_SECONDEN:-316224000}"
 
 MANAGER="$(fsc_env_vereist FSC_PROVIDER_MANAGER 'https://<eigen-manager>:9443')"
 CERT="$(fsc_env_vereist FSC_PROVIDER_CERT)"
@@ -38,8 +48,8 @@ CA="$(fsc_env_vereist FSC_PROVIDER_CA)"
 ADRES="${FSC_PROVIDER_ADRES:-}"
 
 # Her-distributie van de accept-handtekening ook forceren voor contracten die we eerder al tekenden.
-# Uit by default: die push lukt normaal en elke ronde opnieuw pushen is een call per contract per
-# ronde, voor niets. Aan zetten is de knop voor een gestrande push (zie hieronder).
+# Uit by default: die push lukt normaal, en elke ronde opnieuw pushen is een call per contract per
+# ronde voor niets. Aan zetten is de knop voor een gestrande push (zie `distribueer`).
 FORCEER_DISTRIBUTIE="${FSC_FORCEER_DISTRIBUTIE:-0}"
 
 fsc_contract_manager_ok "$MANAGER" || exit 2
@@ -47,22 +57,13 @@ fsc_contract_manager_ok "$MANAGER" || exit 2
 [ "$HAVE_JQ" -eq 1 ] || {
   echo "FAIL: jq is vereist. Zonder jq is niet vast te stellen wélk contract getekend mag worden," >&2
   echo "  en blind tekenen zou elke aangeboden grant ondertekenen." >&2
-  exit 1
+  exit 2
 }
 
 api() { fsc_contract_api "$MANAGER" "$CERT" "$KEY" "$CA" "$ADRES" "$@"; }
 
-# Woordsplitsing één keer, expliciet: `FSC_DIENSTEN=" "` komt langs de aanwezigheidscontrole
-# hierboven maar levert een lege lijst op, en een lege allowlist zou betekenen dat we niets meer
-# tekenen zonder dat iemand dat bedoeld heeft.
-read -r -a DIENSTEN_LIJST <<< "$DIENSTEN"
-read -r -a CONSUMERS_LIJST <<< "$CONSUMERS"
-
-[ "${#DIENSTEN_LIJST[@]}" -gt 0 ] || { echo "FAIL: FSC_DIENSTEN bevat geen enkele dienstnaam." >&2; exit 2; }
-[ "${#CONSUMERS_LIJST[@]}" -gt 0 ] || { echo "FAIL: FSC_CONSUMERS bevat geen enkele OIN." >&2; exit 2; }
-
-DIENSTEN_JSON="$(fsc_json_lijst "${DIENSTEN_LIJST[@]}")"
-CONSUMERS_JSON="$(fsc_json_lijst "${CONSUMERS_LIJST[@]}")"
+DIENSTEN_JSON="$(fsc_lijst_naar_json FSC_DIENSTEN "$DIENSTEN")" || exit 2
+CONSUMERS_JSON="$(fsc_lijst_naar_json FSC_CONSUMERS "$CONSUMERS")" || exit 2
 
 # --- De contracten ophalen en beoordelen ---------------------------------------------------------
 JSON="$(api "${MANAGER}/v1/contracts")" || {
@@ -70,11 +71,9 @@ JSON="$(api "${MANAGER}/v1/contracts")" || {
   exit 1
 }
 
-# Met eigen melding: `fsc_contract_beoordeling` eindigt op `jq … 2>/dev/null`. Antwoordt de manager
-# met 200 maar zonder geldige JSON (een proxy-foutpagina, een afgekapt antwoord), dan faalt deze
-# toekenning onder `pipefail` en zou het script zonder deze tak zwijgend afbreken.
-BEOORDELING="$(fsc_contract_beoordeling "$JSON" "$PROVIDER_OIN" "$DIENSTEN_JSON" "$CONSUMERS_JSON")" || {
-  echo "FAIL: de eigen contractenlijst is niet te lezen — geen geldige JSON?" >&2
+BEOORDELING="$(fsc_contract_beoordeling \
+  "$JSON" "$PROVIDER_OIN" "$DIENSTEN_JSON" "$CONSUMERS_JSON" "$GROUP_ID" "$MAX_GELDIGHEID")" || {
+  echo "FAIL: de contractenlijst is niet te beoordelen: $(fsc_last_error)" >&2
   exit 1
 }
 
@@ -82,8 +81,7 @@ AFGEWEZEN="$(fsc_contract_regels "$BEOORDELING" WEIGER)"
 
 if [ -n "$AFGEWEZEN" ]; then
   # Niet-tekenen is de stille uitkomst: zonder deze regels ziet een operator alleen dat er niets
-  # gebeurde, niet waarom. Geen fout — een contract dat wij niet tekenen, werkt niet, en dat is
-  # precies de bedoeling.
+  # gebeurde, niet waarom.
   echo "provider: contracten die de toets niet halen en dus niet getekend worden:" >&2
   printf '%s\n' "$AFGEWEZEN" | sed 's/^/  /' >&2
 fi
@@ -95,31 +93,68 @@ fi
 # Strandt die push, dan blijft het contract bij de consumer `proposed` en ziet de outway de grant
 # nooit, terwijl het hier geldig heet. Vóór de splitsing merkte het script dat doordat het bij de
 # consumer keek; die kant is nu een ander proces op een andere manager. Deze helft kan het dus niet
-# waarnemen en stuurt daarom één keer na — goedkoop, en het dekt het geval dat de push tijdens de
-# accept mislukt. Strandt hij later alsnog, dan is FSC_FORCEER_DISTRIBUTIE=1 de knop.
+# waarnemen en stuurt daarom één keer na. Strandt hij later alsnog, dan is FSC_FORCEER_DISTRIBUTIE=1
+# de knop.
+#
+# De uitkomst telt mee in FOUTEN: deze call ís het herstelmechanisme voor een gestrande push, dus
+# een mislukking hier stil laten verdwijnen zou juist het geval verbergen waarvoor hij bestaat.
 distribueer() {
-  local hash="$1" consumer="$2"
-  api -X PUT \
+  local hash="$1" consumer="$2" uit
+
+  uit="$(api -X PUT \
     "${MANAGER}/v1/contracts/${hash}/distributions/${consumer}/DISTRIBUTION_ACTION_SUBMIT_ACCEPT_SIGNATURE/retry" \
-    -H 'Content-Type: application/json' >/dev/null \
-    || echo "  WARN: her-distributie van ${hash} naar ${consumer} gaf een fout: $(fsc_last_error)" >&2
+    -H 'Content-Type: application/json')" || {
+    echo "  FAIL: her-distributie van ${hash} naar ${consumer} geweigerd: ${uit:-<leeg>} $(fsc_last_error)" >&2
+    return 1
+  }
 }
 
 GETEKEND=0
 FOUTEN=0
 
-while IFS=' ' read -r hash consumer; do
-  [ -n "$hash" ] || continue
+# Verwerk één beoordelingsregel. `hash` en `consumer` komen uit de respons en gaan een URL-pad in;
+# een waarde met een schuine streep of witruimte zou dat pad verleggen, dus eerst de vorm toetsen.
+verwerk() {
+  local soort="$1" hash="$2" consumer="$3" uit
+
+  case "$hash" in
+    ""|*[!A-Za-z0-9._~$+/-]*|*/*)
+      echo "  FAIL: contract-hash met een onverwachte vorm overgeslagen: '${hash}'" >&2
+      FOUTEN=$((FOUTEN + 1))
+      return
+      ;;
+  esac
+
+  case "$consumer" in
+    ""|*[!0-9]*)
+      echo "  FAIL: consumer-OIN met een onverwachte vorm overgeslagen: '${consumer}'" >&2
+      FOUTEN=$((FOUTEN + 1))
+      return
+      ;;
+  esac
+
+  if [ "$soort" = GETEKEND ]; then
+    echo "provider: her-distributie forceren voor ${hash} (consumer ${consumer})..."
+    distribueer "$hash" "$consumer" || FOUTEN=$((FOUTEN + 1))
+    return
+  fi
 
   echo "provider: tekenen ${hash} (consumer ${consumer})..."
 
-  if api -X PUT "${MANAGER}/v1/contracts/${hash}/accept" -H 'Content-Type: application/json' >/dev/null; then
+  if uit="$(api -X PUT "${MANAGER}/v1/contracts/${hash}/accept" -H 'Content-Type: application/json')"; then
     GETEKEND=$((GETEKEND + 1))
-    distribueer "$hash" "$consumer"
+    distribueer "$hash" "$consumer" || FOUTEN=$((FOUTEN + 1))
   else
-    echo "  FAIL: accept van ${hash} geweigerd: $(fsc_last_error)" >&2
+    echo "  FAIL: accept van ${hash} geweigerd: ${uit:-<leeg>} $(fsc_last_error)" >&2
     FOUTEN=$((FOUTEN + 1))
   fi
+}
+
+# Geen `| while`: dat draait in een subshell en dan komen GETEKEND/FOUTEN niet terug.
+while IFS=' ' read -r hash consumer; do
+  [ -n "$hash" ] || continue
+
+  verwerk TEKEN "$hash" "$consumer"
 done <<EOF
 $(fsc_contract_regels "$BEOORDELING" TEKEN)
 EOF
@@ -128,16 +163,20 @@ if [ "$FORCEER_DISTRIBUTIE" = 1 ]; then
   while IFS=' ' read -r hash consumer; do
     [ -n "$hash" ] || continue
 
-    echo "provider: her-distributie forceren voor ${hash} (consumer ${consumer})..."
-    distribueer "$hash" "$consumer"
+    verwerk GETEKEND "$hash" "$consumer"
   done <<EOF
 $(fsc_contract_regels "$BEOORDELING" GETEKEND)
 EOF
 fi
 
 if [ "$FOUTEN" -gt 0 ]; then
-  echo "PROVIDER ROOD: ${FOUTEN} van $((GETEKEND + FOUTEN)) contract(en) niet getekend." >&2
+  echo "PROVIDER ROOD: ${FOUTEN} handeling(en) mislukt, ${GETEKEND} contract(en) getekend." >&2
   exit 1
+fi
+
+if [ -n "$AFGEWEZEN" ]; then
+  echo "PROVIDER GEWEIGERD ($(printf '%s\n' "$AFGEWEZEN" | grep -c .) contract(en) haalden de toets niet, ${GETEKEND} getekend)." >&2
+  exit 4
 fi
 
 if [ "$GETEKEND" -gt 0 ]; then

--- a/demo/environment/federatie/contracts/bootstrap-provider.sh
+++ b/demo/environment/federatie/contracts/bootstrap-provider.sh
@@ -7,14 +7,15 @@
 # één grant" de eis is en waarom van de thumbprint wel het type maar niet de waarde telt.
 #
 # Uitgangen:
-#   0  klaar — alles wat mocht is getekend, of er was niets
+#   0  klaar — er is iets getekend, of alles wat ons aangaat stond er al
 #   1  fout — een call mislukte, of een contract kon niet getekend worden
 #   2  configuratie deugt niet
-#   4  er lagen contracten die de autorisatietoets niet haalden
+#   3  er is nog niets van een toegelaten consumer binnengekomen — wachten op de overkant
+#   4  er lagen contracten die de autorisatietoets niet haalden, en niets ervan mocht getekend
 #
-# De 4 is er omdat "niets gedaan" twee heel verschillende dingen kan betekenen. Zonder die uitgang
-# meldt een verkeerd gezette allowlist precies hetzelfde als een gezonde ronde, en dan wacht de
-# consumer eeuwig terwijl dit component OK zegt.
+# De 3 en de 4 zijn er omdat "niets gedaan" drie heel verschillende dingen kan betekenen. Zonder
+# die twee meldt een lege lijst hetzelfde als een gezonde ronde, en een verkeerd gezette allowlist
+# ook — waarna de aanroeper een uur gaat slapen terwijl de consumer elke vijftien seconden wacht.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
@@ -39,7 +40,7 @@ GROUP_ID="${FSC_GROUP_ID:-moza-fbs-test}"
 
 # Bovengrens op de geldigheidsduur die een tegenpartij mag voorstellen. De consumer-helft vraagt tien
 # jaar; deze grens ligt er net boven, zodat hij die doorlaat maar een contract van honderd jaar niet.
-MAX_GELDIGHEID="${FSC_MAX_GELDIGHEID_SECONDEN:-316224000}"
+MAX_GELDIGHEID="$(fsc_getal_vereist FSC_MAX_GELDIGHEID_SECONDEN "${FSC_MAX_GELDIGHEID_SECONDEN:-316224000}")"
 
 MANAGER="$(fsc_env_vereist FSC_PROVIDER_MANAGER 'https://<eigen-manager>:9443')"
 CERT="$(fsc_env_vereist FSC_PROVIDER_CERT)"
@@ -72,7 +73,8 @@ JSON="$(api "${MANAGER}/v1/contracts")" || {
 }
 
 BEOORDELING="$(fsc_contract_beoordeling \
-  "$JSON" "$PROVIDER_OIN" "$DIENSTEN_JSON" "$CONSUMERS_JSON" "$GROUP_ID" "$MAX_GELDIGHEID")" || {
+  "$JSON" "$PROVIDER_OIN" "$DIENSTEN_JSON" "$CONSUMERS_JSON" "$GROUP_ID" "$MAX_GELDIGHEID" \
+  "$(date -u +%s)")" || {
   echo "FAIL: de contractenlijst is niet te beoordelen: $(fsc_last_error)" >&2
   exit 1
 }
@@ -117,13 +119,11 @@ FOUTEN=0
 verwerk() {
   local soort="$1" hash="$2" consumer="$3" uit
 
-  case "$hash" in
-    ""|*[!A-Za-z0-9._~$+/-]*|*/*)
-      echo "  FAIL: contract-hash met een onverwachte vorm overgeslagen: '${hash}'" >&2
-      FOUTEN=$((FOUTEN + 1))
-      return
-      ;;
-  esac
+  if ! fsc_hash_ok "$hash"; then
+    echo "  FAIL: contract-hash met een onverwachte vorm overgeslagen: '${hash}'" >&2
+    FOUTEN=$((FOUTEN + 1))
+    return
+  fi
 
   case "$consumer" in
     ""|*[!0-9]*)
@@ -174,13 +174,26 @@ if [ "$FOUTEN" -gt 0 ]; then
   exit 1
 fi
 
-if [ -n "$AFGEWEZEN" ]; then
-  echo "PROVIDER GEWEIGERD ($(printf '%s\n' "$AFGEWEZEN" | grep -c .) contract(en) haalden de toets niet, ${GETEKEND} getekend)." >&2
+# Uitgang 4 alleen als er níéts getekend is. Anders was deze ronde gewoon productief en zou de
+# aanroeper hem onterecht als "beslissing, niets meer te doen" lezen — waarna één blijvend
+# onbetekenbaar contract van een oude consumer de lus permanent op het lange interval zet, en elke
+# nieuwe consumer daardoor tot een uur op zijn handtekening wacht.
+if [ -n "$AFGEWEZEN" ] && [ "$GETEKEND" -eq 0 ]; then
+  echo "PROVIDER GEWEIGERD ($(printf '%s\n' "$AFGEWEZEN" | grep -c .) contract(en) haalden de toets niet)." >&2
   exit 4
 fi
 
 if [ "$GETEKEND" -gt 0 ]; then
-  echo "PROVIDER OK (${GETEKEND} contract(en) getekend)."
-else
-  echo "PROVIDER OK (niets te tekenen)."
+  echo "PROVIDER OK (${GETEKEND} contract(en) getekend${AFGEWEZEN:+, $(printf '%s\n' "$AFGEWEZEN" | grep -c .) geweigerd})."
+  exit 0
 fi
+
+# Niets getekend en niets dat ons aangaat in de lijst: het contract van de consumer is hier nog niet.
+# Dat is wachten op de overkant en geen eindtoestand — de aanroeper hoort er kort op terug te komen
+# in plaats van naar het lange interval te gaan, anders duurt een verse bootstrap tot een uur.
+if [ -z "$(fsc_contract_regels "$BEOORDELING" GETEKEND)" ]; then
+  echo "PROVIDER WACHT (nog geen contract van een toegelaten consumer binnen)."
+  exit 3
+fi
+
+echo "PROVIDER OK (niets te tekenen)."

--- a/demo/environment/federatie/contracts/bootstrap-provider.sh
+++ b/demo/environment/federatie/contracts/bootstrap-provider.sh
@@ -72,7 +72,7 @@ api() { fsc_contract_api "$MANAGER" "$CERT" "$KEY" "$CA" "$ADRES" "$@"; }
 # monotoon, en zodra ons eigen contract van pagina 1 valt zou de consumer elke ronde een nieuw
 # indienen. Een ruime limiet houdt de guard in fsc-contract.sh een vangrail in plaats van een
 # dagelijkse blokkade.
-CONTRACT_LIMIET="${FSC_CONTRACT_LIMIET:-1000}"
+CONTRACT_LIMIET="$(fsc_getal_vereist FSC_CONTRACT_LIMIET "${FSC_CONTRACT_LIMIET:-1000}")"
 
 DIENSTEN_JSON="$(fsc_lijst_naar_json FSC_DIENSTEN "$DIENSTEN")" || exit 2
 CONSUMERS_JSON="$(fsc_lijst_naar_json FSC_CONSUMERS "$CONSUMERS")" || exit 2
@@ -201,6 +201,15 @@ fi
 # nieuwe consumer daardoor tot een uur op zijn handtekening wacht.
 if [ -n "$AFGEWEZEN" ] && [ "$GETEKEND" -eq 0 ]; then
   echo "PROVIDER GEWEIGERD ($(printf '%s\n' "$AFGEWEZEN" | grep -c .) contract(en) haalden de toets niet)." >&2
+  exit 4
+fi
+
+# Ook een uitsluitend-AANDACHT-ronde is geen succes. Er ligt dan een contract dat wij ooit tekenden
+# en dat nu de toets niet meer haalt: het datapad is stuk terwijl de consumer zijn contract geldig
+# ziet. Zou dit 0 opleveren, dan zet de lus de wachtteller op nul en blijft het component eeuwig
+# groen, met één stderr-regel per uur als enige spoor.
+if [ -n "$AANDACHT" ] && [ "$GETEKEND" -eq 0 ]; then
+  echo "PROVIDER GEWEIGERD ($(printf '%s\n' "$AANDACHT" | grep -c .) eerder getekend contract(en) halen de toets niet meer)." >&2
   exit 4
 fi
 

--- a/demo/environment/federatie/contracts/bootstrap.sh
+++ b/demo/environment/federatie/contracts/bootstrap.sh
@@ -1,301 +1,127 @@
 #!/usr/bin/env bash
 # Zet idempotent een geldig, wederzijds ondertekend ServiceConnectionGrant-contract op tussen een
-# consumer-peer en een provider-peer.
+# consumer-peer en een provider-peer, door de twee helften achter elkaar te draaien.
 #
-# Generiek: alle peers, adressen en certificaten komen uit env. `fbs-contracten.sh` ernaast vult
-# die in voor de FBS-peers en loopt over de magazijnen.
+# Generiek: alle peers, adressen en certificaten komen uit env. `fbs-contracten.sh` ernaast vult die
+# in voor de FBS-peers en loopt over de magazijnen.
 #
-# Stroom (OpenFSC Manager Internal-API):
-#   1. bereken de SPKI-SHA256-thumbprint van het GROUP-cert van de consumer-outway. Dat is waarmee
-#      de outway zich naar de provider-inway identificeert, en het is stabiel bij cert-rotatie
-#      binnen hetzelfde sleutelpaar;
-#   2. bestaat er al een geldig contract voor precies deze combinatie? Zo ja, en staat het ook al
-#      geldig bij de consumer: klaar. Staat het alleen bij de provider geldig (de accept-push naar
-#      de consumer kan stranden, zie stap 5), dan wordt hier hetzelfde herstel toegepast als bij een
-#      verse bootstrap, zónder opnieuw te posten;
-#   3. POST /v1/contracts op de EIGEN manager. Die tekent server-side namens de consumer en synct
-#      het contract via de mesh naar de provider;
-#   4. poll de provider tot het contract er is, dan PUT /v1/contracts/{hash}/accept op de
-#      PROVIDER-manager. Expliciet, want `AUTO_SIGN_GRANTS` dekt alleen (delegated)servicePublication;
-#   5. poll tot de CONSUMER het contract als `CONTRACT_STATE_VALID` ziet. De provider-accept wordt
-#      async naar de consumer gepusht met een begrensde backoff en zonder cron-retry; landt die
-#      niet, dan blijft het contract daar `proposed` en ziet de outway de grant nooit. Blijft het
-#      hangen, dan forceren we de her-distributie.
+# WAAROM TWEE HELFTEN. Op ZAD isoleert de tenant-baseline-NetworkPolicy per deployment en heeft de
+# interne manager-API geen route: één proces dat beide managers aanspreekt bestaat daar niet. De
+# helften praten daarom elk met precies één manager en het contract kruist via de FSC-mesh. Dit
+# script is de lokale aanroeper van diezelfde twee helften — niet een aparte, eenvoudigere variant.
+# Wat hier lokaal getoetst wordt, is dus de code die op ZAD draait.
 #
-# IDEMPOTENTIE ZONDER STATE-FILE. De generieke variant in `moza-fsc-testnet` onthoudt de
-# content-hash van het geaccepteerde contract in een bestand. Dat werkt op een ontwikkelmachine,
-# maar niet in een deploy: elke job start met een lege schijf, dus elke run maakt er nóg een
-# geldig contract bij. Deze variant leidt het bestaan af uit de contracten zelf — service, provider,
-# consumer-outway en thumbprint samen zijn de identiteit — zodat een herhaalde run een no-op is,
-# waar hij ook draait.
+# De scheiding wordt hier afgedwongen en niet alleen afgesproken: elke helft start met `env -u` op
+# de adres- en certificaat-variabelen van de overkant. Zou er ooit een call naar de andere manager
+# in sluipen, dan faalt die hier meteen in plaats van pas op ZAD.
 #
-# De existence-check (stap 2) en de POST (stap 3) zijn niet atomair: twee gelijktijdige of
-# herhaalde runs kunnen allebei een nieuw contract posten. Dat wordt hier niet voorkomen (dat vergt
-# een lock, en dus weer state), maar wel zelf-herstellend gemaakt: bij meer dan één geldig contract
-# voor dezelfde combinatie trekt de eerstvolgende run de overtollige in via
-# `PUT /v1/contracts/{hash}/revoke` en gebruikt verder altijd het (sorteer-)eerste hash — stabiel
-# over runs heen, ook als de volgorde van de manager-API zelf niet gegarandeerd stabiel is.
+# Stroom:
+#   1. consumer-helft: contract indienen bij de eigen manager (of vaststellen dat het er al is);
+#   2. provider-helft: het binnengekomen contract tekenen, na de autorisatietoets;
+#   3. consumer-helft opnieuw: vaststellen dat het contract nu geldig is.
+#
+# De eerste stap eindigt op 3 ("ingediend, nog niet getekend"); dat is de normale tussenstand en
+# geen fout. Zie de moduledocs van de twee helften voor de details per kant.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
-ENVDIR="$(cd "${HERE}/../.." && pwd)"
 
-# shellcheck source=../../lib/fsc-harness.sh
-. "${ENVDIR}/lib/fsc-harness.sh"
-
-fsc_errlog_init
-fsc_have_jq
-
-# --- Parameters ---------------------------------------------------------------------------------
 CONSUMER_OIN="${FSC_CONSUMER_OIN:?zet FSC_CONSUMER_OIN}"
-PROVIDER_OIN="${FSC_PROVIDER_OIN:?zet FSC_PROVIDER_OIN}"
 SERVICE_NAME="${FSC_SERVICE_NAME:?zet FSC_SERVICE_NAME}"
-GROUP_ID="${FSC_GROUP_ID:-moza-fbs-test}"
 
-# Het GROUP-cert van de consumer-outway (host-pad). Bewust het group- en niet het internal-cert:
-# de outway registreert bij zijn controller met zijn group-cert en stuurt datzelfde thumbprint naar
-# GetOutwayServices, waar de manager het tegen de grant matcht.
-OUTWAY_CERT="${FSC_OUTWAY_CERT:?zet FSC_OUTWAY_CERT}"
+# De variabelen die de ene helft nooit mag zien. Alleen adressen en sleutelmateriaal: de OIN's zijn
+# publieke organisatienummers en beide helften hebben ze nodig om te weten waar het contract over
+# gaat.
+PROVIDER_GEHEIM=(FSC_PROVIDER_MANAGER FSC_PROVIDER_CERT FSC_PROVIDER_KEY FSC_PROVIDER_CA FSC_PROVIDER_ADRES)
+CONSUMER_GEHEIM=(FSC_CONSUMER_MANAGER FSC_CONSUMER_CERT FSC_CONSUMER_KEY FSC_CONSUMER_CA FSC_CONSUMER_ADRES)
 
-CONSUMER_MANAGER="${FSC_CONSUMER_MANAGER:?zet FSC_CONSUMER_MANAGER}"
-CONSUMER_CERT="${FSC_CONSUMER_CERT:?zet FSC_CONSUMER_CERT}"
-CONSUMER_KEY="${FSC_CONSUMER_KEY:?zet FSC_CONSUMER_KEY}"
-CONSUMER_CA="${FSC_CONSUMER_CA:?zet FSC_CONSUMER_CA}"
+# zonder <var...> -- <commando...>: draai het commando zonder die variabelen in zijn omgeving.
+zonder() {
+  local args=()
+  while [ "$1" != -- ]; do args+=(-u "$1"); shift; done
+  shift
 
-PROVIDER_MANAGER="${FSC_PROVIDER_MANAGER:?zet FSC_PROVIDER_MANAGER}"
-PROVIDER_CERT="${FSC_PROVIDER_CERT:?zet FSC_PROVIDER_CERT}"
-PROVIDER_KEY="${FSC_PROVIDER_KEY:?zet FSC_PROVIDER_KEY}"
-PROVIDER_CA="${FSC_PROVIDER_CA:?zet FSC_PROVIDER_CA}"
-
-SYNC_TIMEOUT="${FSC_SYNC_TIMEOUT:-20}"
-SYNC_INTERVAL="${FSC_SYNC_INTERVAL:-2}"
-
-# De adressen worden geconcateneerd tot curl's URL-argument; een waarde die met `-` begint zou curl
-# als optie lezen (`-K/pad` maakt er een config-file-lees van).
-for _adres in "$CONSUMER_MANAGER" "$PROVIDER_MANAGER"; do
-  case "$_adres" in
-    https://*) ;;
-    *) echo "FAIL: manager-adres moet met https:// beginnen: '${_adres}'" >&2; exit 2 ;;
-  esac
-done
-
-[ "$HAVE_JQ" -eq 1 ] || {
-  echo "FAIL: jq is vereist. De idempotentie leunt op het uitlezen van de contract-JSON; zonder jq" >&2
-  echo "  zou elke run een nieuw contract aanmaken in plaats van een bestaand te herkennen." >&2
-  exit 1
+  env "${args[@]}" "$@"
 }
 
-# --- curl-helpers -------------------------------------------------------------------------------
-# Rechtstreeks vanaf de host: onder hostnet luisteren alle managers in de netns van de aanroeper.
-# De namen staan niet in /etc/hosts (extra_hosts geldt alleen binnen containers), vandaar --resolve
-# op elk manager-adres.
-#
-# Welk adres dat is, verschilt per opstelling: in een standalone harness luistert alles op
-# 127.0.0.1, in de federatie heeft elke component een eigen adres. Vandaar per kant overrulebaar,
-# met de standalone-waarde als default.
-CONSUMER_ADRES="${FSC_CONSUMER_ADRES:-127.0.0.1}"
-PROVIDER_ADRES="${FSC_PROVIDER_ADRES:-127.0.0.1}"
-
-resolve_args() {
-  local url="$1" adres="$2" hostnaam poort
-  hostnaam="${url#https://}"; hostnaam="${hostnaam%%/*}"
-  poort="${hostnaam##*:}"; hostnaam="${hostnaam%%:*}"
-  printf '%s\n' --resolve "${hostnaam}:${poort}:${adres}"
+consumer_helft() {
+  zonder "${PROVIDER_GEHEIM[@]}" -- "${HERE}/bootstrap-consumer.sh"
 }
 
-# api <manager-url> <cert> <key> <ca> <adres> <curl-args...>
-api() {
-  local url="$1" cert="$2" key="$3" ca="$4" adres="$5"; shift 5
-  local r args=()
-  while IFS= read -r r; do args+=("$r"); done < <(resolve_args "$url" "$adres")
-
-  curl -sS --fail-with-body --noproxy '*' "${args[@]}" \
-    --cert "$cert" --key "$key" --cacert "$ca" "$@" 2>"$ERRLOG"
+provider_helft() {
+  # De allowlist van de provider is hier precies één dienst en één consumer: dit script zet één
+  # contract op en heeft geen reden een bredere toestemming te openen. Op ZAD staat de lijst in de
+  # component-env en kan hij meer dan één regel dragen.
+  zonder "${CONSUMER_GEHEIM[@]}" -- \
+    FSC_DIENSTEN="$SERVICE_NAME" FSC_CONSUMERS="$CONSUMER_OIN" \
+    "${HERE}/bootstrap-provider.sh"
 }
 
-consumer_api() { api "$CONSUMER_MANAGER" "$CONSUMER_CERT" "$CONSUMER_KEY" "$CONSUMER_CA" "$CONSUMER_ADRES" "$@"; }
-provider_api() { api "$PROVIDER_MANAGER" "$PROVIDER_CERT" "$PROVIDER_KEY" "$PROVIDER_CA" "$PROVIDER_ADRES" "$@"; }
+# --- 1. Consumer dient in -------------------------------------------------------------------------
+rc=0
+consumer_helft || rc=$?
 
-# --- 1. Outway-thumbprint -----------------------------------------------------------------------
-command -v openssl >/dev/null 2>&1 || { echo "FAIL: openssl niet gevonden." >&2; exit 1; }
-[ -r "$OUTWAY_CERT" ] || { echo "FAIL: outway-cert niet leesbaar: ${OUTWAY_CERT} (pki/issue.sh gedraaid?)" >&2; exit 1; }
-
-THUMB="$(fsc_outway_thumbprint "$OUTWAY_CERT")" \
-  || { echo "FAIL: kon de outway-thumbprint niet berekenen uit ${OUTWAY_CERT}: $(fsc_last_error)" >&2; exit 1; }
-echo "bootstrap: outway public-key-thumbprint = ${THUMB}"
-
-# --- Sync-helpers (gebruikt door zowel de existence-check als de verse bootstrap-flow) -----------
-VALID_STATE=contract_state_valid
-
-# contract_zichtbaar <hash>: staat dit contract al in de contractenlijst van de provider?
-contract_zichtbaar() {
-  local hash="$1" rc
-  provider_api "${PROVIDER_MANAGER}/v1/contracts" 2>"$ERRLOG" \
-    | jq -e --arg h "$hash" 'any(.contracts[]?; .hash == $h)' >/dev/null 2>>"$ERRLOG"
-  rc=$?
-  fsc_warn_errlog "sync-poll (provider)"
-  return "$rc"
-}
-
-# consumer_state <hash>: manager-state van dit contract op de consumer, of "onbekend".
-consumer_state() {
-  local hash="$1" json rc state
-  json="$(consumer_api "${CONSUMER_MANAGER}/v1/contracts" 2>"$ERRLOG")"
-  rc=$?
-  fsc_warn_errlog "state-poll (consumer)"
-  [ "$rc" -eq 0 ] || { echo onbekend; return; }
-
-  state="$(fsc_contract_state "$json" "$hash")"
-  [ "$state" = unknown ] && echo onbekend || printf '%s\n' "$state"
-}
-
-# wacht_op_valid <hash>: pollt tot de consumer het contract als geldig ziet, of tot SYNC_TIMEOUT.
-wacht_op_valid() {
-  local hash="$1" elapsed=0
-  while [ "$elapsed" -lt "$SYNC_TIMEOUT" ]; do
-    [ "$(consumer_state "$hash")" = "$VALID_STATE" ] && return 0
-
-    sleep "$SYNC_INTERVAL"; elapsed=$((elapsed + SYNC_INTERVAL))
-    echo "  ...contract nog niet 'valid' op de consumer (${elapsed}s)" >&2
-  done
-  return 1
-}
-
-# zorg_dat_consumer_gesynct <hash>: wacht tot de consumer het contract geldig ziet; forceert één
-# keer de her-distributie van de accept-handtekening als dat niet vanzelf lukt binnen SYNC_TIMEOUT
-# (het canonieke herstel voor een gestrande best-effort-push, zie de moduledoc).
-zorg_dat_consumer_gesynct() {
-  local hash="$1"
-  wacht_op_valid "$hash" && return 0
-
-  echo "bootstrap: accept-handtekening opnieuw laten distribueren..." >&2
-  provider_api -X PUT \
-    "${PROVIDER_MANAGER}/v1/contracts/${hash}/distributions/${CONSUMER_OIN}/DISTRIBUTION_ACTION_SUBMIT_ACCEPT_SIGNATURE/retry" \
-    -H 'Content-Type: application/json' >/dev/null \
-    || echo "  WARN: her-distributie gaf een fout: $(fsc_last_error)" >&2
-
-  wacht_op_valid "$hash"
-}
-
-# --- 2. Bestaat het contract al? ------------------------------------------------------------------
-# De identiteit van een serviceConnection is de combinatie service + provider + consumer-outway +
-# thumbprint. Alleen op servicenaam matchen zou het servicePublication-contract voor dezelfde
-# dienst meetellen, dat op dezelfde manager staat en altijd matcht.
-bestaande_contracten() {  # hashes van geldige, niet-ingetrokken contracten voor deze combinatie, gesorteerd
-  local json
-  json="$(provider_api "${PROVIDER_MANAGER}/v1/contracts")" || {
-    echo "FAIL: kon de contracten van de provider niet ophalen: $(fsc_last_error)" >&2
-    return 1
-  }
-
-  # Met eigen melding: `fsc_grant_actief` eindigt op `jq … 2>/dev/null` en heeft geen
-  # fallback-waarde. Antwoordt de manager met 200 maar zonder geldige JSON (een proxy-foutpagina,
-  # een afgekapt antwoord), dan faalt deze pipeline onder `pipefail` en zou de aanroeper zonder
-  # deze tak zwijgend afbreken — de laag erboven meldt dan alleen "contract niet opgezet".
-  fsc_grant_actief "$json" "$SERVICE_NAME" "$PROVIDER_OIN" "$CONSUMER_OIN" "$THUMB" | sort || {
-    echo "FAIL: de contractenlijst van de provider is niet te lezen — geen geldige JSON?" >&2
-    return 1
-  }
-}
-
-BESTAAND="$(bestaande_contracten)" || exit 1
-if [ -n "$BESTAAND" ]; then
-  AANTAL="$(printf '%s\n' "$BESTAAND" | grep -c .)"
-  HASH="$(printf '%s\n' "$BESTAAND" | head -n1)"
-  echo "OK: er is al een geldig contract voor ${SERVICE_NAME} (${CONSUMER_OIN} -> ${PROVIDER_OIN})."
-  printf '%s\n' "$BESTAAND" | sed 's/^/  contract: /'
-
-  if [ "$AANTAL" -gt 1 ]; then
-    # Kan ontstaan doordat deze existence-check en de POST (stap 3) niet atomair zijn: twee
-    # gelijktijdige of herhaalde runs kunnen allebei een nieuw contract posten. De outway gebruikt
-    # er sowieso maar één — het gesorteerd-eerste hash hierboven — maar de rest ruimt zichzelf hier
-    # op, zodat een volgende run weer bij één contract uitkomt.
-    echo "  WAARSCHUWING: ${AANTAL} geldige contracten voor dezelfde combinatie; trek de overtollige in." >&2
-    printf '%s\n' "$BESTAAND" | tail -n +2 | while IFS= read -r dup; do
-      provider_api -X PUT "${PROVIDER_MANAGER}/v1/contracts/${dup}/revoke" \
-          -H 'Content-Type: application/json' >/dev/null 2>"$ERRLOG" \
-        && echo "  ingetrokken: ${dup}" >&2 \
-        || echo "  WARN: kon duplicaat ${dup} niet intrekken: $(fsc_last_error)" >&2
-    done
-  fi
-
-  if [ "$(consumer_state "$HASH")" = "$VALID_STATE" ]; then
-    echo "BOOTSTRAP OK (bestaand contract)."
-    exit 0
-  fi
-
-  # Geldig op de provider, maar (nog) niet gesynct naar de consumer — zonder deze controle zou een
-  # retry hier ten onrechte "klaar" melden terwijl de outway de grant nooit ziet (zie moduledoc).
-  echo "bootstrap: contract ${HASH} is geldig op de provider maar nog niet gesynct naar de consumer..." >&2
-  zorg_dat_consumer_gesynct "$HASH" || {
-    echo "FAIL: contract ${HASH} werd niet 'valid' op de consumer (state: $(consumer_state "$HASH"))." >&2
-    exit 1
-  }
-  echo "OK: contract ${HASH} is alsnog wederzijds gesynct."
-  echo "BOOTSTRAP OK (bestaand contract, opnieuw gesynct)."
+if [ "$rc" -eq 0 ]; then
+  echo "BOOTSTRAP OK (bestaand contract)."
   exit 0
 fi
 
-# --- 3. Contract opstellen en indienen bij de eigen manager --------------------------------------
-IV="$(fsc_new_iv)"
-fsc_validity
+[ "$rc" -eq 3 ] || {
+  echo "FAIL: de consumer-helft brak af (exit ${rc})." >&2
+  exit "$rc"
+}
 
-echo "bootstrap: serviceConnection-contract indienen bij de consumer-manager..."
-# `service.type` is verplicht op een connection-grant (de publicatie-grant defaultte 'm, deze niet),
-# en `outway.identification` is sinds OpenFSC v2.0.0 een union met `type` als discriminator — de
-# platte v1-vorm wordt niet meer geaccepteerd. `fsc_version` zetten we niet zelf: de POST neemt
-# `createContractContent`, waar dat veld ontbreekt; de manager vult 'm en neemt 'm mee in de hash.
-RESP="$(consumer_api -X POST "${CONSUMER_MANAGER}/v1/contracts" -H 'Content-Type: application/json' -d "{
-  \"contract_content\": {
-    \"iv\": \"${IV}\",
-    \"group_id\": \"${GROUP_ID}\",
-    \"hash_algorithm\": \"HASH_ALGORITHM_SHA3_512\",
-    \"created_at\": ${NBF},
-    \"validity\": { \"not_before\": $((NBF - 60)), \"not_after\": ${NAF} },
-    \"grants\": [ {
-      \"type\": \"GRANT_TYPE_SERVICE_CONNECTION\",
-      \"service\": { \"type\": \"SERVICE_TYPE_SERVICE\", \"peer_id\": \"${PROVIDER_OIN}\", \"name\": \"${SERVICE_NAME}\" },
-      \"outway\": {
-        \"peer_id\": \"${CONSUMER_OIN}\",
-        \"identification\": {
-          \"type\": \"OUTWAY_IDENTIFICATION_TYPE_PUBLIC_KEY_THUMBPRINT\",
-          \"public_key_thumbprint\": \"${THUMB}\"
-        }
-      }
-    } ]
+# --- 2. Provider tekent ---------------------------------------------------------------------------
+echo
+provider_helft || {
+  echo "FAIL: de provider-helft brak af." >&2
+  exit 1
+}
+
+# --- 3. Consumer stelt vast dat het contract geldig is --------------------------------------------
+# Het wachten staat hier en niet in de consumer-helft. Die weet niet of de provider al getekend
+# heeft, dus daar zou elke aanroep blind pollen — ook de allereerste, waar de provider gegarandeerd
+# nog niet langs is geweest. Deze aanroeper weet het wél: stap 2 is net klaar. Op ZAD vervult de
+# lus om de helften heen dezelfde rol.
+wacht_tot_geldig() {
+  local timeout="${FSC_SYNC_TIMEOUT:-20}" interval="${FSC_SYNC_INTERVAL:-2}" elapsed=0 uitkomst
+
+  while :; do
+    uitkomst=0
+    consumer_helft || uitkomst=$?
+
+    # Alleen 3 ("ingediend, nog niet getekend") is het wachten waard; 0 is klaar en de rest is fout.
+    [ "$uitkomst" -eq 3 ] || return "$uitkomst"
+    [ "$elapsed" -lt "$timeout" ] || return 3
+
+    sleep "$interval"; elapsed=$((elapsed + interval))
+    echo "  ...contract nog niet geldig bij de consumer (${elapsed}s)" >&2
+  done
+}
+
+echo
+rc=0
+wacht_tot_geldig || rc=$?
+
+if [ "$rc" -eq 3 ]; then
+  # De provider heeft getekend, dus als de consumer het contract nog niet geldig ziet is de
+  # accept-handtekening onderweg blijven steken. Dat is precies het geval waar de provider-helft
+  # zijn her-distributie voor heeft; die is al één keer gestuurd, dus hier nog eens forceren.
+  echo
+  echo "bootstrap: contract nog niet geldig bij de consumer; her-distributie forceren..." >&2
+  FSC_FORCEER_DISTRIBUTIE=1 provider_helft || {
+    echo "FAIL: her-distributie via de provider-helft brak af." >&2
+    exit 1
   }
-}")" || { echo "FAIL: POST /v1/contracts geweigerd: ${RESP:-<leeg>} $(fsc_last_error)" >&2; exit 1; }
 
-HASH="$(printf '%s' "$RESP" | jq -r '.content_hash // empty' 2>/dev/null)" || HASH=""
-[ -n "$HASH" ] || { echo "FAIL: respons zonder content_hash (formaat geweigerd?): ${RESP}" >&2; exit 1; }
-echo "  consumer-handtekening gezet; mesh-sync gestart; content_hash=${HASH}"
+  echo
+  rc=0
+  wacht_tot_geldig || rc=$?
+fi
 
-# --- 4. Provider accepteert ----------------------------------------------------------------------
-echo "bootstrap: wachten tot het contract naar de provider gesynct is..."
-elapsed=0; gesynct=0
-while [ "$elapsed" -lt "$SYNC_TIMEOUT" ]; do
-  if contract_zichtbaar "$HASH"; then gesynct=1; break; fi
-
-  sleep "$SYNC_INTERVAL"; elapsed=$((elapsed + SYNC_INTERVAL))
-  echo "  ...nog niet gesynct (${elapsed}s)" >&2
-done
-
-[ "$gesynct" -eq 1 ] || {
-  echo "FAIL: contract ${HASH} is niet binnen ${SYNC_TIMEOUT}s naar de provider gesynct." >&2
+[ "$rc" -eq 0 ] || {
+  echo "FAIL: het contract werd niet geldig bij de consumer (exit ${rc})." >&2
   exit 1
 }
 
-echo "bootstrap: provider accepteert..."
-provider_api -X PUT "${PROVIDER_MANAGER}/v1/contracts/${HASH}/accept" -H 'Content-Type: application/json' >/dev/null \
-  || { echo "FAIL: PUT accept (${HASH}) geweigerd: $(fsc_last_error)" >&2; exit 1; }
-echo "  provider-handtekening gezet."
-
-# --- 5. Wachten tot de consumer het contract als geldig ziet --------------------------------------
-echo "bootstrap: wachten tot de consumer het contract als geldig ziet..."
-zorg_dat_consumer_gesynct "$HASH" || {
-  echo "FAIL: contract ${HASH} werd niet 'valid' op de consumer (state: $(consumer_state "$HASH"))." >&2
-  exit 1
-}
-
-echo "OK: contract ${HASH} is wederzijds ondertekend en geldig."
 echo "BOOTSTRAP OK."

--- a/demo/environment/federatie/contracts/bootstrap.sh
+++ b/demo/environment/federatie/contracts/bootstrap.sh
@@ -20,20 +20,33 @@
 #   2. provider-helft: het binnengekomen contract tekenen, na de autorisatietoets;
 #   3. consumer-helft opnieuw: vaststellen dat het contract nu geldig is.
 #
-# De eerste stap eindigt op 3 ("ingediend, nog niet getekend"); dat is de normale tussenstand en
-# geen fout. Zie de moduledocs van de twee helften voor de details per kant.
+# Bestaat het contract al, dan eindigt stap 1 meteen op 0 en zijn de andere twee niet nodig. Bij een
+# verse bootstrap eindigt hij op 3 ("ingediend, nog niet getekend") — de normale tussenstand, geen
+# fout. Zie de moduledocs van de twee helften voor de details per kant.
+#
+# Uitgangen: 0 = contract staat, 2 = configuratie deugt niet (doorgegeven uit de helft die het
+# vaststelde), 1 = al het overige.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 
-CONSUMER_OIN="${FSC_CONSUMER_OIN:?zet FSC_CONSUMER_OIN}"
-SERVICE_NAME="${FSC_SERVICE_NAME:?zet FSC_SERVICE_NAME}"
+HERE_LIB="${FSC_LIBDIR:-$(cd "${HERE}/../../lib" && pwd)}"
+# shellcheck source=../../lib/fsc-harness.sh
+. "${HERE_LIB}/fsc-harness.sh"
+# shellcheck source=../../lib/fsc-contract.sh
+. "${HERE_LIB}/fsc-contract.sh"
+
+CONSUMER_OIN="$(fsc_env_vereist FSC_CONSUMER_OIN 'de OIN van de afnemende peer')"
+SERVICE_NAME="$(fsc_env_vereist FSC_SERVICE_NAME 'de dienst die afgenomen wordt')"
 
 # De variabelen die de ene helft nooit mag zien. Alleen adressen en sleutelmateriaal: de OIN's zijn
 # publieke organisatienummers en beide helften hebben ze nodig om te weten waar het contract over
 # gaat.
 PROVIDER_GEHEIM=(FSC_PROVIDER_MANAGER FSC_PROVIDER_CERT FSC_PROVIDER_KEY FSC_PROVIDER_CA FSC_PROVIDER_ADRES)
-CONSUMER_GEHEIM=(FSC_CONSUMER_MANAGER FSC_CONSUMER_CERT FSC_CONSUMER_KEY FSC_CONSUMER_CA FSC_CONSUMER_ADRES)
+# Het outway-cert hoort óók bij de consumer-kant: het is het group-cert van díé peer, en de
+# provider-helft heeft er niets mee te maken.
+CONSUMER_GEHEIM=(FSC_CONSUMER_MANAGER FSC_CONSUMER_CERT FSC_CONSUMER_KEY FSC_CONSUMER_CA FSC_CONSUMER_ADRES
+                 FSC_OUTWAY_CERT FSC_OUTWAY_THUMBPRINT)
 
 # zonder <var...> -- <commando...>: draai het commando zonder die variabelen in zijn omgeving.
 zonder() {
@@ -73,10 +86,15 @@ fi
 
 # --- 2. Provider tekent ---------------------------------------------------------------------------
 echo
-provider_helft || {
-  echo "FAIL: de provider-helft brak af." >&2
-  exit 1
-}
+rc=0
+provider_helft || rc=$?
+
+# 4 = er lagen contracten die de autorisatietoets niet haalden. Die melding staat al in de log van
+# de helft zelf; hier telt alleen dat er niet getekend is, en stap 3 stelt dat vervolgens vast.
+if [ "$rc" -ne 0 ] && [ "$rc" -ne 4 ]; then
+  echo "FAIL: de provider-helft brak af (exit ${rc})." >&2
+  exit "$rc"
+fi
 
 # --- 3. Consumer stelt vast dat het contract geldig is --------------------------------------------
 # Het wachten staat hier en niet in de consumer-helft. Die weet niet of de provider al getekend
@@ -85,6 +103,9 @@ provider_helft || {
 # lus om de helften heen dezelfde rol.
 wacht_tot_geldig() {
   local timeout="${FSC_SYNC_TIMEOUT:-20}" interval="${FSC_SYNC_INTERVAL:-2}" elapsed=0 uitkomst
+
+  # Interval 0 zou `elapsed` nooit laten groeien en er een tight loop van maken.
+  [ "$interval" -gt 0 ] || interval=1
 
   while :; do
     uitkomst=0
@@ -109,10 +130,13 @@ if [ "$rc" -eq 3 ]; then
   # zijn her-distributie voor heeft; die is al één keer gestuurd, dus hier nog eens forceren.
   echo
   echo "bootstrap: contract nog niet geldig bij de consumer; her-distributie forceren..." >&2
-  FSC_FORCEER_DISTRIBUTIE=1 provider_helft || {
-    echo "FAIL: her-distributie via de provider-helft brak af." >&2
-    exit 1
-  }
+  rc=0
+  FSC_FORCEER_DISTRIBUTIE=1 provider_helft || rc=$?
+
+  if [ "$rc" -ne 0 ] && [ "$rc" -ne 4 ]; then
+    echo "FAIL: her-distributie via de provider-helft brak af (exit ${rc})." >&2
+    exit "$rc"
+  fi
 
   echo
   rc=0
@@ -121,7 +145,7 @@ fi
 
 [ "$rc" -eq 0 ] || {
   echo "FAIL: het contract werd niet geldig bij de consumer (exit ${rc})." >&2
-  exit 1
+  exit "$rc"
 }
 
 echo "BOOTSTRAP OK."

--- a/demo/environment/federatie/contracts/zad-lus.sh
+++ b/demo/environment/federatie/contracts/zad-lus.sh
@@ -28,17 +28,27 @@ ROL="$(fsc_env_vereist FSC_ROL "'consumer' of 'provider'")"
 # peer die zijn state kwijt is — terwijl het contract zelf tien jaar geldig is. Een uur is daarvoor
 # ruim genoeg; korter pollen kost per peer honderdduizenden calls per jaar om iets te vinden dat er
 # een paar keer is.
-WACHT="${FSC_LUS_WACHT:-15}"
-HERHAAL="${FSC_LUS_HERHAAL:-3600}"
+WACHT="$(fsc_getal_vereist FSC_LUS_WACHT "${FSC_LUS_WACHT:-15}")"
+HERHAAL="$(fsc_getal_vereist FSC_LUS_HERHAAL "${FSC_LUS_HERHAAL:-3600}")"
 
 # Na dit aantal opeenvolgende mislukkingen stopt de lus. Een blijvende fout — verlopen cert, manager
 # die de client weigert — wordt door opnieuw proberen nooit beter, en een component dat eeuwig
 # doordraait ziet er op het platform gezond uit. Afbreken maakt er een zichtbare crashloop van.
-MAX_MISLUKT="${FSC_LUS_MAX_MISLUKT:-20}"
+#
+# Acht en niet twintig: met de ladder hieronder is acht pogingen ongeveer een uur, en twintig zou
+# ruim twaalf uur zijn. Een container die eens per twaalf uur afsluit, is voor het platform geen
+# crashloop maar een herstart — precies het signaal dat deze grens moet opleveren.
+MAX_MISLUKT="$(fsc_getal_vereist FSC_LUS_MAX_MISLUKT "${FSC_LUS_MAX_MISLUKT:-8}")"
 
 # Idem voor "ik wacht al heel lang op de overkant": geen fout, maar wel iets om te melden in plaats
 # van eindeloos dezelfde regel te herhalen.
-MELD_WACHT_NA="${FSC_LUS_MELD_WACHT_NA:-20}"
+MELD_WACHT_NA="$(fsc_getal_vereist FSC_LUS_MELD_WACHT_NA "${FSC_LUS_MELD_WACHT_NA:-20}")"
+
+# En een bovengrens op het wachten zelf. Een consumer die eeuwig op de provider wacht, is de enige
+# permanente blokkade die geen crashloop oplevert — terwijl de oorzaak (onze OIN staat niet in de
+# allowlist van de overkant) juist een van de waarschijnlijkste is. Zonder grens blijft het component
+# "Running" en ziet het platform niets.
+MAX_WACHT="$(fsc_getal_vereist FSC_LUS_MAX_WACHT "${FSC_LUS_MAX_WACHT:-200}")"
 
 case "$ROL" in
   consumer) HELFT="${FSC_HELFT_CONSUMER:-${HERE}/bootstrap-consumer.sh}" ;;
@@ -78,15 +88,22 @@ while [ "$STOPPEN" -eq 0 ]; do
       pauzeer "$HERHAAL"
       ;;
     3)
-      # Alleen de consumer-helft: ingediend, de provider moet nog tekenen. Geen fout — maar wel
-      # iets dat blijvend kan zijn, bijvoorbeeld als onze OIN niet in de allowlist van de provider
-      # staat. Dan hoort het te gaan opvallen in plaats van elke ronde dezelfde regel te herhalen.
+      # Wachten op de overkant: de consumer heeft ingediend en de provider moet nog tekenen, of de
+      # provider heeft nog niets binnen. Geen fout — maar wel iets dat blijvend kan zijn, bijvoorbeeld
+      # als de OIN niet in de allowlist van de overkant staat. Dan hoort het te gaan opvallen in
+      # plaats van elke ronde dezelfde regel te herhalen.
       MISLUKT=0
       GEWACHT=$((GEWACHT + 1))
 
+      if [ "$GEWACHT" -ge "$MAX_WACHT" ]; then
+        echo "FAIL: ${GEWACHT} rondes gewacht zonder dat het contract geldig werd; de lus stopt." >&2
+        echo "  Kijk aan providerkant naar de WEIGER-regels en naar FSC_DIENSTEN/FSC_CONSUMERS." >&2
+        exit 1
+      fi
+
       if [ "$GEWACHT" -eq "$MELD_WACHT_NA" ]; then
-        echo "WARN: al ${GEWACHT} rondes (~$((GEWACHT * WACHT))s) wachten op de provider-helft." >&2
-        echo "  Controleer aan die kant FSC_DIENSTEN/FSC_CONSUMERS en de WEIGER-regels in zijn log." >&2
+        echo "WARN: al ${GEWACHT} rondes (~$((GEWACHT * WACHT))s) wachten op de andere helft." >&2
+        echo "  Controleer daar FSC_DIENSTEN/FSC_CONSUMERS en de WEIGER-regels in de log." >&2
       fi
 
       # Na de melding op het lange interval verder: blijven pollen verandert er niets aan.

--- a/demo/environment/federatie/contracts/zad-lus.sh
+++ b/demo/environment/federatie/contracts/zad-lus.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Entrypoint van het contract-bootstrap-component op ZAD: draai één helft van de bootstrap, herhaald.
+#
+# ZAD kent alleen langlopende componenten — er is geen job-vorm en geen manier om args mee te geven.
+# Vandaar een lus die zijn rol uit `FSC_ROL` leest en blijft draaien. Dat is hier geen omweg maar
+# precies wat de gesplitste opzet nodig heeft: de twee helften coördineren niet met elkaar, ze
+# convergeren. De consumer dient in en wacht; de provider tekent zodra het contract via de mesh bij
+# hem binnenkomt. Wie van de twee als eerste start, doet er daardoor niet toe.
+#
+# Blijven draaien na succes is ook de herstelweg: wordt een contract ingetrokken of raakt een peer
+# zijn state kwijt, dan zet de volgende ronde het opnieuw op. Daarom een lange interval na succes
+# in plaats van slapend blijven hangen — één call per peer per interval is verwaarloosbaar, en de
+# alternatieven (nooit meer kijken, of blijven pollen op het korte interval) zijn allebei slechter.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+ROL="${FSC_ROL:?zet FSC_ROL op 'consumer' of 'provider'}"
+
+# Kort interval zolang er nog iets moet gebeuren, lang interval als alles staat.
+WACHT="${FSC_LUS_WACHT:-15}"
+HERHAAL="${FSC_LUS_HERHAAL:-300}"
+
+case "$ROL" in
+  consumer) HELFT="${HERE}/bootstrap-consumer.sh" ;;
+  provider) HELFT="${HERE}/bootstrap-provider.sh" ;;
+  *) echo "FAIL: FSC_ROL moet 'consumer' of 'provider' zijn, niet '${ROL}'." >&2; exit 2 ;;
+esac
+
+echo "zad-lus: rol=${ROL}, interval ${WACHT}s tot het staat, daarna ${HERHAAL}s."
+
+# Stoppen moet meteen kunnen. Zonder dit blijft de container in een `sleep` hangen tot de
+# stop-timeout van de orchestrator verloopt, en dat vertraagt elke herstart en elke rollout.
+STOPPEN=0
+trap 'STOPPEN=1' TERM INT
+
+# pauzeer <seconden>: onderbreekbaar wachten. Een kale `sleep` vangt het signaal pas als hij klaar
+# is; door hem naar de achtergrond te zetten en erop te wachten, breekt `wait` af op het signaal.
+pauzeer() {
+  sleep "$1" &
+  wait $! 2>/dev/null || true
+}
+
+MISLUKT=0
+
+while [ "$STOPPEN" -eq 0 ]; do
+  rc=0
+  "$HELFT" || rc=$?
+
+  case "$rc" in
+    0)
+      MISLUKT=0
+      pauzeer "$HERHAAL"
+      ;;
+    3)
+      # Alleen de consumer-helft: ingediend, de provider moet nog tekenen. Geen fout.
+      MISLUKT=0
+      pauzeer "$WACHT"
+      ;;
+    2)
+      # Configuratie deugt niet. Doorgaan heeft geen zin en stil blijven draaien zou het verbergen;
+      # afbreken maakt er een zichtbare crashloop van.
+      echo "FAIL: configuratiefout in de ${ROL}-helft; de lus stopt." >&2
+      exit 2
+      ;;
+    *)
+      MISLUKT=$((MISLUKT + 1))
+      echo "WARN: de ${ROL}-helft faalde (exit ${rc}), poging ${MISLUKT}; opnieuw over ${WACHT}s." >&2
+      pauzeer "$WACHT"
+      ;;
+  esac
+done
+
+echo "zad-lus: gestopt op verzoek."

--- a/demo/environment/federatie/contracts/zad-lus.sh
+++ b/demo/environment/federatie/contracts/zad-lus.sh
@@ -152,12 +152,7 @@ while [ "$STOPPEN" -eq 0 ]; do
   esac
 done
 
-# Alleen "op verzoek" als het ook echt zo is: viel de lus er om een andere reden uit, dan zou een
-# nulafsluiting op ZAD lezen als een component dat netjes klaar is — geen crashloop, niets rood, en
-# de bootstrap ligt stil.
-if [ "$STOPPEN" -eq 0 ]; then
-  echo "FAIL: de lus is onverwacht geëindigd." >&2
-  exit 1
-fi
-
+# De lus verlaat zijn conditie alleen als STOPPEN gezet is; valt hij er om een andere reden uit, dan
+# doet `set -e` dat met een non-zero status. Een nulafsluiting hier betekent dus altijd een
+# stopverzoek.
 echo "zad-lus: gestopt op verzoek."

--- a/demo/environment/federatie/contracts/zad-lus.sh
+++ b/demo/environment/federatie/contracts/zad-lus.sh
@@ -35,8 +35,8 @@ HERHAAL="$(fsc_getal_vereist FSC_LUS_HERHAAL "${FSC_LUS_HERHAAL:-3600}")"
 # die de client weigert — wordt door opnieuw proberen nooit beter, en een component dat eeuwig
 # doordraait ziet er op het platform gezond uit. Afbreken maakt er een zichtbare crashloop van.
 #
-# Acht en niet twintig: met de ladder hieronder is acht pogingen ongeveer een uur, en twintig zou
-# ruim twaalf uur zijn. Een container die eens per twaalf uur afsluit, is voor het platform geen
+# Acht en niet twintig: met de ladder hieronder is acht pogingen ongeveer 32 minuten, en twintig
+# zou ruim twaalf uur zijn. Een container die eens per twaalf uur afsluit, is voor het platform geen
 # crashloop maar een herstart — precies het signaal dat deze grens moet opleveren.
 MAX_MISLUKT="$(fsc_getal_vereist FSC_LUS_MAX_MISLUKT "${FSC_LUS_MAX_MISLUKT:-8}")"
 
@@ -114,10 +114,20 @@ while [ "$STOPPEN" -eq 0 ]; do
       exit 2
       ;;
     4)
-      # Provider-helft: er lagen contracten die de toets niet haalden. Dat is een beslissing en geen
-      # storing, dus niet opnieuw proberen op het korte interval — de allowlist verandert alleen
-      # doordat iemand hem aanpast.
+      # Provider-helft: er lagen contracten die de toets niet haalden en niets mocht getekend worden.
+      # Geen storing, dus niet opnieuw proberen op het korte interval — de allowlist verandert alleen
+      # doordat iemand hem aanpast. Maar het telt wél mee als wachten: anders is dit de enige
+      # permanente blokkade waarop de lus nooit escaleert, en blijft het component uren gezond ogen
+      # terwijl er niets gebeurt.
       MISLUKT=0
+      GEWACHT=$((GEWACHT + 1))
+
+      if [ "$GEWACHT" -ge "$MAX_WACHT" ]; then
+        echo "FAIL: ${GEWACHT} rondes zonder dat er iets getekend kon worden; de lus stopt." >&2
+        echo "  Kijk naar de WEIGER-regels hierboven en naar FSC_DIENSTEN/FSC_CONSUMERS." >&2
+        exit 1
+      fi
+
       pauzeer "$HERHAAL"
       ;;
     *)
@@ -141,5 +151,13 @@ while [ "$STOPPEN" -eq 0 ]; do
       ;;
   esac
 done
+
+# Alleen "op verzoek" als het ook echt zo is: viel de lus er om een andere reden uit, dan zou een
+# nulafsluiting op ZAD lezen als een component dat netjes klaar is — geen crashloop, niets rood, en
+# de bootstrap ligt stil.
+if [ "$STOPPEN" -eq 0 ]; then
+  echo "FAIL: de lus is onverwacht geëindigd." >&2
+  exit 1
+fi
 
 echo "zad-lus: gestopt op verzoek."

--- a/demo/environment/federatie/contracts/zad-lus.sh
+++ b/demo/environment/federatie/contracts/zad-lus.sh
@@ -4,44 +4,68 @@
 # ZAD kent alleen langlopende componenten — er is geen job-vorm en geen manier om args mee te geven.
 # Vandaar een lus die zijn rol uit `FSC_ROL` leest en blijft draaien. Dat is hier geen omweg maar
 # precies wat de gesplitste opzet nodig heeft: de twee helften coördineren niet met elkaar, ze
-# convergeren. De consumer dient in en wacht; de provider tekent zodra het contract via de mesh bij
-# hem binnenkomt. Wie van de twee als eerste start, doet er daardoor niet toe.
+# convergeren. Wie van de twee als eerste start, doet er daardoor niet toe.
 #
 # Blijven draaien na succes is ook de herstelweg: wordt een contract ingetrokken of raakt een peer
-# zijn state kwijt, dan zet de volgende ronde het opnieuw op. Daarom een lange interval na succes
-# in plaats van slapend blijven hangen — één call per peer per interval is verwaarloosbaar, en de
-# alternatieven (nooit meer kijken, of blijven pollen op het korte interval) zijn allebei slechter.
+# zijn state kwijt, dan zet de volgende ronde het opnieuw op. Daarom een lang interval na succes in
+# plaats van slapend blijven hangen.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
+LIBDIR="${FSC_LIBDIR:-$(cd "${HERE}/../../lib" && pwd)}"
 
-ROL="${FSC_ROL:?zet FSC_ROL op 'consumer' of 'provider'}"
+# shellcheck source=../../lib/fsc-harness.sh
+. "${LIBDIR}/fsc-harness.sh"
+# shellcheck source=../../lib/fsc-contract.sh
+. "${LIBDIR}/fsc-contract.sh"
+
+# Via de helper en niet via `${FSC_ROL:?}`: die eindigt op 1, en 1 is hier "probeer opnieuw".
+ROL="$(fsc_env_vereist FSC_ROL "'consumer' of 'provider'")"
 
 # Kort interval zolang er nog iets moet gebeuren, lang interval als alles staat.
+#
+# Het lange interval bewaakt een gebeurtenis die zelden voorkomt — een ingetrokken contract of een
+# peer die zijn state kwijt is — terwijl het contract zelf tien jaar geldig is. Een uur is daarvoor
+# ruim genoeg; korter pollen kost per peer honderdduizenden calls per jaar om iets te vinden dat er
+# een paar keer is.
 WACHT="${FSC_LUS_WACHT:-15}"
-HERHAAL="${FSC_LUS_HERHAAL:-300}"
+HERHAAL="${FSC_LUS_HERHAAL:-3600}"
+
+# Na dit aantal opeenvolgende mislukkingen stopt de lus. Een blijvende fout — verlopen cert, manager
+# die de client weigert — wordt door opnieuw proberen nooit beter, en een component dat eeuwig
+# doordraait ziet er op het platform gezond uit. Afbreken maakt er een zichtbare crashloop van.
+MAX_MISLUKT="${FSC_LUS_MAX_MISLUKT:-20}"
+
+# Idem voor "ik wacht al heel lang op de overkant": geen fout, maar wel iets om te melden in plaats
+# van eindeloos dezelfde regel te herhalen.
+MELD_WACHT_NA="${FSC_LUS_MELD_WACHT_NA:-20}"
 
 case "$ROL" in
-  consumer) HELFT="${HERE}/bootstrap-consumer.sh" ;;
-  provider) HELFT="${HERE}/bootstrap-provider.sh" ;;
+  consumer) HELFT="${FSC_HELFT_CONSUMER:-${HERE}/bootstrap-consumer.sh}" ;;
+  provider) HELFT="${FSC_HELFT_PROVIDER:-${HERE}/bootstrap-provider.sh}" ;;
   *) echo "FAIL: FSC_ROL moet 'consumer' of 'provider' zijn, niet '${ROL}'." >&2; exit 2 ;;
 esac
 
 echo "zad-lus: rol=${ROL}, interval ${WACHT}s tot het staat, daarna ${HERHAAL}s."
 
-# Stoppen moet meteen kunnen. Zonder dit blijft de container in een `sleep` hangen tot de
-# stop-timeout van de orchestrator verloopt, en dat vertraagt elke herstart en elke rollout.
+# Stoppen moet zonder de stop-timeout uit te zitten. De trap zet alleen een vlag: bash voert een
+# handler pas uit als het lopende voorgrondcommando klaar is, dus komt het signaal binnen tijdens de
+# helft, dan gebeurt er hier niets tot die terug is. `pauzeer` toetst de vlag daarom zelf ook — zonder
+# dat zou de lus na een TERM alsnog het volle interval afwachten voordat de conditie weer aan bod komt.
 STOPPEN=0
 trap 'STOPPEN=1' TERM INT
 
-# pauzeer <seconden>: onderbreekbaar wachten. Een kale `sleep` vangt het signaal pas als hij klaar
-# is; door hem naar de achtergrond te zetten en erop te wachten, breekt `wait` af op het signaal.
 pauzeer() {
+  [ "$STOPPEN" -eq 0 ] || return 0
+
+  # Een kale `sleep` vangt het signaal pas als hij klaar is; naar de achtergrond en `wait` erop
+  # breekt wél af op het signaal.
   sleep "$1" &
   wait $! 2>/dev/null || true
 }
 
 MISLUKT=0
+GEWACHT=0
 
 while [ "$STOPPEN" -eq 0 ]; do
   rc=0
@@ -50,23 +74,53 @@ while [ "$STOPPEN" -eq 0 ]; do
   case "$rc" in
     0)
       MISLUKT=0
+      GEWACHT=0
       pauzeer "$HERHAAL"
       ;;
     3)
-      # Alleen de consumer-helft: ingediend, de provider moet nog tekenen. Geen fout.
+      # Alleen de consumer-helft: ingediend, de provider moet nog tekenen. Geen fout — maar wel
+      # iets dat blijvend kan zijn, bijvoorbeeld als onze OIN niet in de allowlist van de provider
+      # staat. Dan hoort het te gaan opvallen in plaats van elke ronde dezelfde regel te herhalen.
       MISLUKT=0
-      pauzeer "$WACHT"
+      GEWACHT=$((GEWACHT + 1))
+
+      if [ "$GEWACHT" -eq "$MELD_WACHT_NA" ]; then
+        echo "WARN: al ${GEWACHT} rondes (~$((GEWACHT * WACHT))s) wachten op de provider-helft." >&2
+        echo "  Controleer aan die kant FSC_DIENSTEN/FSC_CONSUMERS en de WEIGER-regels in zijn log." >&2
+      fi
+
+      # Na de melding op het lange interval verder: blijven pollen verandert er niets aan.
+      [ "$GEWACHT" -lt "$MELD_WACHT_NA" ] && pauzeer "$WACHT" || pauzeer "$HERHAAL"
       ;;
     2)
-      # Configuratie deugt niet. Doorgaan heeft geen zin en stil blijven draaien zou het verbergen;
-      # afbreken maakt er een zichtbare crashloop van.
       echo "FAIL: configuratiefout in de ${ROL}-helft; de lus stopt." >&2
       exit 2
       ;;
+    4)
+      # Provider-helft: er lagen contracten die de toets niet haalden. Dat is een beslissing en geen
+      # storing, dus niet opnieuw proberen op het korte interval — de allowlist verandert alleen
+      # doordat iemand hem aanpast.
+      MISLUKT=0
+      pauzeer "$HERHAAL"
+      ;;
     *)
       MISLUKT=$((MISLUKT + 1))
-      echo "WARN: de ${ROL}-helft faalde (exit ${rc}), poging ${MISLUKT}; opnieuw over ${WACHT}s." >&2
-      pauzeer "$WACHT"
+
+      if [ "$MISLUKT" -ge "$MAX_MISLUKT" ]; then
+        echo "FAIL: de ${ROL}-helft faalde ${MISLUKT} keer op rij; de lus stopt." >&2
+        exit 1
+      fi
+
+      # Exponentieel terug, afgetopt op het lange interval: een manager die weg is, wordt niet
+      # sneller bereikbaar door hem elke 15 seconden opnieuw te bevragen.
+      pauze="$WACHT"
+      for _ in $(seq 2 "$MISLUKT"); do
+        pauze=$((pauze * 2))
+        [ "$pauze" -lt "$HERHAAL" ] || { pauze="$HERHAAL"; break; }
+      done
+
+      echo "WARN: de ${ROL}-helft faalde (exit ${rc}), poging ${MISLUKT}; opnieuw over ${pauze}s." >&2
+      pauzeer "$pauze"
       ;;
   esac
 done

--- a/demo/environment/federatie/contracts/zad-runbook.md
+++ b/demo/environment/federatie/contracts/zad-runbook.md
@@ -42,7 +42,9 @@ Gemeenschappelijk (beide componenten):
 |-----------|--------|
 | `FSC_ROL` | `consumer` respectievelijk `provider` |
 | `FSC_LUS_WACHT` | optioneel, standaard `15` — interval zolang er nog iets moet gebeuren |
-| `FSC_LUS_HERHAAL` | optioneel, standaard `300` — interval als alles staat |
+| `FSC_LUS_HERHAAL` | optioneel, standaard `3600` — interval als alles staat |
+| `FSC_LUS_MAX_MISLUKT` | optioneel, standaard `20` — na zoveel mislukkingen op rij stopt de lus |
+| `FSC_GROUP_ID` | optioneel, standaard `moza-fbs-test` |
 
 `logius-fscbootstrap` (consumer):
 
@@ -62,8 +64,9 @@ Gemeenschappelijk (beide componenten):
 | Variabele | Waarde |
 |-----------|--------|
 | `FSC_PROVIDER_OIN` | `00000000000000100000` |
-| `FSC_DIENSTEN` | `berichtenmagazijn` — spaties-gescheiden lijst |
-| `FSC_CONSUMERS` | `00000000000000001000` — spaties-gescheiden lijst |
+| `FSC_DIENSTEN` | `berichtenmagazijn` — door witruimte gescheiden lijst |
+| `FSC_CONSUMERS` | `00000000000000001000` — door witruimte gescheiden lijst |
+| `FSC_MAX_GELDIGHEID_SECONDEN` | optioneel, standaard `316224000` (ruim tien jaar) — bovengrens op de looptijd die een tegenpartij mag voorstellen |
 | `FSC_PROVIDER_MANAGER` | `https://fsc-magazijna-magazijna-fscmgr:9443` |
 | `FSC_PROVIDER_CERT` | `/etc/fsc/internal/magazijn-a/bootstrap/cert.pem` |
 | `FSC_PROVIDER_KEY` | `/etc/fsc/internal/magazijn-a/bootstrap/key.pem` |
@@ -86,15 +89,22 @@ openssl x509 -in demo/environment/logius/pki/out/logius/outway/cert.pem -pubkey 
   | openssl dgst -sha256 -r | cut -d' ' -f1
 ```
 
-64 hex-tekens. De waarde is stabiel zolang het sleutelpaar dat is — een cert-rotatie binnen
-hetzelfde sleutelpaar verandert hem niet. Rouleer je het sleutelpaar wél, dan moet deze env mee en
-komt er een nieuw contract; het oude wordt door de consumer-helft opgeruimd zodra het overtollig is.
+64 lowercase hex-tekens; het component weigert elke andere vorm.
+
+De waarde is stabiel zolang het sleutelpaar dat is — een cert-rotatie binnen hetzelfde sleutelpaar
+verandert hem niet. **Rouleer je het sleutelpaar wél, dan blijft het oude contract staan.** De
+thumbprint is onderdeel van de identiteit waarop de consumer-helft matcht, dus na een rotatie valt
+het oude contract buiten die match: er komt een nieuw contract bij en het oude wordt niet
+opgeruimd. Trek het met de hand in (`PUT /v1/contracts/<hash>/revoke` op de eigen manager), anders
+blijft een grant voor een outway die niet meer bestaat geldig tot zijn einddatum.
 
 ## Cert-attachments
 
 Het component gebruikt het **internal**-cert van het `bootstrap`-endpoint als client naar de
 manager-API. Dat is een eigen cert en niet dat van een andere component: wie een cert deelt, deelt
-een identiteit, en dan is in het txlog niet meer te zien wie wat deed.
+een identiteit, en dan is in het auditlog van de manager niet meer te zien welk component welke
+contract-call deed. (Niet in het FSC-txlog — dat legt data-plane-transacties vast, gelogd door
+inway en outway; een call op de interne contract-API verschijnt daar niet.)
 
 `pki/issue.sh` geeft dit endpoint bewust **geen group-cert** — het bedient zelf geen TLS en hoort
 zich niet in de mesh als de peer te kunnen voordoen.
@@ -110,25 +120,54 @@ Attachments per bootstrap-component (UI-only; de v2-API kloont ze niet):
 Zie `deploy/zad/cert-manifest.md` bij de peer voor de algemene valkuilen (internal-pad krijgt het
 internal-cert, group-pad het group-cert inclusief intermediate).
 
+## Voorwaarden
+
+Beide peers zijn in de group geannounced en de provider heeft zijn dienst gepubliceerd
+(ServicePublicationGrant). Zonder dat laatste heeft de mesh niets om het contract naartoe te
+synchroniseren en blijft de bootstrap hangen zonder duidelijke oorzaak.
+
 ## Volgorde
 
-1. `pki/issue.sh -f` bij beide peers — geeft het nieuwe `bootstrap`-endpoint uit.
+1. `pki/issue.sh` bij beide peers — geeft het nieuwe `bootstrap`-endpoint uit. **Zonder `-f`**:
+   die vlag hergenereert de internal-CA per peer en daarmee álle bestaande certificaten, zodat
+   elke attachment op ZAD opnieuw geüpload moet worden. Het bootstrap-endpoint heeft nog geen
+   certificaat, dus een kale run geeft het al uit.
 2. `pki/zad-bundle.sh <peer>` — zet de upload-set klaar.
 3. Component éénmalig aanmaken in de ZAD-UI, in de deployment van díé peer, met de env hierboven
    en zonder inbound poort.
 4. De drie attachments koppelen.
 5. Component starten en de log volgen.
 
-Daarna houdt de `deploy-test-*`-job de image-tag bij, zoals bij de andere peer-componenten.
+Doe dit **vóór** de merge naar main: de `deploy-test-*`-job werkt daarna bij elke push de image-tag
+van dit component bij, en dat werkt alleen als het component al bestaat.
+
+> `upsert-peer.sh` noemt het bootstrap-component wel in zijn deployment-lijst — anders haalt een
+> upsert het eruit — maar zet zijn env en attachments niet. Draai je dat script na een herstel, dan
+> zijn die twee dus opnieuw handwerk.
+
+Geef het component het kleinste CPU-/geheugenprofiel dat het project toestaat. Het rekent een paar
+tientallen CPU-seconden per dag en slaapt de rest van de tijd; een standaardprofiel reserveert
+24/7 capaciteit die leeg blijft.
 
 ## Verifiëren
 
 De consumer-log meldt `CONSUMER OK`, de provider-log `PROVIDER OK (1 contract(en) getekend)` en
-daarna elke ronde `PROVIDER OK (niets te tekenen)`. Dat laatste is het idempotentie-signaal: draait
+daarna elke ronde `PROVIDER OK (niets te tekenen)`. Een `PROVIDER GEWEIGERD`-regel (uitgang 4)
+betekent dat er wél iets lag maar dat het de toets niet haalde. Dat laatste is het idempotentie-signaal: draait
 het component opnieuw of herstart de pod, dan komt er geen tweede contract bij.
 
-Blijft de consumer `CONSUMER WACHT` melden terwijl de provider niets meer te tekenen heeft, dan is
-de accept-handtekening onderweg blijven steken (zie hieronder).
+Blijft de consumer `CONSUMER WACHT` melden, kijk dan in deze volgorde:
+
+1. **De WEIGER-regels in de log van de provider.** Meldt die `PROVIDER GEWEIGERD`, dan lag het
+   contract er wél maar haalde het de autorisatietoets niet — bij een verse opstelling bijna altijd
+   een typefout in `FSC_DIENSTEN` of een OIN die niet in `FSC_CONSUMERS` staat. De regel noemt de
+   eerste eis die faalde.
+2. **Meldt de provider `niets te tekenen`**, dan is het contract daar niet aangekomen: controleer
+   de announce en de dienstpublicatie uit de voorwaarden hierboven.
+3. **Heeft de provider wél getekend** en blijft de consumer toch wachten, dan is de
+   accept-handtekening onderweg blijven steken — zie hieronder.
+
+Na twintig rondes wachten meldt de lus dat zelf ook, met een verwijzing naar deze drie.
 
 ## Bekende beperking: een gestrande accept-push
 

--- a/demo/environment/federatie/contracts/zad-runbook.md
+++ b/demo/environment/federatie/contracts/zad-runbook.md
@@ -43,7 +43,9 @@ Gemeenschappelijk (beide componenten):
 | `FSC_ROL` | `consumer` respectievelijk `provider` |
 | `FSC_LUS_WACHT` | optioneel, standaard `15` — interval zolang er nog iets moet gebeuren |
 | `FSC_LUS_HERHAAL` | optioneel, standaard `3600` — interval als alles staat |
-| `FSC_LUS_MAX_MISLUKT` | optioneel, standaard `20` — na zoveel mislukkingen op rij stopt de lus |
+| `FSC_LUS_MAX_MISLUKT` | optioneel, standaard `8` — na zoveel mislukkingen op rij stopt de lus (met de backoff-ladder is dat ruim een uur) |
+| `FSC_LUS_MELD_WACHT_NA` | optioneel, standaard `20` — na zoveel rondes wachten volgt een waarschuwing |
+| `FSC_LUS_MAX_WACHT` | optioneel, standaard `200` — na zoveel rondes wachten op de overkant stopt de lus |
 | `FSC_GROUP_ID` | optioneel, standaard `moza-fbs-test` |
 
 `logius-fscbootstrap` (consumer):
@@ -152,11 +154,13 @@ tientallen CPU-seconden per dag en slaapt de rest van de tijd; een standaardprof
 ## Verifiëren
 
 De consumer-log meldt `CONSUMER OK`, de provider-log `PROVIDER OK (1 contract(en) getekend)` en
-daarna elke ronde `PROVIDER OK (niets te tekenen)`. Een `PROVIDER GEWEIGERD`-regel (uitgang 4)
-betekent dat er wél iets lag maar dat het de toets niet haalde. Dat laatste is het idempotentie-signaal: draait
+daarna elke ronde `PROVIDER OK (niets te tekenen)`. Dat laatste is het idempotentie-signaal: draait
 het component opnieuw of herstart de pod, dan komt er geen tweede contract bij.
 
-Blijft de consumer `CONSUMER WACHT` melden, kijk dan in deze volgorde:
+Een `PROVIDER GEWEIGERD`-regel (uitgang 4) betekent dat er wél iets lag maar dat niets ervan de
+toets haalde. `PROVIDER WACHT` betekent dat er nog niets van een toegelaten consumer binnen is —
+normaal bij een koude start, en de lus komt daar dan snel op terug in plaats van een uur te wachten. Werd er in dezelfde ronde ook iets getekend, dan meldt de log `PROVIDER OK (… , N
+geweigerd)` — dan is er iets aan de hand met één contract, niet met de ronde. Blijft de consumer `CONSUMER WACHT` melden, kijk dan in deze volgorde:
 
 1. **De WEIGER-regels in de log van de provider.** Meldt die `PROVIDER GEWEIGERD`, dan lag het
    contract er wél maar haalde het de autorisatietoets niet — bij een verse opstelling bijna altijd
@@ -167,7 +171,13 @@ Blijft de consumer `CONSUMER WACHT` melden, kijk dan in deze volgorde:
 3. **Heeft de provider wél getekend** en blijft de consumer toch wachten, dan is de
    accept-handtekening onderweg blijven steken — zie hieronder.
 
-Na twintig rondes wachten meldt de lus dat zelf ook, met een verwijzing naar deze drie.
+Na twintig rondes wachten meldt de lus dat zelf ook, met een verwijzing naar deze drie; na
+`FSC_LUS_MAX_WACHT` rondes stopt hij, zodat het platform de blokkade als crashloop laat zien in
+plaats van als een gezond component.
+
+> Alle numerieke knoppen hierboven worden bij het opstarten op vorm gecontroleerd. Een waarde als
+> `15s` zou anders `sleep` laten falen, en dan keert het wachten meteen terug: een lus die de
+> manager zo snel mogelijk bevraagt terwijl hij elke ronde OK meldt.
 
 ## Bekende beperking: een gestrande accept-push
 

--- a/demo/environment/federatie/contracts/zad-runbook.md
+++ b/demo/environment/federatie/contracts/zad-runbook.md
@@ -43,7 +43,7 @@ Gemeenschappelijk (beide componenten):
 | `FSC_ROL` | `consumer` respectievelijk `provider` |
 | `FSC_LUS_WACHT` | optioneel, standaard `15` — interval zolang er nog iets moet gebeuren |
 | `FSC_LUS_HERHAAL` | optioneel, standaard `3600` — interval als alles staat |
-| `FSC_LUS_MAX_MISLUKT` | optioneel, standaard `8` — na zoveel mislukkingen op rij stopt de lus (met de backoff-ladder is dat ruim een uur) |
+| `FSC_LUS_MAX_MISLUKT` | optioneel, standaard `8` — na zoveel mislukkingen op rij stopt de lus (met de backoff-ladder ongeveer 32 minuten) |
 | `FSC_LUS_MELD_WACHT_NA` | optioneel, standaard `20` — na zoveel rondes wachten volgt een waarschuwing |
 | `FSC_LUS_MAX_WACHT` | optioneel, standaard `200` — na zoveel rondes wachten op de overkant stopt de lus |
 | `FSC_GROUP_ID` | optioneel, standaard `moza-fbs-test` |
@@ -68,7 +68,7 @@ Gemeenschappelijk (beide componenten):
 | `FSC_PROVIDER_OIN` | `00000000000000100000` |
 | `FSC_DIENSTEN` | `berichtenmagazijn` — door witruimte gescheiden lijst |
 | `FSC_CONSUMERS` | `00000000000000001000` — door witruimte gescheiden lijst |
-| `FSC_MAX_GELDIGHEID_SECONDEN` | optioneel, standaard `316224000` (ruim tien jaar) — bovengrens op de looptijd die een tegenpartij mag voorstellen |
+| `FSC_MAX_GELDIGHEID_SECONDEN` | optioneel, standaard `316224000` (ruim tien jaar) — bovengrens op de RESTERENDE geldigheid (`not_after` min nu), niet op de vensterlengte |
 | `FSC_PROVIDER_MANAGER` | `https://fsc-magazijna-magazijna-fscmgr:9443` |
 | `FSC_PROVIDER_CERT` | `/etc/fsc/internal/magazijn-a/bootstrap/cert.pem` |
 | `FSC_PROVIDER_KEY` | `/etc/fsc/internal/magazijn-a/bootstrap/key.pem` |
@@ -124,9 +124,10 @@ internal-cert, group-pad het group-cert inclusief intermediate).
 
 ## Voorwaarden
 
-Beide peers zijn in de group geannounced en de provider heeft zijn dienst gepubliceerd
-(ServicePublicationGrant). Zonder dat laatste heeft de mesh niets om het contract naartoe te
-synchroniseren en blijft de bootstrap hangen zonder duidelijke oorzaak.
+Beide peers zijn in de group geannounced — daaruit kent de mesh elkaars manageradres — en de
+provider heeft zijn dienst gepubliceerd (ServicePublicationGrant). Dat laatste is niet nodig om het
+contract te synchroniseren maar wel om het te mogen tekenen: de provider toetst dat de dienst uit de
+grant ook echt door hem wordt aangeboden, en zonder publicatie geeft hij later ook geen token uit.
 
 ## Volgorde
 
@@ -168,8 +169,14 @@ geweigerd)` — dan is er iets aan de hand met één contract, niet met de ronde
    eerste eis die faalde.
 2. **Meldt de provider `niets te tekenen`**, dan is het contract daar niet aangekomen: controleer
    de announce en de dienstpublicatie uit de voorwaarden hierboven.
-3. **Heeft de provider wél getekend** en blijft de consumer toch wachten, dan is de
-   accept-handtekening onderweg blijven steken — zie hieronder.
+3. **Meldt de provider `eerder getekende contracten die de toets nu niet meer halen`**, dan is de
+   allowlist of de geldigheidsgrens ná de eerste tekenronde aangepast; het contract ligt er wel maar
+   telt niet meer mee.
+4. **Heeft de provider wél getekend** en blijft de consumer toch wachten, dan is de
+   accept-handtekening onderweg blijven steken — zie hieronder. Dat kan ook de andere kant op: is de
+   handtekening van de consumer nooit bij de provider aangekomen, dan weigert die met "draagt de
+   handtekening van de consumer nog niet" en is er aan consumerkant geen knop om hem opnieuw te
+   sturen. Dien in dat geval opnieuw in door het contract bij de consumer in te trekken.
 
 Na twintig rondes wachten meldt de lus dat zelf ook, met een verwijzing naar deze drie; na
 `FSC_LUS_MAX_WACHT` rondes stopt hij, zodat het platform de blokkade als crashloop laat zien in

--- a/demo/environment/federatie/contracts/zad-runbook.md
+++ b/demo/environment/federatie/contracts/zad-runbook.md
@@ -170,26 +170,33 @@ geweigerd)` — dan is er iets aan de hand met één contract, niet met de ronde
    eerste eis die faalde.
 2. **Meldt de provider `niets te tekenen`**, dan is het contract daar niet aangekomen: controleer
    de announce en de dienstpublicatie uit de voorwaarden hierboven.
-3. **Meldt de provider `PROVIDER GEWEIGERD (… eerder getekend …)`**, dan is de allowlist of de
-   geldigheidsgrens ná de eerste tekenronde aangepast; het contract ligt er wel maar telt niet meer
-   mee. Let op: de consumer ziet zijn contract dan nog steeds als geldig, dus alleen de provider-log
-   verraadt dat het datapad stuk is.
-4. **Meldt de consumer `de provider heeft minstens één van onze contracten AFGEWEZEN`**, dan heeft
+3. **Meldt de consumer `de provider heeft minstens één van onze contracten AFGEWEZEN`**, dan heeft
    de overkant actief geweigerd. Opnieuw indienen heeft pas zin na een fix aan die kant; trek het
-   afgewezen contract daarna bij de consumer in.
-5. **Heeft de provider wél getekend** en blijft de consumer toch wachten, dan is de
+   afgewezen contract daarna bij de consumer in — zolang het in de lijst staat, dient de consumer
+   niet opnieuw in.
+4. **Heeft de provider wél getekend** en blijft de consumer toch wachten, dan is de
    accept-handtekening onderweg blijven steken — zie hieronder. Dat kan ook de andere kant op: is de
    handtekening van de consumer nooit bij de provider aangekomen, dan weigert die met "draagt de
    handtekening van de consumer nog niet" en is er aan consumerkant geen knop om hem opnieuw te
    sturen. Dien in dat geval opnieuw in door het contract bij de consumer in te trekken.
 
-Na twintig rondes wachten meldt de lus dat zelf ook, met een verwijzing naar deze drie; na
+Na twintig rondes wachten meldt de lus dat zelf ook, met een verwijzing naar deze punten; na
 `FSC_LUS_MAX_WACHT` rondes stopt hij, zodat het platform de blokkade als crashloop laat zien in
 plaats van als een gezond component.
 
 > Alle numerieke knoppen hierboven worden bij het opstarten op vorm gecontroleerd. Een waarde als
 > `15s` zou anders `sleep` laten falen, en dan keert het wachten meteen terug: een lus die de
 > manager zo snel mogelijk bevraagt terwijl hij elke ronde OK meldt.
+
+## Als beide kanten groen melden en het datapad tóch stuk is
+
+Kijk dan naar de provider-log op `PROVIDER GEWEIGERD (… eerder getekend …)`. Dat betekent dat de
+allowlist of de geldigheidsgrens ná de eerste tekenronde is aangepast: het contract ligt er nog,
+de consumer ziet het als geldig, maar de provider rekent het niet meer mee.
+
+Dit is het enige geval waarin de consumer-log geen enkel signaal geeft — hij heeft een geldig
+contract en meldt terecht `CONSUMER OK`. Zet de allowlist terug of trek het contract aan beide
+kanten in en laat het opnieuw opzetten.
 
 ## Bekende beperking: een gestrande accept-push
 

--- a/demo/environment/federatie/contracts/zad-runbook.md
+++ b/demo/environment/federatie/contracts/zad-runbook.md
@@ -47,6 +47,7 @@ Gemeenschappelijk (beide componenten):
 | `FSC_LUS_MELD_WACHT_NA` | optioneel, standaard `20` — na zoveel rondes wachten volgt een waarschuwing |
 | `FSC_LUS_MAX_WACHT` | optioneel, standaard `200` — na zoveel rondes wachten op de overkant stopt de lus |
 | `FSC_GROUP_ID` | optioneel, standaard `moza-fbs-test` |
+| `FSC_CONTRACT_LIMIET` | optioneel, standaard `1000` — paginalimiet op het ophalen van de contracten; de manager staat maximaal 1000 toe en weigert meer met een 400 |
 
 `logius-fscbootstrap` (consumer):
 
@@ -169,10 +170,14 @@ geweigerd)` — dan is er iets aan de hand met één contract, niet met de ronde
    eerste eis die faalde.
 2. **Meldt de provider `niets te tekenen`**, dan is het contract daar niet aangekomen: controleer
    de announce en de dienstpublicatie uit de voorwaarden hierboven.
-3. **Meldt de provider `eerder getekende contracten die de toets nu niet meer halen`**, dan is de
-   allowlist of de geldigheidsgrens ná de eerste tekenronde aangepast; het contract ligt er wel maar
-   telt niet meer mee.
-4. **Heeft de provider wél getekend** en blijft de consumer toch wachten, dan is de
+3. **Meldt de provider `PROVIDER GEWEIGERD (… eerder getekend …)`**, dan is de allowlist of de
+   geldigheidsgrens ná de eerste tekenronde aangepast; het contract ligt er wel maar telt niet meer
+   mee. Let op: de consumer ziet zijn contract dan nog steeds als geldig, dus alleen de provider-log
+   verraadt dat het datapad stuk is.
+4. **Meldt de consumer `de provider heeft minstens één van onze contracten AFGEWEZEN`**, dan heeft
+   de overkant actief geweigerd. Opnieuw indienen heeft pas zin na een fix aan die kant; trek het
+   afgewezen contract daarna bij de consumer in.
+5. **Heeft de provider wél getekend** en blijft de consumer toch wachten, dan is de
    accept-handtekening onderweg blijven steken — zie hieronder. Dat kan ook de andere kant op: is de
    handtekening van de consumer nooit bij de provider aangekomen, dan weigert die met "draagt de
    handtekening van de consumer nog niet" en is er aan consumerkant geen knop om hem opnieuw te

--- a/demo/environment/federatie/contracts/zad-runbook.md
+++ b/demo/environment/federatie/contracts/zad-runbook.md
@@ -1,0 +1,147 @@
+# Contract-bootstrap op ZAD — runbook
+
+Draaiboek voor de operator: de contract-bootstrap als component per peer neerzetten. Eén keer per
+peer; daarna houdt `deploy.yml` alleen de image-tag bij.
+
+## Waarom een component en geen CI-stap
+
+Elk ZAD-deployment krijgt een `<deployment>-tenant-baseline-network-policy` met
+`podSelector: {deployment: <naam>}`. Ingress komt alleen van pods met hetzelfde `deployment`-label,
+de `rig`-ingresscontroller, `rig-prd-operations` en `rig-prd-backup`; egress gaat alleen naar
+kube-dns, hetzelfde deployment, die twee namespaces, `<project>-infrastructure`, en `0.0.0.0/0`
+beperkt tot TCP 443/80. De isolatie loopt dus per **deployment**, niet per project.
+
+Daar komt bij dat de manager-internal-API (`:9443` authenticated, `:9444` unauthenticated) geen
+route heeft — de ingress publiceert alleen backend-poort `:8443`, de mesh-poort. Alleen een pod
+binnen hetzelfde deployment kan de contract-API dus bereiken, en een CI-runner of een pod uit een
+ander project nooit.
+
+Vandaar: elke peer bootstrapt zijn eigen kant tegen zijn eigen manager, en het contract kruist via
+de FSC-mesh. Dat is geen omweg — het is dezelfde weg die de managers onderling toch al gebruiken,
+en het houdt de contract-API van elke peer onbereikbaar van buiten.
+
+## De twee componenten
+
+| Deployment | Component | `FSC_ROL` | Doet |
+|------------|-----------|-----------|------|
+| `fsc-logius` (`mpfb-8wh`) | `logius-fscbootstrap` | `consumer` | dient het contract in bij de eigen manager en stelt vast dat het geldig wordt |
+| `fsc-magazijna` (`mpfm-w3h`) | `magazijna-fscbootstrap` | `provider` | tekent binnengekomen contracten die de autorisatietoets halen |
+
+Beide draaien hetzelfde image (`ghcr.io/minbzk/fbs-fsc-contract-bootstrap`). ZAD staat geen
+component-args toe, dus de rol komt uit env.
+
+De componenten hebben **geen ingress en geen inbound poort**: ze bellen alleen uit, naar de manager
+van hun eigen deployment. Geef ze dus geen `ports.inbound` — dat zou een Service opleveren die
+niemand gebruikt.
+
+## Env per component
+
+Gemeenschappelijk (beide componenten):
+
+| Variabele | Waarde |
+|-----------|--------|
+| `FSC_ROL` | `consumer` respectievelijk `provider` |
+| `FSC_LUS_WACHT` | optioneel, standaard `15` — interval zolang er nog iets moet gebeuren |
+| `FSC_LUS_HERHAAL` | optioneel, standaard `300` — interval als alles staat |
+
+`logius-fscbootstrap` (consumer):
+
+| Variabele | Waarde |
+|-----------|--------|
+| `FSC_CONSUMER_OIN` | `00000000000000001000` |
+| `FSC_PROVIDER_OIN` | `00000000000000100000` |
+| `FSC_SERVICE_NAME` | `berichtenmagazijn` |
+| `FSC_OUTWAY_THUMBPRINT` | zie hieronder |
+| `FSC_CONSUMER_MANAGER` | `https://fsc-logius-logius-fscmgr:9443` |
+| `FSC_CONSUMER_CERT` | `/etc/fsc/internal/logius/bootstrap/cert.pem` |
+| `FSC_CONSUMER_KEY` | `/etc/fsc/internal/logius/bootstrap/key.pem` |
+| `FSC_CONSUMER_CA` | `/etc/fsc/internal/logius/ca/root.pem` |
+
+`magazijna-fscbootstrap` (provider):
+
+| Variabele | Waarde |
+|-----------|--------|
+| `FSC_PROVIDER_OIN` | `00000000000000100000` |
+| `FSC_DIENSTEN` | `berichtenmagazijn` — spaties-gescheiden lijst |
+| `FSC_CONSUMERS` | `00000000000000001000` — spaties-gescheiden lijst |
+| `FSC_PROVIDER_MANAGER` | `https://fsc-magazijna-magazijna-fscmgr:9443` |
+| `FSC_PROVIDER_CERT` | `/etc/fsc/internal/magazijn-a/bootstrap/cert.pem` |
+| `FSC_PROVIDER_KEY` | `/etc/fsc/internal/magazijn-a/bootstrap/key.pem` |
+| `FSC_PROVIDER_CA` | `/etc/fsc/internal/magazijn-a/ca/root.pem` |
+
+> `FSC_DIENSTEN` en `FSC_CONSUMERS` samen zijn de autorisatiegrens van de provider: alles wat er
+> niet in staat, wordt niet getekend. Een contract dat de toets niet haalt blijft ongetekend en
+> werkt daarmee niet — dat is de bedoelde uitkomst, geen storing. Zet er dus niet ruimhartig extra
+> waarden in "voor later"; een OIN erbij is een peer die van ons mag afnemen.
+
+### De outway-thumbprint bepalen
+
+De consumer-helft heeft de SPKI-SHA256-thumbprint van het **group**-cert van de eigen outway nodig.
+Op ZAD komt die uit env in plaats van uit een bestand: het group-cert hangt aan het
+outway-component, en het aan een tweede component koppelen zou die identiteit verspreiden.
+
+```bash
+openssl x509 -in demo/environment/logius/pki/out/logius/outway/cert.pem -pubkey -noout \
+  | openssl pkey -pubin -outform DER \
+  | openssl dgst -sha256 -r | cut -d' ' -f1
+```
+
+64 hex-tekens. De waarde is stabiel zolang het sleutelpaar dat is — een cert-rotatie binnen
+hetzelfde sleutelpaar verandert hem niet. Rouleer je het sleutelpaar wél, dan moet deze env mee en
+komt er een nieuw contract; het oude wordt door de consumer-helft opgeruimd zodra het overtollig is.
+
+## Cert-attachments
+
+Het component gebruikt het **internal**-cert van het `bootstrap`-endpoint als client naar de
+manager-API. Dat is een eigen cert en niet dat van een andere component: wie een cert deelt, deelt
+een identiteit, en dan is in het txlog niet meer te zien wie wat deed.
+
+`pki/issue.sh` geeft dit endpoint bewust **geen group-cert** — het bedient zelf geen TLS en hoort
+zich niet in de mesh als de peer te kunnen voordoen.
+
+Attachments per bootstrap-component (UI-only; de v2-API kloont ze niet):
+
+| Bestand uit `pki/zad-upload/<peer>/` | Pod-pad |
+|--------------------------------------|---------|
+| `internal/<peer>/bootstrap/cert.pem` | `/etc/fsc/internal/<peer>/bootstrap/cert.pem` |
+| `internal/<peer>/bootstrap/key.pem` | `/etc/fsc/internal/<peer>/bootstrap/key.pem` |
+| `internal/<peer>/ca/root.pem` | `/etc/fsc/internal/<peer>/ca/root.pem` |
+
+Zie `deploy/zad/cert-manifest.md` bij de peer voor de algemene valkuilen (internal-pad krijgt het
+internal-cert, group-pad het group-cert inclusief intermediate).
+
+## Volgorde
+
+1. `pki/issue.sh -f` bij beide peers — geeft het nieuwe `bootstrap`-endpoint uit.
+2. `pki/zad-bundle.sh <peer>` — zet de upload-set klaar.
+3. Component éénmalig aanmaken in de ZAD-UI, in de deployment van díé peer, met de env hierboven
+   en zonder inbound poort.
+4. De drie attachments koppelen.
+5. Component starten en de log volgen.
+
+Daarna houdt de `deploy-test-*`-job de image-tag bij, zoals bij de andere peer-componenten.
+
+## Verifiëren
+
+De consumer-log meldt `CONSUMER OK`, de provider-log `PROVIDER OK (1 contract(en) getekend)` en
+daarna elke ronde `PROVIDER OK (niets te tekenen)`. Dat laatste is het idempotentie-signaal: draait
+het component opnieuw of herstart de pod, dan komt er geen tweede contract bij.
+
+Blijft de consumer `CONSUMER WACHT` melden terwijl de provider niets meer te tekenen heeft, dan is
+de accept-handtekening onderweg blijven steken (zie hieronder).
+
+## Bekende beperking: een gestrande accept-push
+
+De manager pusht de accept-handtekening na het tekenen naar de consumer, maar best-effort: met
+begrensde backoff en zonder cron-retry. Strandt die push, dan blijft het contract bij de consumer
+`proposed` en ziet de outway de grant nooit, terwijl het bij de provider geldig heet.
+
+De provider-helft stuurt daarom na elke accept één keer na. Strandt de push daarná alsnog, dan kan
+geen van beide helften dat waarnemen: de consumer ziet het probleem maar kan de her-distributie niet
+aanroepen (dat is een provider-endpoint), en de provider kan de her-distributie aanroepen maar het
+probleem niet zien. Lokaal loste één script dat op door bij beide managers te kijken; op ZAD kan dat
+niet.
+
+De uitweg is een handmatige duw: zet op het provider-component tijdelijk
+`FSC_FORCEER_DISTRIBUTIE=1`, laat één ronde lopen, en zet hem weer uit. Aan laten staan kost een
+extra API-call per contract per ronde zonder dat er iets mis is.

--- a/demo/environment/federatie/smoke-contract-split.sh
+++ b/demo/environment/federatie/smoke-contract-split.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Smoke: bewijst dat de twee helften van de contract-bootstrap los van elkaar werken en samen
+# convergeren. Draai na `./federatie.sh up` en nadat elk magazijn zijn dienst gepubliceerd heeft.
+#
+# Waarom naast smoke-contract.sh. Die toetst de UITKOMST: er ligt een geldig contract en het
+# data-pad werkt. Deze toetst de WEG ernaartoe, en dat is precies wat op ZAD anders is — daar
+# draaien de helften in verschillende deployments die elkaars manager niet kunnen bereiken. Zonder
+# deze smoke zou die opzet alleen op ZAD zelf blijken te werken of niet.
+#
+#   1. de consumer-helft dient in en meldt dat hij wacht (exit 3), zónder de provider aan te raken;
+#   2. de provider-helft tekent wat er ligt, zónder de consumer aan te raken;
+#   3. de consumer-helft ziet het contract daarna geldig worden (exit 0);
+#   4. een tweede ronde levert geen tweede contract op en niets meer te tekenen.
+#
+# Linux + podman: gebruikt `podman`, `curl` en `jq`.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ENVDIR="$(cd "${HERE}/.." && pwd)"
+
+# shellcheck source=../lib/fsc-harness.sh
+. "${ENVDIR}/lib/fsc-harness.sh"
+# shellcheck source=../lib/fsc-contract.sh
+. "${ENVDIR}/lib/fsc-contract.sh"
+# shellcheck source=peers.env
+. "${HERE}/peers.env"
+
+fsc_errlog_init
+fsc_have_jq
+
+command -v curl >/dev/null 2>&1 || { echo "FAIL: 'curl' is vereist." >&2; exit 1; }
+[ "$HAVE_JQ" -eq 1 ] || { echo "FAIL: 'jq' is vereist — elke assert hieronder leest contract-JSON." >&2; exit 1; }
+
+FOUTEN=0
+fout() { echo "FAIL: $*" >&2; FOUTEN=$((FOUTEN + 1)); }
+ok()   { echo "OK: $*"; }
+
+: "${UITVRAAG:?geen UITVRAAG in peers.env}"
+: "${MAGAZIJNEN:?geen MAGAZIJNEN in peers.env}"
+: "${MAGAZIJN_DIENST:?geen MAGAZIJN_DIENST in peers.env}"
+
+CONS_NET="$(fsc_peer_waarde NET "$UITVRAAG")"
+CONS_OIN="$(fsc_peer_waarde OIN "$UITVRAAG")"
+[ -n "$CONS_NET" ] && [ -n "$CONS_OIN" ] || { echo "FAIL: NET_/OIN_ ontbreekt voor '${UITVRAAG}'." >&2; exit 1; }
+
+CONS_OUTWAY_CERT="${ENVDIR}/${UITVRAAG}/pki/out/${UITVRAAG}/outway/cert.pem"
+CONS_THUMB="$(fsc_outway_thumbprint "$CONS_OUTWAY_CERT")" \
+  || { echo "FAIL: kon de outway-thumbprint niet berekenen uit ${CONS_OUTWAY_CERT}: $(fsc_last_error)" >&2; exit 1; }
+
+CONTRACTS="${ENVDIR}/federatie/contracts"
+
+# consumer_helft <provider-oin>: de consumer-helft met UITSLUITEND zijn eigen adres en certificaten.
+#
+# `env -i` en niet alleen "de andere variabelen weglaten": deze smoke moet kunnen aantonen dat de
+# helft het zonder de overkant redt, en dat bewijst hij alleen als die overkant er echt niet is. Een
+# geërfde FSC_PROVIDER_MANAGER uit de shell van de aanroeper zou dat stil ondergraven.
+consumer_helft() {
+  env -i PATH="$PATH" HOME="$HOME" \
+    FSC_CONSUMER_OIN="$CONS_OIN" \
+    FSC_PROVIDER_OIN="$1" \
+    FSC_SERVICE_NAME="$MAGAZIJN_DIENST" \
+    FSC_OUTWAY_CERT="$CONS_OUTWAY_CERT" \
+    FSC_CONSUMER_MANAGER="https://manager.${UITVRAAG}.fsc-test.local:9443" \
+    FSC_CONSUMER_ADRES="$(fsc_component_adres "$CONS_NET" manager)" \
+    FSC_CONSUMER_CERT="${ENVDIR}/${UITVRAAG}/pki/internal/${UITVRAAG}/manager/cert.pem" \
+    FSC_CONSUMER_KEY="${ENVDIR}/${UITVRAAG}/pki/internal/${UITVRAAG}/manager/key.pem" \
+    FSC_CONSUMER_CA="${ENVDIR}/${UITVRAAG}/pki/internal/${UITVRAAG}/ca/root.pem" \
+    "${CONTRACTS}/bootstrap-consumer.sh"
+}
+
+# provider_helft <magazijn> <net> <oin>: idem voor de provider-kant.
+provider_helft() {
+  env -i PATH="$PATH" HOME="$HOME" \
+    FSC_PROVIDER_OIN="$3" \
+    FSC_DIENSTEN="$MAGAZIJN_DIENST" \
+    FSC_CONSUMERS="$CONS_OIN" \
+    FSC_PROVIDER_MANAGER="https://manager.${1}.fsc-test.local:9443" \
+    FSC_PROVIDER_ADRES="$(fsc_component_adres "$2" manager)" \
+    FSC_PROVIDER_CERT="${ENVDIR}/${1}/pki/internal/${1}/manager/cert.pem" \
+    FSC_PROVIDER_KEY="${ENVDIR}/${1}/pki/internal/${1}/manager/key.pem" \
+    FSC_PROVIDER_CA="${ENVDIR}/${1}/pki/internal/${1}/ca/root.pem" \
+    "${CONTRACTS}/bootstrap-provider.sh"
+}
+
+# geldige_contracten <peer> <net> <provider-oin>: hashes van geldige contracten voor deze combinatie.
+geldige_contracten() {
+  local json
+  json="$(fsc_manager_contracts "$ENVDIR" "$1" "$(fsc_component_adres "$2" manager)")" || return 1
+  fsc_grant_actief "$json" "$MAGAZIJN_DIENST" "$3" "$CONS_OIN" "$CONS_THUMB" | sort
+}
+
+# aantal_regels <tekst>: 0 voor leeg, anders het aantal niet-lege regels.
+aantal_regels() { printf '%s' "${1:-}" | grep -c . || true; }
+
+for magazijn in $MAGAZIJNEN; do
+  PROV_NET="$(fsc_peer_waarde NET "$magazijn")"
+  PROV_OIN="$(fsc_peer_waarde OIN "$magazijn")"
+  [ -n "$PROV_NET" ] && [ -n "$PROV_OIN" ] || { fout "NET_/OIN_ ontbreekt voor '${magazijn}'"; continue; }
+
+  echo "===== ${UITVRAAG} -> ${magazijn} ====="
+
+  VOORAF="$(aantal_regels "$(geldige_contracten "$UITVRAAG" "$CONS_NET" "$PROV_OIN" || true)")"
+
+  # --- 1. Consumer dient in, alleen bij zijn eigen manager ---------------------------------------
+  echo "== 1. consumer-helft =="
+  rc=0
+  consumer_helft "$PROV_OIN" || rc=$?
+
+  case "$rc" in
+    0) ok "consumer: contract was al geldig (${VOORAF} contract(en) vooraf)" ;;
+    3) ok "consumer: ingediend en wachtend op de provider" ;;
+    *) fout "consumer-helft brak af met exit ${rc}"; continue ;;
+  esac
+
+  # --- 2. Provider tekent, alleen bij zijn eigen manager -----------------------------------------
+  echo "== 2. provider-helft =="
+
+  if provider_helft "$magazijn" "$PROV_NET" "$PROV_OIN"; then
+    ok "provider: helft afgerond zonder de consumer-manager aan te raken"
+  else
+    fout "provider-helft brak af"
+    continue
+  fi
+
+  # --- 3. Consumer ziet het contract geldig worden -----------------------------------------------
+  echo "== 3. consumer-helft opnieuw =="
+  rc=0
+  POGING=0
+
+  # De accept-handtekening reist via de mesh terug; dat duurt even. Zelfde grens als de orkestrator.
+  while :; do
+    rc=0
+    consumer_helft "$PROV_OIN" || rc=$?
+    [ "$rc" -eq 3 ] || break
+    [ "$POGING" -lt "${SPLIT_POGINGEN:-10}" ] || break
+
+    POGING=$((POGING + 1))
+    sleep "${SPLIT_WACHT:-2}"
+  done
+
+  if [ "$rc" -eq 0 ]; then
+    ok "consumer: contract is geldig geworden na de provider-helft"
+  else
+    fout "consumer zag het contract niet geldig worden (exit ${rc})"
+    continue
+  fi
+
+  # --- 4. Tweede ronde: niets erbij --------------------------------------------------------------
+  echo "== 4. tweede ronde =="
+  NA_EEN="$(aantal_regels "$(geldige_contracten "$UITVRAAG" "$CONS_NET" "$PROV_OIN" || true)")"
+
+  rc=0
+  consumer_helft "$PROV_OIN" || rc=$?
+  [ "$rc" -eq 0 ] && ok "consumer: herhaalde run is een no-op" \
+    || fout "consumer: herhaalde run gaf exit ${rc} in plaats van 0"
+
+  PROV_UIT="$(provider_helft "$magazijn" "$PROV_NET" "$PROV_OIN" 2>&1)" || {
+    fout "provider: herhaalde run brak af"
+    continue
+  }
+
+  case "$PROV_UIT" in
+    *"niets te tekenen"*) ok "provider: herhaalde run heeft niets meer te tekenen" ;;
+    *) fout "provider: herhaalde run tekende opnieuw — $(printf '%s' "$PROV_UIT" | tail -n1)" ;;
+  esac
+
+  NA_TWEE="$(aantal_regels "$(geldige_contracten "$UITVRAAG" "$CONS_NET" "$PROV_OIN" || true)")"
+
+  if [ "$NA_TWEE" -eq "$NA_EEN" ]; then
+    ok "aantal geldige contracten ongewijzigd na de tweede ronde (${NA_TWEE})"
+  else
+    fout "tweede ronde veranderde het aantal geldige contracten: ${NA_EEN} -> ${NA_TWEE}"
+  fi
+
+  # Eén contract is de bedoeling. Meer betekent dat de idempotentie lekt; de opruiming in de
+  # consumer-helft hoort dat in de volgende ronde recht te trekken, maar dan is er iets te melden.
+  if [ "$NA_TWEE" -eq 1 ]; then
+    ok "precies één geldig contract voor ${MAGAZIJN_DIENST}"
+  else
+    fout "verwachtte precies één geldig contract, vond ${NA_TWEE}"
+  fi
+
+  echo
+done
+
+if [ "$FOUTEN" -ne 0 ]; then
+  echo "SMOKE-CONTRACT-SPLIT ROOD: ${FOUTEN} bevinding(en)." >&2
+  exit 1
+fi
+
+echo "SMOKE-CONTRACT-SPLIT OK."

--- a/demo/environment/federatie/smoke-contract-split.sh
+++ b/demo/environment/federatie/smoke-contract-split.sh
@@ -92,19 +92,31 @@ geldige_contracten() {
 # aantal_regels <tekst>: 0 voor leeg, anders het aantal niet-lege regels.
 aantal_regels() { printf '%s' "${1:-}" | grep -c . || true; }
 
-# tel_geldige <peer> <net> <provider-oin>: aantal geldige contracten, of afbreken.
+# tel_geldige <peer> <net> <provider-oin>: aantal geldige contracten op stdout, non-zero bij een
+# leesfout.
 #
 # Zonder deze tak zou een mislukte managerbevraging als "0 contracten" doorgaan. Twee mislukte
 # metingen op rij zijn dan gelijk aan elkaar, en de vergelijking "aantal ongewijzigd" wordt groen
 # op grond van twee fouten.
+#
+# De functie meldt zelf NIET: hij wordt in een commando-substitutie aangeroepen, dus een `fout`
+# hier zou `FOUTEN` in een subshell ophogen en bij terugkeer verdwenen zijn — waarna de smoke
+# alsnog groen eindigt. De aanroeper doet de melding.
 tel_geldige() {
   local regels
-  regels="$(geldige_contracten "$1" "$2" "$3")" || {
-    fout "kon de contracten van ${1} niet ophalen: $(fsc_last_error)"
-    return 1
-  }
+  regels="$(geldige_contracten "$1" "$2" "$3")" || return 1
 
   aantal_regels "$regels"
+}
+
+# meet <naam> <peer> <net> <provider-oin>: tel_geldige met de melding op de juiste plek.
+meet() {
+  local naam="$1"; shift
+
+  tel_geldige "$@" || {
+    fout "kon de contracten van ${1} niet ophalen (${naam}): $(fsc_last_error)"
+    return 1
+  }
 }
 
 for magazijn in $MAGAZIJNEN; do
@@ -114,7 +126,7 @@ for magazijn in $MAGAZIJNEN; do
 
   echo "===== ${UITVRAAG} -> ${magazijn} ====="
 
-  VOORAF="$(tel_geldige "$UITVRAAG" "$CONS_NET" "$PROV_OIN")" || continue
+  VOORAF="$(meet vooraf "$UITVRAAG" "$CONS_NET" "$PROV_OIN")" || { fout "meting vooraf mislukt"; continue; }
 
   # --- 1. Consumer dient in, alleen bij zijn eigen manager ---------------------------------------
   echo "== 1. consumer-helft =="
@@ -132,12 +144,16 @@ for magazijn in $MAGAZIJNEN; do
 
   # De helft draait onder `env -i` met uitsluitend zijn eigen adres en certificaten, dus dat hij
   # hier klaarkomt ís het bewijs dat hij de overkant niet nodig heeft.
-  if provider_helft "$magazijn" "$PROV_NET" "$PROV_OIN"; then
-    ok "provider: klaar met alleen zijn eigen manager in de omgeving"
-  else
-    fout "provider-helft brak af"
-    continue
-  fi
+  rc=0
+  provider_helft "$magazijn" "$PROV_NET" "$PROV_OIN" || rc=$?
+
+  case "$rc" in
+    0|3) ok "provider: klaar met alleen zijn eigen manager in de omgeving" ;;
+    # 4 = er lag iets dat de autorisatietoets niet haalde. Geen crash: stap 3 stelt vast of ons
+    # eigen contract er wél doorheen kwam, en dat is wat deze smoke meet.
+    4) ok "provider: klaar, met een of meer contracten buiten de allowlist" ;;
+    *) fout "provider-helft brak af met exit ${rc}"; continue ;;
+  esac
 
   # --- 3. Consumer ziet het contract geldig worden -----------------------------------------------
   echo "== 3. consumer-helft opnieuw =="
@@ -164,7 +180,7 @@ for magazijn in $MAGAZIJNEN; do
 
   # --- 4. Tweede ronde: niets erbij --------------------------------------------------------------
   echo "== 4. tweede ronde =="
-  NA_EEN="$(tel_geldige "$UITVRAAG" "$CONS_NET" "$PROV_OIN")" || continue
+  NA_EEN="$(meet na-ronde-1 "$UITVRAAG" "$CONS_NET" "$PROV_OIN")" || { fout "meting na ronde 1 mislukt"; continue; }
 
   rc=0
   consumer_helft "$PROV_OIN" || rc=$?
@@ -181,7 +197,7 @@ for magazijn in $MAGAZIJNEN; do
     *) fout "provider: herhaalde run tekende opnieuw — $(printf '%s' "$PROV_UIT" | tail -n1)" ;;
   esac
 
-  NA_TWEE="$(tel_geldige "$UITVRAAG" "$CONS_NET" "$PROV_OIN")" || continue
+  NA_TWEE="$(meet na-ronde-2 "$UITVRAAG" "$CONS_NET" "$PROV_OIN")" || { fout "meting na ronde 2 mislukt"; continue; }
 
   if [ "$NA_TWEE" -eq "$NA_EEN" ]; then
     ok "aantal geldige contracten ongewijzigd na de tweede ronde (${NA_TWEE})"

--- a/demo/environment/federatie/smoke-contract-split.sh
+++ b/demo/environment/federatie/smoke-contract-split.sh
@@ -92,6 +92,21 @@ geldige_contracten() {
 # aantal_regels <tekst>: 0 voor leeg, anders het aantal niet-lege regels.
 aantal_regels() { printf '%s' "${1:-}" | grep -c . || true; }
 
+# tel_geldige <peer> <net> <provider-oin>: aantal geldige contracten, of afbreken.
+#
+# Zonder deze tak zou een mislukte managerbevraging als "0 contracten" doorgaan. Twee mislukte
+# metingen op rij zijn dan gelijk aan elkaar, en de vergelijking "aantal ongewijzigd" wordt groen
+# op grond van twee fouten.
+tel_geldige() {
+  local regels
+  regels="$(geldige_contracten "$1" "$2" "$3")" || {
+    fout "kon de contracten van ${1} niet ophalen: $(fsc_last_error)"
+    return 1
+  }
+
+  aantal_regels "$regels"
+}
+
 for magazijn in $MAGAZIJNEN; do
   PROV_NET="$(fsc_peer_waarde NET "$magazijn")"
   PROV_OIN="$(fsc_peer_waarde OIN "$magazijn")"
@@ -99,7 +114,7 @@ for magazijn in $MAGAZIJNEN; do
 
   echo "===== ${UITVRAAG} -> ${magazijn} ====="
 
-  VOORAF="$(aantal_regels "$(geldige_contracten "$UITVRAAG" "$CONS_NET" "$PROV_OIN" || true)")"
+  VOORAF="$(tel_geldige "$UITVRAAG" "$CONS_NET" "$PROV_OIN")" || continue
 
   # --- 1. Consumer dient in, alleen bij zijn eigen manager ---------------------------------------
   echo "== 1. consumer-helft =="
@@ -115,8 +130,10 @@ for magazijn in $MAGAZIJNEN; do
   # --- 2. Provider tekent, alleen bij zijn eigen manager -----------------------------------------
   echo "== 2. provider-helft =="
 
+  # De helft draait onder `env -i` met uitsluitend zijn eigen adres en certificaten, dus dat hij
+  # hier klaarkomt ís het bewijs dat hij de overkant niet nodig heeft.
   if provider_helft "$magazijn" "$PROV_NET" "$PROV_OIN"; then
-    ok "provider: helft afgerond zonder de consumer-manager aan te raken"
+    ok "provider: klaar met alleen zijn eigen manager in de omgeving"
   else
     fout "provider-helft brak af"
     continue
@@ -147,7 +164,7 @@ for magazijn in $MAGAZIJNEN; do
 
   # --- 4. Tweede ronde: niets erbij --------------------------------------------------------------
   echo "== 4. tweede ronde =="
-  NA_EEN="$(aantal_regels "$(geldige_contracten "$UITVRAAG" "$CONS_NET" "$PROV_OIN" || true)")"
+  NA_EEN="$(tel_geldige "$UITVRAAG" "$CONS_NET" "$PROV_OIN")" || continue
 
   rc=0
   consumer_helft "$PROV_OIN" || rc=$?
@@ -155,7 +172,7 @@ for magazijn in $MAGAZIJNEN; do
     || fout "consumer: herhaalde run gaf exit ${rc} in plaats van 0"
 
   PROV_UIT="$(provider_helft "$magazijn" "$PROV_NET" "$PROV_OIN" 2>&1)" || {
-    fout "provider: herhaalde run brak af"
+    fout "provider: herhaalde run brak af — $(printf '%s' "$PROV_UIT" | tail -n1)"
     continue
   }
 
@@ -164,7 +181,7 @@ for magazijn in $MAGAZIJNEN; do
     *) fout "provider: herhaalde run tekende opnieuw — $(printf '%s' "$PROV_UIT" | tail -n1)" ;;
   esac
 
-  NA_TWEE="$(aantal_regels "$(geldige_contracten "$UITVRAAG" "$CONS_NET" "$PROV_OIN" || true)")"
+  NA_TWEE="$(tel_geldige "$UITVRAAG" "$CONS_NET" "$PROV_OIN")" || continue
 
   if [ "$NA_TWEE" -eq "$NA_EEN" ]; then
     ok "aantal geldige contracten ongewijzigd na de tweede ronde (${NA_TWEE})"

--- a/demo/environment/lib/fsc-contract.sh
+++ b/demo/environment/lib/fsc-contract.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Bouwstenen voor de contract-bootstrap, gedeeld door de consumer- en de provider-helft.
+#
+# De twee helften praten elk met precies één manager: die van hun eigen peer. Dat is geen
+# stijlkeuze maar een eis van de omgeving — op ZAD isoleert de tenant-baseline-NetworkPolicy per
+# deployment, en de interne manager-API heeft geen route. Eén proces dat beide managers aanspreekt
+# bestaat daar dus niet. Het contract kruist in plaats daarvan via de FSC-mesh, de weg die de
+# managers onderling toch al gebruiken.
+#
+# Vereist $ERRLOG (fsc_errlog_init) en $HAVE_JQ (fsc_have_jq) uit fsc-harness.sh.
+
+# fsc_env_vereist <naam> [uitleg]: de waarde van die variabele op stdout, of afbreken met 2.
+#
+# Niet `${VAR:?melding}`: dat eindigt op 1, en 1 betekent hier "het ging mis, probeer opnieuw".
+# Een ontbrekende variabele wordt door opnieuw proberen nooit beter, en de lus op ZAD zou er
+# eindeloos op blijven herstarten met steeds dezelfde melding. Uitgang 2 is de afspraak voor
+# "configuratie deugt niet"; de lus stopt daarop, wat een zichtbare crashloop oplevert in plaats van
+# een component dat draait en niets doet.
+#
+# Leunt op `set -e` bij de aanroeper: de exit-status van de commando-substitutie is de status van de
+# toekenning, dus `X="$(fsc_env_vereist FOO)"` breekt het script af met 2.
+fsc_env_vereist() {
+  local naam="$1" waarde="${!1-}"
+
+  [ -n "$waarde" ] || {
+    echo "FAIL: zet ${naam}${2:+ — $2}" >&2
+    exit 2
+  }
+
+  printf '%s' "$waarde"
+}
+
+# fsc_contract_manager_ok <url...>: elk adres moet met https:// beginnen.
+#
+# De adressen worden geconcateneerd tot curl's URL-argument; een waarde die met `-` begint zou curl
+# als optie lezen (`-K/pad` maakt er een config-file-lees van).
+fsc_contract_manager_ok() {
+  local url
+  for url in "$@"; do
+    case "$url" in
+      https://*) ;;
+      *) echo "FAIL: manager-adres moet met https:// beginnen: '${url}'" >&2; return 1 ;;
+    esac
+  done
+}
+
+# fsc_contract_api <url> <cert> <key> <ca> <adres> <curl-args...>: één call naar een manager.
+#
+# <adres> is het IP waar de hostnaam heen moet wijzen, of leeg. Leeg = gewone DNS-resolutie, wat op
+# ZAD het geval is: daar is de manager een ClusterIP-service met een echte naam. Lokaal staan de
+# federatie-namen in geen enkele resolver (`extra_hosts` geldt alleen binnen containers), vandaar
+# --resolve met het loopback-adres van die component.
+fsc_contract_api() {
+  local url="$1" cert="$2" key="$3" ca="$4" adres="$5"; shift 5
+  local args=() hostnaam poort
+
+  if [ -n "$adres" ]; then
+    hostnaam="${url#https://}"; hostnaam="${hostnaam%%/*}"
+    poort="${hostnaam##*:}"; hostnaam="${hostnaam%%:*}"
+    args=(--resolve "${hostnaam}:${poort}:${adres}")
+  fi
+
+  curl -sS --fail-with-body --noproxy '*' "${args[@]}" \
+    --cert "$cert" --key "$key" --cacert "$ca" "$@" 2>"$ERRLOG"
+}
+
+# fsc_json_lijst <woord...>: de woorden als JSON-array op stdout, voor jq's --argjson.
+fsc_json_lijst() {
+  local eerste=1 woord
+  printf '['
+  for woord in "$@"; do
+    [ "$eerste" -eq 1 ] || printf ','
+    eerste=0
+    printf '%s' "$woord" | jq -R .
+  done
+  printf ']'
+}
+
+# --- Wat de provider mag tekenen ----------------------------------------------------------------
+# Vóór de splitsing was de accept een gerichte handeling: het script kende het hash dat het zelf
+# net had laten indienen. De provider-helft kent dat hash niet — hij vindt een contract in zijn
+# lijst en moet zélf besluiten of hij tekent. Dat is een autorisatiebesluit, en de inhoud van het
+# contract komt van de tegenpartij.
+#
+# Een contract draagt een LIJST grants. Toetsen of er een grant in zit die ons bevalt is daarom
+# niet genoeg: wie een tweede grant meestuurt, krijgt die anders mee-ondertekend. Het contract moet
+# als geheel kloppen, dus de eis is "precies één grant, en die klopt" — niet "er is er één die
+# klopt".
+#
+# De thumbprint in de grant wordt bewust NIET getoetst. De provider heeft het outway-cert van de
+# consumer niet en kan hem dus niet onafhankelijk verifiëren. Hij hoeft dat ook niet: de thumbprint
+# zegt wélke outway van díé consumer de dienst mag afnemen, en dat is aan de consumer. Wat de
+# provider bewaakt is dat het om zijn eigen dienst gaat en om een consumer die hij kent.
+
+# fsc_contract_beoordeling <json> <provider_oin> <diensten-json> <consumers-json>: één regel per
+# niet-ingetrokken contract dat de provider aangaat:
+#
+#   TEKEN    <hash> <consumer_oin>   mag getekend worden, is dat nog niet
+#   GETEKEND <hash> <consumer_oin>   voldoet en draagt onze handtekening al
+#   WEIGER   <hash> <reden>          nog niet getekend en haalt de toets niet
+#
+# Alle drie komen uit hetzelfde jq-programma en dus uit dezelfde toets. Twee programma's zouden
+# uiteen kunnen lopen, en een diagnose die andere contracten bekijkt dan de matcher tekent wijst de
+# operator juist de verkeerde kant op. De reden noemt de eerste eis die faalt.
+#
+# Een contract dat de toets niet haalt én al getekend is levert niets op: dat is andermans zaak.
+# Het servicePublication-contract voor onze eigen dienst staat op dezelfde manager en wordt door
+# `AUTO_SIGN_GRANTS` vanzelf getekend; zou dat een WEIGER-regel opleveren, dan stond de log elke
+# ronde vol met contracten waar niets mee mis is.
+fsc_contract_beoordeling() {
+  [ "$HAVE_JQ" -eq 1 ] || return 0
+  printf '%s' "$1" | jq -r \
+    --arg prov "$2" --argjson diensten "$3" --argjson consumers "$4" '
+    def weiger($ondertekend; $tekst): if $ondertekend then empty else "WEIGER \($tekst)" end;
+
+    .contracts[]?
+    | select((.has_revoked // false) == false)
+    | . as $c
+    | (.content.grants // []) as $g
+    | (((.signatures.accept // {}) | has($prov))) as $ondertekend
+    | if ($g | length) != 1 then
+        weiger($ondertekend; "\($c.hash) draagt \($g | length) grants in plaats van precies 1")
+      elif $g[0].type != "GRANT_TYPE_SERVICE_CONNECTION" then
+        weiger($ondertekend; "\($c.hash) grant-type \($g[0].type // "ontbreekt") is geen serviceConnection")
+      elif $g[0].service.peer_id != $prov then
+        weiger($ondertekend; "\($c.hash) dienst hoort bij peer \($g[0].service.peer_id // "ontbreekt"), niet bij ons")
+      elif ($diensten | index($g[0].service.name)) == null then
+        weiger($ondertekend; "\($c.hash) dienst \($g[0].service.name // "ontbreekt") bieden wij niet aan")
+      elif ($consumers | index($g[0].outway.peer_id)) == null then
+        weiger($ondertekend; "\($c.hash) consumer \($g[0].outway.peer_id // "ontbreekt") staat niet op de lijst")
+      elif $ondertekend then "GETEKEND \($c.hash) \($g[0].outway.peer_id)"
+      else "TEKEN \($c.hash) \($g[0].outway.peer_id)" end' 2>/dev/null
+}
+
+# --- Wat de consumer al heeft uitstaan ----------------------------------------------------------
+
+# fsc_contract_voor_combinatie <json> <service> <provider_oin> <consumer_oin> <thumbprint>:
+# `<hash> <state> <provider-getekend ja|nee>` per regel, voor elk niet-ingetrokken contract dat
+# precies deze serviceConnection draagt.
+#
+# De consumer-helft heeft dit nodig om te weten of hij nog moet indienen. Alleen kijken naar
+# volledig geldige contracten (fsc_grant_actief) zou niet volstaan: in de gesplitste opzet zit er
+# tijd tussen indienen en tekenen, en in dat gat zou elke ronde er nóg een contract bij posten.
+#
+# De "precies één grant"-eis staat er ook hier, zodat consumer en provider dezelfde contracten als
+# "van deze combinatie" zien. Zouden ze daarin verschillen, dan wacht de consumer op een contract
+# dat de provider nooit gaat tekenen.
+fsc_contract_voor_combinatie() {
+  [ "$HAVE_JQ" -eq 1 ] || return 0
+  printf '%s' "$1" | jq -r \
+    --arg svc "$2" --arg prov "$3" --arg cons "$4" --arg thumb "$5" '
+    .contracts[]?
+    | select((.has_revoked // false) == false)
+    | select((.content.grants // []) | length == 1)
+    | select(.content.grants[0]
+        | .type == "GRANT_TYPE_SERVICE_CONNECTION"
+          and .service.name == $svc
+          and .service.peer_id == $prov
+          and .outway.peer_id == $cons
+          and .outway.identification.public_key_thumbprint == $thumb)
+    | "\(.hash) \((.state // "onbekend") | ascii_downcase) \(if ((.signatures.accept // {}) | has($prov)) then "ja" else "nee" end)"
+    ' 2>/dev/null
+}
+
+# fsc_contract_regels <beoordeling> <soort>: de regels van één soort, zonder het soort-woord.
+fsc_contract_regels() {
+  printf '%s' "${1:-}" | sed -n "s/^$2 //p"
+}

--- a/demo/environment/lib/fsc-contract.sh
+++ b/demo/environment/lib/fsc-contract.sh
@@ -30,6 +30,24 @@ fsc_env_vereist() {
   printf '%s' "$waarde"
 }
 
+# fsc_getal_vereist <naam> <waarde>: de waarde op stdout als het een geheel getal is, anders exit 2.
+#
+# Intervallen en drempels komen op ZAD uit component-env. Een tikfout maakt daar geen fout van maar
+# iets ergers: `sleep "15s"` mislukt meteen, `pauzeer` keert direct terug en de lus wordt een hot
+# loop die de manager zo snel mogelijk bevraagt terwijl hij elke ronde OK meldt. En een niet-numerieke
+# drempel laat `[ ]` falen, waarna de vangrail die de lus zou stoppen niets meer doet. Beide falen
+# dus open; vandaar één controle bij het opstarten.
+fsc_getal_vereist() {
+  case "${2:-}" in
+    ""|*[!0-9]*)
+      echo "FAIL: ${1} moet een geheel getal zijn, niet '${2:-}'." >&2
+      exit 2
+      ;;
+  esac
+
+  printf '%s' "$2"
+}
+
 # fsc_hex64 <waarde>: is dit precies 64 lowercase hex-tekens?
 #
 # `[0-9a-f]*` in een case-patroon toetst alléén het eerste teken — de overige 63 komen er dan
@@ -39,6 +57,16 @@ fsc_hex64() {
   case "${1:-}" in
     ""|*[!0-9a-f]*) return 1 ;;
     *) [ "${#1}" -eq 64 ] ;;
+  esac
+}
+
+# fsc_hash_ok <waarde>: heeft dit contract-hash een vorm die veilig in een URL-pad past?
+#
+# FSC-hashes hebben de vorm `$1$4$<base64url>`. Een waarde met een schuine streep of witruimte zou
+# het pad verleggen — curl normaliseert `..`-segmenten — dus die valt af.
+fsc_hash_ok() {
+  case "${1:-}" in
+    ""|*[!A-Za-z0-9._~$+-]*) return 1 ;;
   esac
 }
 
@@ -85,7 +113,7 @@ fsc_contract_api() {
 # zou alles na de eerste regel geruisloos buiten de autorisatiegrens vallen. Vandaar splitsen op
 # elke witruimte, en een lege uitkomst als fout behandelen in plaats van als "niemand mag iets".
 fsc_lijst_naar_json() {
-  local naam="$1" woorden=()
+  local naam="$1" woord woorden=()
 
   # `|| [ -n "$woord" ]`: de invoer eindigt niet op een newline, en een kale `read` laat het laatste
   # stuk dan vallen — dat zou stilletjes de laatste dienst of consumer uit de allowlist halen.
@@ -126,6 +154,12 @@ _FSC_CONTRACTEN_JQ='
     if type != "object" then error("respons is geen JSON-object")
     elif has("contracts") | not then error("respons heeft geen veld \"contracts\"")
     elif (.contracts | type) != "array" then error("veld \"contracts\" is \(.contracts | type), geen array")
+    elif ((.next_cursor // "") | tostring) != "" then
+      # De lijst is cursor-gepagineerd. Alleen pagina 1 lezen zou betekenen dat de consumer zijn
+      # eigen contract niet meer ziet zodra de manager er genoeg heeft — en dan dient hij elke
+      # ronde een nieuw contract in. Afbreken tot iemand de cursor volgt; stil doorgaan is hier de
+      # gevaarlijke keuze.
+      error("de contractenlijst is gepagineerd (next_cursor gezet) en dat volgen we nog niet")
     else .contracts end;
 '
 
@@ -135,7 +169,12 @@ _FSC_CONTRACTEN_JQ='
 # er komt niets uit en de exit-status is 0. De prelude hierboven zou dat dus nooit zien, en een
 # HTTP 200 met lege body zou als "geen contracten" gelezen worden.
 _fsc_respons_ok() {
-  [ -n "${1:-}" ] && return 0
+  # Niet `[ -n ]`: jq draait óók niet op invoer die alleen witruimte is — het programma komt dan
+  # nooit aan bod, er komt niets uit en de status is 0. Vandaar toetsen op minstens één teken dat
+  # géén witruimte is.
+  case "${1:-}" in
+    *[![:space:]]*) return 0 ;;
+  esac
 
   echo 'lege respons van de manager (HTTP 200 zonder body?)' >>"$ERRLOG"
   return 1
@@ -192,38 +231,64 @@ fsc_contract_beoordeling() {
   _fsc_respons_ok "${1:-}" || return 1
   printf '%s' "$1" | jq -r \
     --arg prov "$2" --argjson diensten "$3" --argjson consumers "$4" \
-    --arg groep "${5:-}" --argjson maxgeldig "${6:-0}" "${_FSC_CONTRACTEN_JQ}"'
+    --arg groep "${5:-}" --argjson maxgeldig "${6:-0}" --argjson nu "${7:-0}" "${_FSC_CONTRACTEN_JQ}"'
     def veilig: (. // "ontbreekt") | tostring | gsub("[[:cntrl:]]"; "\u00b7");
     def weiger($ondertekend; $tekst): if $ondertekend then empty else "WEIGER \($tekst)" end;
 
     contracten[]
     | select((.has_revoked // false) == false)
     | . as $c
-    | (.content.grants // []) as $g
-    | (((.signatures.accept // {}) | has($prov))) as $ondertekend
-    | ((.content.validity.not_after // 0) - (.content.validity.not_before // 0)) as $duur
-    | if $groep != "" and .content.group_id != $groep then
-        weiger($ondertekend; "\($c.hash) hoort bij group \(.content.group_id | veilig), niet bij de onze")
-      elif .content.hash_algorithm != "HASH_ALGORITHM_SHA3_512" then
-        weiger($ondertekend; "\($c.hash) hash-algoritme \(.content.hash_algorithm | veilig) wijkt af")
-      elif (.content.validity | type) != "object" then
-        weiger($ondertekend; "\($c.hash) draagt geen geldigheidsduur")
-      elif $maxgeldig > 0 and $duur > $maxgeldig then
-        weiger($ondertekend; "\($c.hash) geldigheidsduur \($duur)s overschrijdt het maximum van \($maxgeldig)s")
-      elif ($g | length) != 1 then
-        weiger($ondertekend; "\($c.hash) draagt \($g | length) grants in plaats van precies 1")
-      elif $g[0].type != "GRANT_TYPE_SERVICE_CONNECTION" then
-        weiger($ondertekend; "\($c.hash) grant-type \($g[0].type | veilig) is geen serviceConnection")
-      elif $g[0].service.peer_id != $prov then
-        weiger($ondertekend; "\($c.hash) dienst hoort bij peer \($g[0].service.peer_id | veilig), niet bij ons")
-      elif ($diensten | index($g[0].service.name)) == null then
-        weiger($ondertekend; "\($c.hash) dienst \($g[0].service.name | veilig) bieden wij niet aan")
-      elif $g[0].outway.identification.type != "OUTWAY_IDENTIFICATION_TYPE_PUBLIC_KEY_THUMBPRINT" then
-        weiger($ondertekend; "\($c.hash) outway-identificatie \($g[0].outway.identification.type | veilig) is geen thumbprint")
-      elif ($consumers | index($g[0].outway.peer_id)) == null then
-        weiger($ondertekend; "\($c.hash) consumer \($g[0].outway.peer_id | veilig) staat niet op de lijst")
-      elif $ondertekend then "GETEKEND \($c.hash) \($g[0].outway.peer_id)"
-      else "TEKEN \($c.hash) \($g[0].outway.peer_id)" end' 2>>"$ERRLOG"
+    | ($c.hash | veilig) as $h
+
+    # Per contract afvangen. Zonder deze try sloopt één misvormde rij — `content` een string,
+    # `validity` een datumtekst, een grant die geen object is — het hele programma, en dan wordt in
+    # die ronde geen enkel legitiem contract meer getekend. Een rij die we niet kunnen lezen, tekenen
+    # we niet: dat is dezelfde veilige uitkomst als elke andere weigering.
+    | try (
+        (.content.grants // []) as $g
+        | (((.signatures.accept // {}) | has($prov))) as $ondertekend
+        | if $groep != "" and .content.group_id != $groep then
+            weiger($ondertekend; "\($h) hoort bij group \(.content.group_id | veilig), niet bij de onze")
+          elif .content.hash_algorithm != "HASH_ALGORITHM_SHA3_512" then
+            weiger($ondertekend; "\($h) hash-algoritme \(.content.hash_algorithm | veilig) wijkt af")
+          elif (.content.validity | type) != "object" then
+            weiger($ondertekend; "\($h) draagt geen geldigheidsduur")
+          elif (.content.validity.not_before | type) != "number"
+               or (.content.validity.not_after | type) != "number" then
+            # Alleen op "is een object" toetsen zou te weinig zijn: een `validity` zonder `not_after`
+            # levert een contract zonder einddatum op, en dat is juist wat de bovengrens moet vangen.
+            weiger($ondertekend; "\($h) geldigheidsduur is onvolledig (not_before/not_after ontbreekt of is geen getal)")
+          elif .content.validity.not_after <= .content.validity.not_before then
+            weiger($ondertekend; "\($h) einddatum ligt niet ná de begindatum")
+          elif $nu > 0 and .content.validity.not_after <= $nu then
+            # fsc-core eist dat not_after in de toekomst ligt. Een verlopen contract tekenen is
+            # bovendien zinloos werk dat elke ronde terugkomt.
+            weiger($ondertekend; "\($h) is al verlopen")
+          elif $nu > 0 and $maxgeldig > 0 and (.content.validity.not_after - $nu) > $maxgeldig then
+            # Gemeten vanaf NU en niet als vensterlengte: de vraag is hoe lang deze tegenpartij een
+            # claim op ons kan houden. Een venster van tien jaar dat over vijf jaar begint, is een
+            # claim tot over vijftien jaar terwijl de lengte binnen de grens valt.
+            weiger($ondertekend; "\($h) loopt nog \(.content.validity.not_after - $nu)s, meer dan het maximum van \($maxgeldig)s")
+          elif ($g | length) != 1 then
+            weiger($ondertekend; "\($h) draagt \($g | length) grants in plaats van precies 1")
+          elif $g[0].type != "GRANT_TYPE_SERVICE_CONNECTION" then
+            weiger($ondertekend; "\($h) grant-type \($g[0].type | veilig) is geen serviceConnection")
+          elif $g[0].service.peer_id != $prov then
+            weiger($ondertekend; "\($h) dienst hoort bij peer \($g[0].service.peer_id | veilig), niet bij ons")
+          elif ($diensten | index($g[0].service.name)) == null then
+            weiger($ondertekend; "\($h) dienst \($g[0].service.name | veilig) bieden wij niet aan")
+          elif $g[0].outway.identification.type != "OUTWAY_IDENTIFICATION_TYPE_PUBLIC_KEY_THUMBPRINT" then
+            weiger($ondertekend; "\($h) outway-identificatie \($g[0].outway.identification.type | veilig) is geen thumbprint")
+          elif ($consumers | index($g[0].outway.peer_id)) == null then
+            weiger($ondertekend; "\($h) consumer \($g[0].outway.peer_id | veilig) staat niet op de lijst")
+          elif ((.signatures.accept // {}) | has($g[0].outway.peer_id)) | not then
+            # fsc-core wil onder een serviceConnection de handtekening van beide kanten. Tekenen
+            # vóór de tegenpartij zich gecommitteerd heeft, is een verplichting aangaan die de ander
+            # nog niet is aangegaan.
+            weiger($ondertekend; "\($h) draagt de handtekening van de consumer nog niet")
+          elif $ondertekend then "GETEKEND \($c.hash) \($g[0].outway.peer_id)"
+          else "TEKEN \($c.hash) \($g[0].outway.peer_id)" end
+      ) catch "WEIGER \($h) is niet te beoordelen: \(. | tostring | gsub("[[:cntrl:]]"; "·"))"' 2>>"$ERRLOG"
 }
 
 # --- Wat de consumer al heeft uitstaan ----------------------------------------------------------
@@ -246,16 +311,27 @@ fsc_contract_voor_combinatie() {
   _fsc_respons_ok "${1:-}" || return 1
   printf '%s' "$1" | jq -r \
     --arg svc "$2" --arg prov "$3" --arg cons "$4" --arg thumb "$5" "${_FSC_CONTRACTEN_JQ}"'
+    def veilig: (. // "ontbreekt") | tostring | gsub("[[:cntrl:]]"; "\u00b7");
+
     contracten[]
     | select((.has_revoked // false) == false)
-    | select((.content.grants // []) | length == 1)
+    # Zelfde reden als in de beoordeling hiernaast: één misvormde rij mag de rest niet meenemen.
+    # Hier zonder melding — deze matcher zoekt ons eigen contract, en een rij van iemand anders die
+    # we niet kunnen lezen is simpelweg niet de onze. De provider-kant maakt er wél een WEIGER van,
+    # want daar is het een besluit.
+    | try (
+        select((.content.grants // []) | length == 1)
     | select(.content.grants[0]
         | .type == "GRANT_TYPE_SERVICE_CONNECTION"
           and .service.name == $svc
           and .service.peer_id == $prov
           and .outway.peer_id == $cons
           and .outway.identification.public_key_thumbprint == $thumb)
-    | "\(.hash) \((.state // "ontbreekt") | ascii_downcase) \(if ((.signatures.accept // {}) | has($prov)) then "ja" else "nee" end)"
+    # `veilig` ook op het hash: dit is net zo goed een regelgebaseerde stroom als de beoordeling
+    # hiernaast, dus een hash met een newline erin zou hier een tweede record schrijven dat de
+    # consumer-helft als eigen contract leest — en vervolgens intrekt, op een pad naar keuze.
+        | "\(.hash | veilig) \((.state // "ontbreekt") | tostring | ascii_downcase) \(if ((.signatures.accept // {}) | has($prov)) then "ja" else "nee" end)"
+      ) catch empty
     ' 2>>"$ERRLOG"
 }
 

--- a/demo/environment/lib/fsc-contract.sh
+++ b/demo/environment/lib/fsc-contract.sh
@@ -53,6 +53,19 @@ fsc_getal_vereist() {
   printf '%s' "$2"
 }
 
+# fsc_getal_hoogstens <naam> <waarde> <max>: als fsc_getal_vereist, met een bovengrens.
+fsc_getal_hoogstens() {
+  local waarde
+  waarde="$(fsc_getal_vereist "$1" "$2")"
+
+  [ "$waarde" -le "$3" ] || {
+    echo "FAIL: ${1} mag hoogstens ${3} zijn, niet '${waarde}'." >&2
+    exit 2
+  }
+
+  printf '%s' "$waarde"
+}
+
 # fsc_hex64 <waarde>: is dit precies 64 lowercase hex-tekens?
 #
 # `[0-9a-f]*` in een case-patroon toetst alléén het eerste teken — de overige 63 komen er dan
@@ -229,7 +242,9 @@ _fsc_respons_ok() {
 # operator juist de verkeerde kant op. De reden noemt de eerste eis die faalt.
 #
 # Elke waarde uit het contract komt van de tegenpartij en gaat hier een regelgebaseerde stroom in.
-# De `veilig`-filter in het programma hieronder vervangt daarom stuurtekens: zonder dat schrijft
+# De `veilig`-filter vervangt daarom álle witruimte en niet alleen newlines: elke lezer van deze
+# regels telt kolommen, dus een spatie in een hash verschuift de rest en laat een controle op de
+# verkeerde kolom kijken. Zonder dat schrijft
 # `jq -r` een newline in een dienstnaam letterlijk weg, en leest de aanroeper de tweede helft als
 # een eigen record. Een peer die zijn dienst "x<newline>TEKEN <hash> <oin>" noemt, laat zich zo een
 # contract naar keuze tekenen — de allowlist wordt dan volledig omzeild.

--- a/demo/environment/lib/fsc-contract.sh
+++ b/demo/environment/lib/fsc-contract.sh
@@ -307,7 +307,7 @@ fsc_contract_beoordeling() {
             weiger($ondertekend; "\($h) dienst hoort bij peer \($g[0].service.peer_id | veilig), niet bij ons")
           elif ($diensten | index($g[0].service.name)) == null then
             weiger($ondertekend; "\($h) dienst \($g[0].service.name | veilig) bieden wij niet aan")
-          elif ($g[0].service.type // "SERVICE_TYPE_SERVICE") != "SERVICE_TYPE_SERVICE" then
+          elif $g[0].service.type != "SERVICE_TYPE_SERVICE" then
             # Dezelfde klasse discriminator als het identificatietype hieronder: een
             # DELEGATED_SERVICE zet een delegator-claim in het token en verandert welke
             # handtekeningen vereist zijn. Wij bieden geen gedelegeerde diensten aan.
@@ -335,7 +335,8 @@ fsc_contract_beoordeling() {
 # --- Wat de consumer al heeft uitstaan ----------------------------------------------------------
 
 # fsc_contract_voor_combinatie <json> <service> <provider_oin> <consumer_oin> <thumbprint>:
-# `<hash> <state> <provider-getekend ja|nee>` per regel, voor elk niet-ingetrokken contract dat
+# `<hash> <state> <provider-getekend ja|nee> <afgewezen|->` per regel, voor elk niet-ingetrokken
+# contract dat
 # precies deze serviceConnection draagt. De state komt lowercase terug (`contract_state_valid`), en
 # `ontbreekt` als de manager het veld niet meestuurt — dat laatste is geen synoniem voor ongeldig,
 # maar een toestand die de aanroeper hoort te melden in plaats van als "nog niet klaar" te lezen.
@@ -356,7 +357,11 @@ fsc_contract_voor_combinatie() {
 
     contracten[]
     | select(type == "object")
-    | select((.has_revoked // false) == false and (.has_rejected // false) == false)
+    # Hier bewust WÉL de afgewezen contracten erbij, anders dan in de beoordeling hiernaast. Daar is
+    # "afgewezen" een besluit van onszelf dat we niet moeten overdoen; hier is het het antwoord van
+    # de overkant op ónze aanvraag. Wegfilteren zou de consumer zijn eigen afgewezen contract niet
+    # meer laten zien, waarna hij elke ronde een nieuwe indient en de afwijzing nergens blijkt.
+    | select((.has_revoked // false) == false)
     # Zelfde reden als in de beoordeling hiernaast: één misvormde rij mag de rest niet meenemen.
     # Hier zonder melding — deze matcher zoekt ons eigen contract, en een rij van iemand anders die
     # we niet kunnen lezen is simpelweg niet de onze. De provider-kant maakt er wél een WEIGER van,
@@ -372,7 +377,7 @@ fsc_contract_voor_combinatie() {
     # `veilig` ook op het hash: dit is net zo goed een regelgebaseerde stroom als de beoordeling
     # hiernaast, dus een hash met een newline erin zou hier een tweede record schrijven dat de
     # consumer-helft als eigen contract leest — en vervolgens intrekt, op een pad naar keuze.
-        | "\(.hash | veilig) \((.state // "ontbreekt") | tostring | ascii_downcase) \(if ((.signatures.accept // {}) | has($prov)) then "ja" else "nee" end)"
+        | "\(.hash | veilig) \((.state // "ontbreekt") | tostring | ascii_downcase) \(if ((.signatures.accept // {}) | has($prov)) then "ja" else "nee" end) \(if (.has_rejected // false) then "afgewezen" else "-" end)"
       ) catch empty
     ' 2>>"$ERRLOG"
 }

--- a/demo/environment/lib/fsc-contract.sh
+++ b/demo/environment/lib/fsc-contract.sh
@@ -30,6 +30,18 @@ fsc_env_vereist() {
   printf '%s' "$waarde"
 }
 
+# fsc_hex64 <waarde>: is dit precies 64 lowercase hex-tekens?
+#
+# `[0-9a-f]*` in een case-patroon toetst alléén het eerste teken — de overige 63 komen er dan
+# ongezien doorheen, inclusief een uppercase SHA-256 (de vorm die veel tooling teruggeeft). Vandaar
+# het negatieve patroon: één teken buiten de verzameling en de waarde valt af.
+fsc_hex64() {
+  case "${1:-}" in
+    ""|*[!0-9a-f]*) return 1 ;;
+    *) [ "${#1}" -eq 64 ] ;;
+  esac
+}
+
 # fsc_contract_manager_ok <url...>: elk adres moet met https:// beginnen.
 #
 # De adressen worden geconcateneerd tot curl's URL-argument; een waarde die met `-` begint zou curl
@@ -60,8 +72,33 @@ fsc_contract_api() {
     args=(--resolve "${hostnaam}:${poort}:${adres}")
   fi
 
-  curl -sS --fail-with-body --noproxy '*' "${args[@]}" \
+  # `${args[@]+…}`: bash < 4.4 (de macOS-default 3.2) ziet "${args[@]}" op een lege array onder
+  # `set -u` als unbound. Leeg is hier de normale toestand — op ZAD resolveert DNS gewoon.
+  curl -sS --fail-with-body --noproxy '*' ${args[@]+"${args[@]}"} \
     --cert "$cert" --key "$key" --cacert "$ca" "$@" 2>"$ERRLOG"
+}
+
+# fsc_lijst_naar_json <naam> <waarde>: een spaties-gescheiden lijst uit env als JSON-array.
+#
+# `read -r -a` leest maar één REGEL: `$'a\nb'` levert één element op. Een allowlist komt op ZAD uit
+# component-env (YAML), waar een waarde over meerdere regels schrijven voor de hand ligt — en dan
+# zou alles na de eerste regel geruisloos buiten de autorisatiegrens vallen. Vandaar splitsen op
+# elke witruimte, en een lege uitkomst als fout behandelen in plaats van als "niemand mag iets".
+fsc_lijst_naar_json() {
+  local naam="$1" woorden=()
+
+  # `|| [ -n "$woord" ]`: de invoer eindigt niet op een newline, en een kale `read` laat het laatste
+  # stuk dan vallen — dat zou stilletjes de laatste dienst of consumer uit de allowlist halen.
+  while IFS= read -r woord || [ -n "$woord" ]; do
+    [ -n "$woord" ] && woorden+=("$woord")
+  done < <(printf '%s' "${2:-}" | tr -s '[:space:]' '\n')
+
+  [ "${#woorden[@]}" -gt 0 ] || {
+    echo "FAIL: ${naam} bevat geen enkele waarde." >&2
+    return 1
+  }
+
+  fsc_json_lijst "${woorden[@]}"
 }
 
 # fsc_json_lijst <woord...>: de woorden als JSON-array op stdout, voor jq's --argjson.
@@ -76,6 +113,34 @@ fsc_json_lijst() {
   printf ']'
 }
 
+# --- De contractenlijst binnenhalen -------------------------------------------------------------
+
+# _FSC_CONTRACTEN_JQ: jq-prelude die `.contracts` als array oplevert of afbreekt.
+#
+# `.contracts[]?` leek de veilige vorm, maar doet precies het verkeerde: de `?` onderdrukt juist de
+# fout die hier het signaal is. Een 200 met een ander lijstveld, met `null`, of met een lege body
+# levert dan 0 regels op — niet te onderscheiden van "er zijn geen contracten". Aan consumer-kant
+# betekent dat elke ronde een nieuw contract indienen, en op ZAD draait die ronde elke 15 seconden.
+_FSC_CONTRACTEN_JQ='
+  def contracten:
+    if type != "object" then error("respons is geen JSON-object")
+    elif has("contracts") | not then error("respons heeft geen veld \"contracts\"")
+    elif (.contracts | type) != "array" then error("veld \"contracts\" is \(.contracts | type), geen array")
+    else .contracts end;
+'
+
+# _fsc_respons_ok <body>: een lege body is geen lege lijst.
+#
+# Aparte controle, want jq draait bij lege invoer helemaal niet: het programma komt nooit aan bod,
+# er komt niets uit en de exit-status is 0. De prelude hierboven zou dat dus nooit zien, en een
+# HTTP 200 met lege body zou als "geen contracten" gelezen worden.
+_fsc_respons_ok() {
+  [ -n "${1:-}" ] && return 0
+
+  echo 'lege respons van de manager (HTTP 200 zonder body?)' >>"$ERRLOG"
+  return 1
+}
+
 # --- Wat de provider mag tekenen ----------------------------------------------------------------
 # Vóór de splitsing was de accept een gerichte handeling: het script kende het hash dat het zelf
 # net had laten indienen. De provider-helft kent dat hash niet — hij vindt een contract in zijn
@@ -87,13 +152,22 @@ fsc_json_lijst() {
 # als geheel kloppen, dus de eis is "precies één grant, en die klopt" — niet "er is er één die
 # klopt".
 #
-# De thumbprint in de grant wordt bewust NIET getoetst. De provider heeft het outway-cert van de
-# consumer niet en kan hem dus niet onafhankelijk verifiëren. Hij hoeft dat ook niet: de thumbprint
-# zegt wélke outway van díé consumer de dienst mag afnemen, en dat is aan de consumer. Wat de
-# provider bewaakt is dat het om zijn eigen dienst gaat en om een consumer die hij kent.
+# Buiten de grant tellen ook de eigenschappen van het contract zelf mee. De allowlist bepaalt WIE er
+# mag afnemen; zonder deze vier bepaalt de tegenpartij in zijn eentje HOE LANG en onder welke
+# voorwaarden: `group_id` (anders tekenen we iets dat de inway later afwijst op
+# WRONG_GROUP_ID_IN_TOKEN — geldig en toch stuk), `hash_algorithm` (dat bindt de content aan de
+# handtekening), de aanwezigheid van een geldigheidsduur, en een bovengrens daarop.
+#
+# De WAARDE van de thumbprint wordt bewust niet getoetst, het TYPE wel. Het type moet
+# PUBLIC_KEY_THUMBPRINT zijn: fsc-core kent daarnaast DOMAIN_NAME, een zwakkere binding die een
+# provider niet hoort te accepteren. De waarde zelf kan de provider niet onafhankelijk verifiëren en
+# hoeft hij ook niet — die wordt aan zijn eigen kant cryptografisch afgedwongen op een later moment:
+# de outway haalt zijn token bij ONZE manager, die de presentatie tegen de thumbprint in de grant
+# houdt, en onze inway verifieert `cnf.x5t#S256` tegen het verbindingscertificaat.
 
-# fsc_contract_beoordeling <json> <provider_oin> <diensten-json> <consumers-json>: één regel per
-# niet-ingetrokken contract dat de provider aangaat:
+# fsc_contract_beoordeling <json> <provider_oin> <diensten-json> <consumers-json> <group_id>
+# <max-geldigheid-seconden>: één regel per niet-ingetrokken contract dat nog een besluit vraagt.
+# Ook contracten die ons NIET aangaan komen langs — juist die leveren een WEIGER-regel op.
 #
 #   TEKEN    <hash> <consumer_oin>   mag getekend worden, is dat nog niet
 #   GETEKEND <hash> <consumer_oin>   voldoet en draagt onze handtekening al
@@ -103,40 +177,62 @@ fsc_json_lijst() {
 # uiteen kunnen lopen, en een diagnose die andere contracten bekijkt dan de matcher tekent wijst de
 # operator juist de verkeerde kant op. De reden noemt de eerste eis die faalt.
 #
+# Elke waarde uit het contract komt van de tegenpartij en gaat hier een regelgebaseerde stroom in.
+# De `veilig`-filter in het programma hieronder vervangt daarom stuurtekens: zonder dat schrijft
+# `jq -r` een newline in een dienstnaam letterlijk weg, en leest de aanroeper de tweede helft als
+# een eigen record. Een peer die zijn dienst "x<newline>TEKEN <hash> <oin>" noemt, laat zich zo een
+# contract naar keuze tekenen — de allowlist wordt dan volledig omzeild.
+#
 # Een contract dat de toets niet haalt én al getekend is levert niets op: dat is andermans zaak.
-# Het servicePublication-contract voor onze eigen dienst staat op dezelfde manager en wordt door
-# `AUTO_SIGN_GRANTS` vanzelf getekend; zou dat een WEIGER-regel opleveren, dan stond de log elke
-# ronde vol met contracten waar niets mee mis is.
+# Het servicePublication-contract voor onze eigen dienst staat op dezelfde manager en draagt onze
+# eigen handtekening al — die zet de manager er server-side op bij het publiceren. Zou dat een
+# WEIGER-regel opleveren, dan stond de log elke ronde vol met contracten waar niets mee mis is.
 fsc_contract_beoordeling() {
   [ "$HAVE_JQ" -eq 1 ] || return 0
+  _fsc_respons_ok "${1:-}" || return 1
   printf '%s' "$1" | jq -r \
-    --arg prov "$2" --argjson diensten "$3" --argjson consumers "$4" '
+    --arg prov "$2" --argjson diensten "$3" --argjson consumers "$4" \
+    --arg groep "${5:-}" --argjson maxgeldig "${6:-0}" "${_FSC_CONTRACTEN_JQ}"'
+    def veilig: (. // "ontbreekt") | tostring | gsub("[[:cntrl:]]"; "\u00b7");
     def weiger($ondertekend; $tekst): if $ondertekend then empty else "WEIGER \($tekst)" end;
 
-    .contracts[]?
+    contracten[]
     | select((.has_revoked // false) == false)
     | . as $c
     | (.content.grants // []) as $g
     | (((.signatures.accept // {}) | has($prov))) as $ondertekend
-    | if ($g | length) != 1 then
+    | ((.content.validity.not_after // 0) - (.content.validity.not_before // 0)) as $duur
+    | if $groep != "" and .content.group_id != $groep then
+        weiger($ondertekend; "\($c.hash) hoort bij group \(.content.group_id | veilig), niet bij de onze")
+      elif .content.hash_algorithm != "HASH_ALGORITHM_SHA3_512" then
+        weiger($ondertekend; "\($c.hash) hash-algoritme \(.content.hash_algorithm | veilig) wijkt af")
+      elif (.content.validity | type) != "object" then
+        weiger($ondertekend; "\($c.hash) draagt geen geldigheidsduur")
+      elif $maxgeldig > 0 and $duur > $maxgeldig then
+        weiger($ondertekend; "\($c.hash) geldigheidsduur \($duur)s overschrijdt het maximum van \($maxgeldig)s")
+      elif ($g | length) != 1 then
         weiger($ondertekend; "\($c.hash) draagt \($g | length) grants in plaats van precies 1")
       elif $g[0].type != "GRANT_TYPE_SERVICE_CONNECTION" then
-        weiger($ondertekend; "\($c.hash) grant-type \($g[0].type // "ontbreekt") is geen serviceConnection")
+        weiger($ondertekend; "\($c.hash) grant-type \($g[0].type | veilig) is geen serviceConnection")
       elif $g[0].service.peer_id != $prov then
-        weiger($ondertekend; "\($c.hash) dienst hoort bij peer \($g[0].service.peer_id // "ontbreekt"), niet bij ons")
+        weiger($ondertekend; "\($c.hash) dienst hoort bij peer \($g[0].service.peer_id | veilig), niet bij ons")
       elif ($diensten | index($g[0].service.name)) == null then
-        weiger($ondertekend; "\($c.hash) dienst \($g[0].service.name // "ontbreekt") bieden wij niet aan")
+        weiger($ondertekend; "\($c.hash) dienst \($g[0].service.name | veilig) bieden wij niet aan")
+      elif $g[0].outway.identification.type != "OUTWAY_IDENTIFICATION_TYPE_PUBLIC_KEY_THUMBPRINT" then
+        weiger($ondertekend; "\($c.hash) outway-identificatie \($g[0].outway.identification.type | veilig) is geen thumbprint")
       elif ($consumers | index($g[0].outway.peer_id)) == null then
-        weiger($ondertekend; "\($c.hash) consumer \($g[0].outway.peer_id // "ontbreekt") staat niet op de lijst")
+        weiger($ondertekend; "\($c.hash) consumer \($g[0].outway.peer_id | veilig) staat niet op de lijst")
       elif $ondertekend then "GETEKEND \($c.hash) \($g[0].outway.peer_id)"
-      else "TEKEN \($c.hash) \($g[0].outway.peer_id)" end' 2>/dev/null
+      else "TEKEN \($c.hash) \($g[0].outway.peer_id)" end' 2>>"$ERRLOG"
 }
 
 # --- Wat de consumer al heeft uitstaan ----------------------------------------------------------
 
 # fsc_contract_voor_combinatie <json> <service> <provider_oin> <consumer_oin> <thumbprint>:
 # `<hash> <state> <provider-getekend ja|nee>` per regel, voor elk niet-ingetrokken contract dat
-# precies deze serviceConnection draagt.
+# precies deze serviceConnection draagt. De state komt lowercase terug (`contract_state_valid`), en
+# `ontbreekt` als de manager het veld niet meestuurt — dat laatste is geen synoniem voor ongeldig,
+# maar een toestand die de aanroeper hoort te melden in plaats van als "nog niet klaar" te lezen.
 #
 # De consumer-helft heeft dit nodig om te weten of hij nog moet indienen. Alleen kijken naar
 # volledig geldige contracten (fsc_grant_actief) zou niet volstaan: in de gesplitste opzet zit er
@@ -147,9 +243,10 @@ fsc_contract_beoordeling() {
 # dat de provider nooit gaat tekenen.
 fsc_contract_voor_combinatie() {
   [ "$HAVE_JQ" -eq 1 ] || return 0
+  _fsc_respons_ok "${1:-}" || return 1
   printf '%s' "$1" | jq -r \
-    --arg svc "$2" --arg prov "$3" --arg cons "$4" --arg thumb "$5" '
-    .contracts[]?
+    --arg svc "$2" --arg prov "$3" --arg cons "$4" --arg thumb "$5" "${_FSC_CONTRACTEN_JQ}"'
+    contracten[]
     | select((.has_revoked // false) == false)
     | select((.content.grants // []) | length == 1)
     | select(.content.grants[0]
@@ -158,8 +255,8 @@ fsc_contract_voor_combinatie() {
           and .service.peer_id == $prov
           and .outway.peer_id == $cons
           and .outway.identification.public_key_thumbprint == $thumb)
-    | "\(.hash) \((.state // "onbekend") | ascii_downcase) \(if ((.signatures.accept // {}) | has($prov)) then "ja" else "nee" end)"
-    ' 2>/dev/null
+    | "\(.hash) \((.state // "ontbreekt") | ascii_downcase) \(if ((.signatures.accept // {}) | has($prov)) then "ja" else "nee" end)"
+    ' 2>>"$ERRLOG"
 }
 
 # fsc_contract_regels <beoordeling> <soort>: de regels van één soort, zonder het soort-woord.

--- a/demo/environment/lib/fsc-contract.sh
+++ b/demo/environment/lib/fsc-contract.sh
@@ -37,10 +37,15 @@ fsc_env_vereist() {
 # loop die de manager zo snel mogelijk bevraagt terwijl hij elke ronde OK meldt. En een niet-numerieke
 # drempel laat `[ ]` falen, waarna de vangrail die de lus zou stoppen niets meer doet. Beide falen
 # dus open; vandaar één controle bij het opstarten.
+# Het patroon eist een positief getal zónder voorloopnul, niet "alleen cijfers". `0` zou de guard
+# passeren en precies de hot loop opleveren waarvoor hij bestaat, en `08` wordt door bash als
+# octaal gelezen: `$((… * 08))` breekt af met "value too great for base", midden in de lus.
 fsc_getal_vereist() {
+  # Twee patronen en niet één: een case-patroon is een glob, geen reguliere expressie, dus
+  # `[1-9][0-9]*` zou ook `15s` accepteren — de `*` matcht daar willekeurige tekens.
   case "${2:-}" in
-    ""|*[!0-9]*)
-      echo "FAIL: ${1} moet een geheel getal zijn, niet '${2:-}'." >&2
+    ""|*[!0-9]*|0|0*)
+      echo "FAIL: ${1} moet een positief geheel getal zijn zonder voorloopnul, niet '${2:-}'." >&2
       exit 2
       ;;
   esac
@@ -66,7 +71,9 @@ fsc_hex64() {
 # het pad verleggen — curl normaliseert `..`-segmenten — dus die valt af.
 fsc_hash_ok() {
   case "${1:-}" in
-    ""|*[!A-Za-z0-9._~$+-]*) return 1 ;;
+    # Puur punten apart: `.` en `..` bestaan volledig uit toegestane tekens, en curl normaliseert ze
+    # weg — `/v1/contracts/../revoke` komt aan als `/v1/revoke`.
+    ""|.|..|*[!A-Za-z0-9._~$+-]*) return 1 ;;
   esac
 }
 
@@ -154,11 +161,16 @@ _FSC_CONTRACTEN_JQ='
     if type != "object" then error("respons is geen JSON-object")
     elif has("contracts") | not then error("respons heeft geen veld \"contracts\"")
     elif (.contracts | type) != "array" then error("veld \"contracts\" is \(.contracts | type), geen array")
-    elif ((.next_cursor // "") | tostring) != "" then
+    elif ((.pagination.next_cursor? // .next_cursor? // "") | tostring) != "" then
       # De lijst is cursor-gepagineerd. Alleen pagina 1 lezen zou betekenen dat de consumer zijn
-      # eigen contract niet meer ziet zodra de manager er genoeg heeft — en dan dient hij elke
-      # ronde een nieuw contract in. Afbreken tot iemand de cursor volgt; stil doorgaan is hier de
+      # eigen contract niet meer ziet zodra de manager er genoeg heeft — en dan dient hij elke ronde
+      # een nieuw contract in. Afbreken tot iemand de cursor volgt; stil doorgaan is hier de
       # gevaarlijke keuze.
+      #
+      # Twee plekken, want het veld staat genest onder `pagination` en niet op topniveau; alleen de
+      # topniveau-vorm toetsen zou een guard opleveren die nooit vuurt, en dat is slechter dan geen
+      # guard. De aanroepers vragen daarnaast expliciet een ruime `limit` op, zodat dit een vangrail
+      # blijft in plaats van een dagelijkse blokkade.
       error("de contractenlijst is gepagineerd (next_cursor gezet) en dat volgen we nog niet")
     else .contracts end;
 '
@@ -233,10 +245,28 @@ fsc_contract_beoordeling() {
     --arg prov "$2" --argjson diensten "$3" --argjson consumers "$4" \
     --arg groep "${5:-}" --argjson maxgeldig "${6:-0}" --argjson nu "${7:-0}" "${_FSC_CONTRACTEN_JQ}"'
     def veilig: (. // "ontbreekt") | tostring | gsub("[[:cntrl:]]"; "\u00b7");
-    def weiger($ondertekend; $tekst): if $ondertekend then empty else "WEIGER \($tekst)" end;
+    # Een contract dat de toets niet haalt en al onze handtekening draagt, is meestal andermans zaak
+    # (het publicatiecontract voor onze eigen dienst staat op dezelfde manager). Máár als het een
+    # serviceConnection voor onze eigen dienst is, was het ooit van ons en is het nu afgekeurd — door
+    # een gecorrigeerde allowlist, een verlopen looptijd of een verlaagde bovengrens. Dat stil laten
+    # zou de provider "nog niets binnen" laten melden terwijl het contract er wel degelijk ligt.
+    def weiger($ondertekend; $tekst):
+      if $ondertekend then
+        if (((.content.grants // [])[0].type? // "") == "GRANT_TYPE_SERVICE_CONNECTION"
+            and ((.content.grants // [])[0].service?.peer_id? // "") == $prov)
+        then "AANDACHT \($tekst)" else empty end
+      else "WEIGER \($tekst)" end;
 
     contracten[]
-    | select((.has_revoked // false) == false)
+    # Eerst het type: een rij die geen object is, laat élke veldtoets hieronder afbreken en daarmee
+    # het hele programma — dan wordt in die ronde geen enkel legitiem contract meer getekend. De
+    # `try` verderop begint pas ná deze regels en zou dat niet vangen.
+    | if type != "object" then "WEIGER <geen object> een rij in de contractenlijst is \(type), geen object"
+      else
+        # Ook `has_rejected`: een contract dat wij eerder hebben afgewezen draagt onze
+        # accept-handtekening niet, dus zonder deze regel komt het elke ronde terug als kandidaat en
+        # tekenen we alsnog wat we bewust hebben geweigerd.
+        select((.has_revoked // false) == false and (.has_rejected // false) == false)
     | . as $c
     | ($c.hash | veilig) as $h
 
@@ -277,6 +307,16 @@ fsc_contract_beoordeling() {
             weiger($ondertekend; "\($h) dienst hoort bij peer \($g[0].service.peer_id | veilig), niet bij ons")
           elif ($diensten | index($g[0].service.name)) == null then
             weiger($ondertekend; "\($h) dienst \($g[0].service.name | veilig) bieden wij niet aan")
+          elif ($g[0].service.type // "SERVICE_TYPE_SERVICE") != "SERVICE_TYPE_SERVICE" then
+            # Dezelfde klasse discriminator als het identificatietype hieronder: een
+            # DELEGATED_SERVICE zet een delegator-claim in het token en verandert welke
+            # handtekeningen vereist zijn. Wij bieden geen gedelegeerde diensten aan.
+            weiger($ondertekend; "\($h) dienst-type \($g[0].service.type | veilig) is geen gewone dienst")
+          elif (($g[0].properties // {}) | length) != 0 then
+            # `properties` schrijft claims die onze eigen manager in het access token zet en die onze
+            # inway en de dienst erachter te zien krijgen — ongesanitiseerd, door de tegenpartij
+            # opgesteld. Dat is dezelfde soort blinde ondertekening als een tweede grant.
+            weiger($ondertekend; "\($h) draagt grant-properties die wij niet ondertekenen")
           elif $g[0].outway.identification.type != "OUTWAY_IDENTIFICATION_TYPE_PUBLIC_KEY_THUMBPRINT" then
             weiger($ondertekend; "\($h) outway-identificatie \($g[0].outway.identification.type | veilig) is geen thumbprint")
           elif ($consumers | index($g[0].outway.peer_id)) == null then
@@ -288,7 +328,8 @@ fsc_contract_beoordeling() {
             weiger($ondertekend; "\($h) draagt de handtekening van de consumer nog niet")
           elif $ondertekend then "GETEKEND \($c.hash) \($g[0].outway.peer_id)"
           else "TEKEN \($c.hash) \($g[0].outway.peer_id)" end
-      ) catch "WEIGER \($h) is niet te beoordelen: \(. | tostring | gsub("[[:cntrl:]]"; "·"))"' 2>>"$ERRLOG"
+      ) catch "WEIGER \($h) is niet te beoordelen: \(. | tostring | gsub("[[:cntrl:]]"; "·"))"
+      end' 2>>"$ERRLOG"
 }
 
 # --- Wat de consumer al heeft uitstaan ----------------------------------------------------------
@@ -314,7 +355,8 @@ fsc_contract_voor_combinatie() {
     def veilig: (. // "ontbreekt") | tostring | gsub("[[:cntrl:]]"; "\u00b7");
 
     contracten[]
-    | select((.has_revoked // false) == false)
+    | select(type == "object")
+    | select((.has_revoked // false) == false and (.has_rejected // false) == false)
     # Zelfde reden als in de beoordeling hiernaast: één misvormde rij mag de rest niet meenemen.
     # Hier zonder melding — deze matcher zoekt ons eigen contract, en een rij van iemand anders die
     # we niet kunnen lezen is simpelweg niet de onze. De provider-kant maakt er wél een WEIGER van,

--- a/demo/environment/lib/test-bootstrap-uitgangen.sh
+++ b/demo/environment/lib/test-bootstrap-uitgangen.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Fixture-tests voor de uitgangen van de twee bootstrap-helften.
+#
+# Deze bestaan omdat de exit-codes de coördinatie ZIJN: `zad-lus.sh` vertakt erop, en `bootstrap.sh`
+# ook. Twee opeenvolgende reviewrondes introduceerden allebei een regressie in precies deze ladder —
+# een kapotte toestand die als 0 naar buiten kwam — en geen enkele test merkte dat, omdat alle
+# andere tests op bibliotheekniveau zitten en de smokes alleen het gelukkige pad tegen een draaiende
+# federatie lopen.
+#
+# De helften worden hier zonder netwerk gedraaid: een `curl` vooraan op PATH levert een vaste
+# contractenlijst, zodat elke combinatie van getekend/geweigerd/aandacht afdwingbaar is.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CONTRACTS="$(cd "${HERE}/../federatie/contracts" && pwd)"
+
+fails=0
+
+assert_uitgang() {
+  local desc="$1" verwacht="$2" kregen="$3"
+  if [ "$kregen" = "$verwacht" ]; then
+    echo "OK: $desc (exit $kregen)"
+  else
+    echo "FAIL: $desc — verwacht exit $verwacht, kreeg $kregen" >&2
+    fails=$((fails + 1))
+  fi
+}
+
+PROV=00000000000000100000
+CONS=00000000000000001000
+THUMB="$(printf 'a%.0s' $(seq 1 64))"
+NU="$(date -u +%s)"
+
+# contract <hash> <dienst> <getekend-door-provider> <not_after-offset>
+contract() {
+  jq -nc --arg h "$1" --arg svc "$2" --argjson sig "$3" --argjson na "$4" \
+         --arg prov "$PROV" --arg cons "$CONS" --arg thumb "$THUMB" --argjson nu "$NU" '
+    { hash: $h, state: "CONTRACT_STATE_PROPOSED", has_revoked: false, has_rejected: false,
+      signatures: { accept: ({($cons): true} + (if $sig then {($prov): true} else {} end)) },
+      content: { group_id: "moza-fbs-test", hash_algorithm: "HASH_ALGORITHM_SHA3_512",
+                 validity: { not_before: ($nu - 60), not_after: ($nu + $na) },
+                 grants: [ { type: "GRANT_TYPE_SERVICE_CONNECTION",
+                   service: { type: "SERVICE_TYPE_SERVICE", name: $svc, peer_id: $prov },
+                   outway: { peer_id: $cons,
+                     identification: { type: "OUTWAY_IDENTIFICATION_TYPE_PUBLIC_KEY_THUMBPRINT",
+                                       public_key_thumbprint: $thumb } } } ] } }'
+}
+
+# draai_provider <contract-json...>: de provider-helft tegen een gestubde manager; echoot de exit-code.
+draai_provider() {
+  local tmp lijst rc=0
+  tmp="$(mktemp -d)"
+  lijst="$(printf '%s\n' "$@" | jq -sc '{ contracts: . }')"
+
+  # De stub antwoordt op de lijst-call en zegt op alles wat muteert simpelweg ja. Meer is hier niet
+  # nodig: getoetst wordt de uitgang, niet de manager.
+  printf '%s' "$lijst" > "${tmp}/lijst.json"
+  cat > "${tmp}/curl" <<'STUB'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  case "$arg" in
+    *"/v1/contracts?"*) cat "$(dirname "$0")/lijst.json"; exit 0 ;;
+  esac
+done
+exit 0
+STUB
+  chmod +x "${tmp}/curl"
+
+  PATH="${tmp}:$PATH" \
+  FSC_LIBDIR="$HERE" \
+  FSC_PROVIDER_OIN="$PROV" FSC_DIENSTEN=berichtenmagazijn FSC_CONSUMERS="$CONS" \
+  FSC_PROVIDER_MANAGER=https://manager:9443 \
+  FSC_PROVIDER_CERT=/dev/null FSC_PROVIDER_KEY=/dev/null FSC_PROVIDER_CA=/dev/null \
+    "${CONTRACTS}/bootstrap-provider.sh" >/dev/null 2>&1 || rc=$?
+
+  rm -rf "$tmp"
+  printf '%s' "$rc"
+}
+
+command -v jq >/dev/null 2>&1 || { echo "FAIL: jq is vereist." >&2; exit 1; }
+
+echo "== provider-helft: de uitgangen per combinatie =="
+
+TEKENBAAR="$(contract h1 berichtenmagazijn false 315360000)"
+GEWEIGERD="$(contract h2 andere-dienst false 315360000)"
+AANDACHT="$(contract h3 berichtenmagazijn true -1)"
+
+assert_uitgang "lege lijst: wachten op de overkant" 3 "$(draai_provider)"
+assert_uitgang "alleen iets tekenbaars" 0 "$(draai_provider "$TEKENBAAR")"
+assert_uitgang "alleen iets geweigerds" 4 "$(draai_provider "$GEWEIGERD")"
+
+# De regressie uit reviewronde 3: dit gaf exit 0, waarna de lus de wachtteller op nul zette en het
+# component eeuwig groen bleef terwijl het datapad stuk was.
+assert_uitgang "alleen een eerder getekend contract dat nu afvalt" 4 "$(draai_provider "$AANDACHT")"
+
+assert_uitgang "geweigerd én aandacht, niets getekend" 4 "$(draai_provider "$GEWEIGERD" "$AANDACHT")"
+assert_uitgang "getekend naast geweigerd" 0 "$(draai_provider "$TEKENBAAR" "$GEWEIGERD")"
+assert_uitgang "getekend naast aandacht" 0 "$(draai_provider "$TEKENBAAR" "$AANDACHT")"
+
+echo
+echo "== provider-helft: configuratie eindigt op 2, niet op 1 =="
+
+assert_config() {
+  local desc="$1" rc=0; shift
+  env -i PATH="$PATH" FSC_LIBDIR="$HERE" "$@" "${CONTRACTS}/bootstrap-provider.sh" >/dev/null 2>&1 || rc=$?
+  assert_uitgang "$desc" 2 "$rc"
+}
+
+assert_config "ontbrekende OIN" FSC_DIENSTEN=d FSC_CONSUMERS=1 FSC_PROVIDER_MANAGER=https://m:9443 \
+  FSC_PROVIDER_CERT=/dev/null FSC_PROVIDER_KEY=/dev/null FSC_PROVIDER_CA=/dev/null
+assert_config "lege dienstenlijst" FSC_PROVIDER_OIN=1 FSC_DIENSTEN=" " FSC_CONSUMERS=1 \
+  FSC_PROVIDER_MANAGER=https://m:9443 \
+  FSC_PROVIDER_CERT=/dev/null FSC_PROVIDER_KEY=/dev/null FSC_PROVIDER_CA=/dev/null
+assert_config "manager-adres als curl-optie" FSC_PROVIDER_OIN=1 FSC_DIENSTEN=d FSC_CONSUMERS=1 \
+  FSC_PROVIDER_MANAGER=-K/etc/passwd \
+  FSC_PROVIDER_CERT=/dev/null FSC_PROVIDER_KEY=/dev/null FSC_PROVIDER_CA=/dev/null
+assert_config "limiet boven het maximum" FSC_PROVIDER_OIN=1 FSC_DIENSTEN=d FSC_CONSUMERS=1 \
+  FSC_CONTRACT_LIMIET=5000 FSC_PROVIDER_MANAGER=https://m:9443 \
+  FSC_PROVIDER_CERT=/dev/null FSC_PROVIDER_KEY=/dev/null FSC_PROVIDER_CA=/dev/null
+
+echo
+if [ "$fails" -ne 0 ]; then
+  echo "ROOD: ${fails} test(s) gefaald." >&2
+  exit 1
+fi
+
+echo "GROEN: alle uitgang-tests geslaagd."

--- a/demo/environment/lib/test-fsc-contract.sh
+++ b/demo/environment/lib/test-fsc-contract.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# Fixture-tests voor de matchers in fsc-contract.sh.
+#
+# Het zwaartepunt ligt op fsc_contract_beoordeling: dat is de autorisatiegrens van de provider-helft.
+# Waar de accept vóór de splitsing een gerichte handeling was (het script kende het hash dat het zelf
+# net had ingediend), besluit de provider nu per binnengekomen contract of hij tekent — en de inhoud
+# van dat contract komt van de tegenpartij. Elke eis heeft daarom zijn eigen weiger-test, inclusief
+# het geval waar het contract een tweede grant meesmokkelt.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=fsc-harness.sh
+source "$HERE/fsc-harness.sh"
+# shellcheck source=fsc-contract.sh
+source "$HERE/fsc-contract.sh"
+
+fails=0
+
+fsc_have_jq
+[ "$HAVE_JQ" -eq 1 ] || { echo "FAIL: jq is vereist voor deze fixture-tests." >&2; exit 1; }
+
+# Vaste testidentiteiten. De waarden zelf doen er niet toe, alleen dat ze van elkaar verschillen.
+SVC=berichtenmagazijn
+SVC2=berichtenarchief
+PROV=00000000000000100000
+CONS=00000000000000001000
+CONS2=00000000000000002000
+VREEMDE=00000000000000009999
+THUMB="$(printf 'a%.0s' $(seq 1 64))"
+
+DIENSTEN="$(fsc_json_lijst "$SVC")"
+CONSUMERS="$(fsc_json_lijst "$CONS")"
+
+# --- fixtures ------------------------------------------------------------------------------------
+
+# grant <service> <service-peer> <consumer-peer> [type]: één grant-object.
+grant() {
+  jq -nc --arg svc "$1" --arg sp "$2" --arg cp "$3" --arg t "${4:-GRANT_TYPE_SERVICE_CONNECTION}" \
+         --arg thumb "$THUMB" '
+    { type: $t,
+      service: { name: $svc, peer_id: $sp },
+      outway: { peer_id: $cp, identification: { public_key_thumbprint: $thumb } } }'
+}
+
+# contract <hash> <state> <has_revoked> <getekend-door-provider> <grant-json...>
+contract() {
+  local h="$1" st="$2" rv="$3" ondertekend="$4"; shift 4
+  printf '%s\n' "$@" | jq -sc --arg h "$h" --arg st "$st" --argjson rv "$rv" \
+        --argjson sig "$ondertekend" --arg prov "$PROV" '
+    { hash: $h, state: $st, has_revoked: $rv,
+      signatures: { accept: (if $sig then {($prov): true} else {} end) },
+      content: { grants: . } }'
+}
+
+bundel() { printf '%s\n' "$@" | jq -sc '{ contracts: . }'; }
+
+# --- assert-helpers ------------------------------------------------------------------------------
+
+assert_gelijk() {
+  local desc="$1" verwacht="$2" kregen="$3"
+  if [ "$kregen" = "$verwacht" ]; then
+    echo "OK: $desc"
+  else
+    echo "FAIL: $desc — verwacht [$verwacht], kreeg [$kregen]" >&2
+    fails=$((fails + 1))
+  fi
+}
+
+# assert_beoordeling <desc> <json> <soort> <verwacht> [diensten-json] [consumers-json]
+assert_beoordeling() {
+  local desc="$1" json="$2" soort="$3" verwacht="$4" d="${5:-$DIENSTEN}" c="${6:-$CONSUMERS}"
+  assert_gelijk "$desc" "$verwacht" \
+    "$(fsc_contract_regels "$(fsc_contract_beoordeling "$json" "$PROV" "$d" "$c")" "$soort")"
+}
+
+# assert_weigerreden <desc> <json> <fragment>: de weigering noemt deze grond.
+assert_weigerreden() {
+  local desc="$1" json="$2" fragment="$3" reden
+  reden="$(fsc_contract_regels "$(fsc_contract_beoordeling "$json" "$PROV" "$DIENSTEN" "$CONSUMERS")" WEIGER)"
+
+  case "$reden" in
+    *"$fragment"*) echo "OK: $desc" ;;
+    *) echo "FAIL: $desc — verwachtte een reden met '$fragment', kreeg [$reden]" >&2
+       fails=$((fails + 1)) ;;
+  esac
+}
+
+echo "== fsc_contract_beoordeling: cardinaliteit =="
+
+assert_beoordeling "lege contractenlijst levert niets op" '{"contracts":[]}' TEKEN ""
+assert_beoordeling "lege contractenlijst weigert ook niets" '{"contracts":[]}' WEIGER ""
+
+GOED="$(contract h1 CONTRACT_STATE_PROPOSED false false "$(grant "$SVC" "$PROV" "$CONS")")"
+assert_beoordeling "één passend contract wordt getekend" "$(bundel "$GOED")" TEKEN "h1 ${CONS}"
+
+# Twee passende contracten: een matcher die alleen het eerste teruggeeft zou hier de helft laten
+# liggen, en dat is precies het geval dat op ZAD ontstaat zodra een tweede consumer aanhaakt.
+GOED2="$(contract h2 CONTRACT_STATE_PROPOSED false false "$(grant "$SVC" "$PROV" "$CONS")")"
+assert_beoordeling "twee passende contracten worden allebei getekend" \
+  "$(bundel "$GOED" "$GOED2")" TEKEN "h1 ${CONS}
+h2 ${CONS}"
+
+echo
+echo "== fsc_contract_beoordeling: de autorisatie-eisen, elk apart =="
+
+# De kern van de invariant. Een contract draagt een LIJST grants; wie alleen toetst of er één
+# passende grant in zit, tekent de tweede mee.
+SMOKKEL="$(contract hs CONTRACT_STATE_PROPOSED false false \
+  "$(grant "$SVC" "$PROV" "$CONS")" "$(grant "$SVC2" "$PROV" "$VREEMDE")")"
+assert_beoordeling "een tweede grant erbij: niet tekenen" "$(bundel "$SMOKKEL")" TEKEN ""
+assert_weigerreden "en de reden noemt het aantal grants" "$(bundel "$SMOKKEL")" "draagt 2 grants"
+
+GEEN_GRANTS="$(contract hg CONTRACT_STATE_PROPOSED false false)"
+assert_beoordeling "nul grants: niet tekenen" "$(bundel "$GEEN_GRANTS")" TEKEN ""
+
+VERKEERD_TYPE="$(contract ht CONTRACT_STATE_PROPOSED false false \
+  "$(grant "$SVC" "$PROV" "$CONS" GRANT_TYPE_SERVICE_PUBLICATION)")"
+assert_beoordeling "ander grant-type: niet tekenen" "$(bundel "$VERKEERD_TYPE")" TEKEN ""
+assert_weigerreden "en de reden noemt het type" "$(bundel "$VERKEERD_TYPE")" "geen serviceConnection"
+
+ANDERE_PEER="$(contract hp CONTRACT_STATE_PROPOSED false false "$(grant "$SVC" "$VREEMDE" "$CONS")")"
+assert_beoordeling "dienst van een andere peer: niet tekenen" "$(bundel "$ANDERE_PEER")" TEKEN ""
+assert_weigerreden "en de reden noemt de vreemde peer" "$(bundel "$ANDERE_PEER")" "niet bij ons"
+
+ANDERE_DIENST="$(contract hd CONTRACT_STATE_PROPOSED false false "$(grant "$SVC2" "$PROV" "$CONS")")"
+assert_beoordeling "dienst die wij niet aanbieden: niet tekenen" "$(bundel "$ANDERE_DIENST")" TEKEN ""
+assert_weigerreden "en de reden noemt de dienst" "$(bundel "$ANDERE_DIENST")" "bieden wij niet aan"
+
+VREEMDE_CONS="$(contract hc CONTRACT_STATE_PROPOSED false false "$(grant "$SVC" "$PROV" "$VREEMDE")")"
+assert_beoordeling "onbekende consumer: niet tekenen" "$(bundel "$VREEMDE_CONS")" TEKEN ""
+assert_weigerreden "en de reden noemt de consumer" "$(bundel "$VREEMDE_CONS")" "staat niet op de lijst"
+
+echo
+echo "== fsc_contract_beoordeling: allowlists met meer dan één waarde =="
+
+# Een allowlist van één verbergt het verschil tussen "geeft de enige terug" en "kiest per sleutel".
+BREED_D="$(fsc_json_lijst "$SVC2" "$SVC")"
+BREED_C="$(fsc_json_lijst "$CONS2" "$CONS")"
+
+assert_beoordeling "tweede dienst uit een bredere lijst telt mee" \
+  "$(bundel "$ANDERE_DIENST")" TEKEN "hd ${CONS}" "$BREED_D" "$CONSUMERS"
+assert_beoordeling "tweede consumer uit een bredere lijst telt mee" \
+  "$(bundel "$(contract hb CONTRACT_STATE_PROPOSED false false "$(grant "$SVC" "$PROV" "$CONS2")")")" \
+  TEKEN "hb ${CONS2}" "$DIENSTEN" "$BREED_C"
+assert_beoordeling "een waarde buiten de bredere lijst blijft geweigerd" \
+  "$(bundel "$VREEMDE_CONS")" TEKEN "" "$BREED_D" "$BREED_C"
+
+echo
+echo "== fsc_contract_beoordeling: al getekend en ingetrokken =="
+
+AL_GETEKEND="$(contract hq CONTRACT_STATE_VALID false true "$(grant "$SVC" "$PROV" "$CONS")")"
+assert_beoordeling "al getekend contract komt niet opnieuw langs" "$(bundel "$AL_GETEKEND")" TEKEN ""
+assert_beoordeling "maar is wel als GETEKEND zichtbaar" "$(bundel "$AL_GETEKEND")" GETEKEND "hq ${CONS}"
+
+# Het servicePublication-contract voor onze eigen dienst staat op dezelfde manager en wordt door
+# AUTO_SIGN_GRANTS vanzelf getekend. Zou dat elke ronde een weigering opleveren, dan stond de log vol
+# met contracten waar niets mee mis is.
+PUBLICATIE="$(contract hpub CONTRACT_STATE_VALID false true \
+  "$(grant "$SVC" "$PROV" "$CONS" GRANT_TYPE_SERVICE_PUBLICATION)")"
+assert_beoordeling "een getekend contract dat de toets niet haalt zwijgt" "$(bundel "$PUBLICATIE")" WEIGER ""
+assert_beoordeling "en verschijnt ook niet als GETEKEND" "$(bundel "$PUBLICATIE")" GETEKEND ""
+
+INGETROKKEN="$(contract hr CONTRACT_STATE_PROPOSED true false "$(grant "$SVC" "$PROV" "$CONS")")"
+assert_beoordeling "ingetrokken contract wordt niet getekend" "$(bundel "$INGETROKKEN")" TEKEN ""
+assert_beoordeling "en levert geen weigering op" "$(bundel "$INGETROKKEN")" WEIGER ""
+
+echo
+echo "== fsc_contract_beoordeling: gemengde lijst =="
+
+GEMENGD="$(bundel "$GOED" "$SMOKKEL" "$AL_GETEKEND" "$INGETROKKEN" "$VREEMDE_CONS")"
+assert_beoordeling "uit een gemengde lijst alleen het juiste contract" "$GEMENGD" TEKEN "h1 ${CONS}"
+assert_beoordeling "de getekende komt als GETEKEND terug" "$GEMENGD" GETEKEND "hq ${CONS}"
+assert_gelijk "twee weigeringen met hun eigen grond" "hs
+hc" \
+  "$(fsc_contract_regels "$(fsc_contract_beoordeling "$GEMENGD" "$PROV" "$DIENSTEN" "$CONSUMERS")" WEIGER \
+     | cut -d' ' -f1)"
+
+echo
+echo "== fsc_contract_voor_combinatie =="
+
+assert_combinatie() {
+  local desc="$1" json="$2" verwacht="$3"
+  assert_gelijk "$desc" "$verwacht" "$(fsc_contract_voor_combinatie "$json" "$SVC" "$PROV" "$CONS" "$THUMB")"
+}
+
+assert_combinatie "lege lijst levert niets op" '{"contracts":[]}' ""
+assert_combinatie "ingediend maar niet getekend telt mee als uitstaand" \
+  "$(bundel "$GOED")" "h1 contract_state_proposed nee"
+assert_combinatie "getekend en geldig komt met beide kenmerken terug" \
+  "$(bundel "$AL_GETEKEND")" "hq contract_state_valid ja"
+
+# Zonder deze regel zou de consumer een contract van een andere outway voor "het onze" aanzien en
+# nooit meer indienen, terwijl zíjn outway de grant nooit krijgt.
+ANDERE_THUMB_C="$(contract hz CONTRACT_STATE_VALID false true "$(
+  jq -nc --arg svc "$SVC" --arg sp "$PROV" --arg cp "$CONS" '
+    { type: "GRANT_TYPE_SERVICE_CONNECTION",
+      service: { name: $svc, peer_id: $sp },
+      outway: { peer_id: $cp, identification: { public_key_thumbprint: "ffff" } } }')")"
+assert_combinatie "een andere outway-thumbprint is een ander contract" "$(bundel "$ANDERE_THUMB_C")" ""
+
+assert_combinatie "een contract met twee grants hoort niet bij deze combinatie" "$(bundel "$SMOKKEL")" ""
+assert_combinatie "ingetrokken telt niet mee" "$(bundel "$INGETROKKEN")" ""
+assert_combinatie "twee uitstaande contracten komen allebei terug" \
+  "$(bundel "$GOED" "$GOED2")" "h1 contract_state_proposed nee
+h2 contract_state_proposed nee"
+
+echo
+echo "== de helften kennen elkaars manager niet =="
+
+# Statisch, en daarom hier en niet in de smoke: dit is de eigenschap waar de hele ZAD-opzet op
+# rust, en hij moet ook toetsbaar zijn zonder draaiende federatie. Een half dat de adres- of
+# certificaat-variabelen van de overkant leest, werkt lokaal prima en faalt pas op ZAD — precies de
+# terugkoppeling die we niet willen.
+#
+# De OIN's staan er bewust niet bij: dat zijn publieke organisatienummers, geen adressen, en beide
+# helften hebben ze nodig om te weten waar het contract over gaat.
+CONTRACTS_DIR="$(cd "$HERE/../federatie/contracts" && pwd)"
+
+assert_geen_verwijzing() {
+  local desc="$1" bestand="$2" patroon="$3" treffers
+  treffers="$(grep -nE "$patroon" "$bestand" || true)"
+
+  if [ -z "$treffers" ]; then
+    echo "OK: $desc"
+  else
+    echo "FAIL: $desc — gevonden in $(basename "$bestand"):" >&2
+    printf '%s\n' "$treffers" | sed 's/^/  /' >&2
+    fails=$((fails + 1))
+  fi
+}
+
+assert_geen_verwijzing "de consumer-helft noemt de provider-manager nergens" \
+  "${CONTRACTS_DIR}/bootstrap-consumer.sh" 'FSC_PROVIDER_(MANAGER|CERT|KEY|CA|ADRES)'
+assert_geen_verwijzing "de provider-helft noemt de consumer-manager nergens" \
+  "${CONTRACTS_DIR}/bootstrap-provider.sh" 'FSC_CONSUMER_(MANAGER|CERT|KEY|CA|ADRES)'
+
+echo
+if [ "$fails" -ne 0 ]; then
+  echo "ROOD: ${fails} test(s) gefaald." >&2
+  exit 1
+fi
+
+echo "GROEN: alle fsc-contract-tests geslaagd."

--- a/demo/environment/lib/test-fsc-contract.sh
+++ b/demo/environment/lib/test-fsc-contract.sh
@@ -45,7 +45,7 @@ grant() {
   jq -nc --arg svc "$1" --arg sp "$2" --arg cp "$3" --arg t "${4:-GRANT_TYPE_SERVICE_CONNECTION}" \
          --arg it "${5:-OUTWAY_IDENTIFICATION_TYPE_PUBLIC_KEY_THUMBPRINT}" --arg thumb "$THUMB" '
     { type: $t,
-      service: { name: $svc, peer_id: $sp },
+      service: { type: "SERVICE_TYPE_SERVICE", name: $svc, peer_id: $sp },
       outway: { peer_id: $cp, identification: { type: $it, public_key_thumbprint: $thumb } } }'
 }
 
@@ -168,8 +168,11 @@ assert_weigerreden "en de reden noemt de consumer" "$(bundel "$VREEMDE_CONS")" "
 assert_weiger_regel "gedelegeerde dienst: niet tekenen" \
   "$(bundel "$(contract_ruw '.content.grants[0].service.type = "SERVICE_TYPE_DELEGATED_SERVICE"')")" \
   "hx dienst-type SERVICE_TYPE_DELEGATED_SERVICE is geen gewone dienst"
-assert_beoordeling "een gewone dienst mag expliciet ook" \
-  "$(bundel "$(contract_ruw '.content.grants[0].service.type = "SERVICE_TYPE_SERVICE"')")" TEKEN "hx ${CONS}"
+# De discriminator is verplicht in de spec; een ontbrekende waarde als "gewone dienst" lezen zou
+# precies de blinde ondertekening zijn die deze check moet voorkomen.
+assert_weiger_regel "ontbrekend dienst-type: niet tekenen" \
+  "$(bundel "$(contract_ruw 'del(.content.grants[0].service.type)')")" \
+  "hx dienst-type ontbreekt is geen gewone dienst"
 
 # `properties` schrijft claims die onze eigen manager in het token zet en die onze inway en de dienst
 # erachter te zien krijgen — door de tegenpartij opgesteld. Blind mee-ondertekenen is dezelfde fout
@@ -244,9 +247,9 @@ assert_combinatie() {
 
 assert_combinatie "lege lijst levert niets op" '{"contracts":[]}' ""
 assert_combinatie "ingediend maar niet getekend telt mee als uitstaand" \
-  "$(bundel "$GOED")" "h1 contract_state_proposed nee"
+  "$(bundel "$GOED")" "h1 contract_state_proposed nee -"
 assert_combinatie "getekend en geldig komt met beide kenmerken terug" \
-  "$(bundel "$AL_GETEKEND")" "hq contract_state_valid ja"
+  "$(bundel "$AL_GETEKEND")" "hq contract_state_valid ja -"
 
 # Zonder deze regel zou de consumer een contract van een andere outway voor "het onze" aanzien en
 # nooit meer indienen, terwijl zíjn outway de grant nooit krijgt.
@@ -259,6 +262,14 @@ assert_combinatie "een andere outway-thumbprint is een ander contract" "$(bundel
 
 assert_combinatie "een contract met twee grants hoort niet bij deze combinatie" "$(bundel "$SMOKKEL")" ""
 assert_combinatie "ingetrokken telt niet mee" "$(bundel "$INGETROKKEN")" ""
+
+# Anders dan bij de beoordeling blijft een AFGEWEZEN contract hier zichtbaar. Zou het wegvallen, dan
+# ziet de consumer zijn eigen aanvraag niet meer en dient hij elke ronde een nieuwe in, terwijl de
+# afwijzing nergens blijkt.
+assert_combinatie "een afgewezen contract blijft zichtbaar, met vlag" \
+  "$(bundel "$(contract hr2 CONTRACT_STATE_REJECTED false false "$(grant "$SVC" "$PROV" "$CONS")" \
+      | jq -c '.has_rejected = true')")" \
+  "hr2 contract_state_rejected nee afgewezen"
 # Ook hier mag één misvormde rij de rest niet meenemen: de consumer zou zijn eigen contract dan niet
 # meer zien en elke ronde een nieuw indienen.
 #
@@ -272,13 +283,13 @@ for rot in '{"hash":"rot","content":"x"}' \
   uitkomst="$(fsc_contract_voor_combinatie "$gemengd" "$SVC" "$PROV" "$CONS" "$THUMB")" && rc=0 || rc=$?
 
   assert_gelijk "naast $(printf '%s' "$rot" | cut -c1-34)… blijft het uitstaande contract zichtbaar" \
-    "h1 contract_state_proposed nee" "$uitkomst"
+    "h1 contract_state_proposed nee -" "$uitkomst"
   assert_gelijk "  en de matcher zelf slaagt (exit 0)" "0" "$rc"
 done
 
 assert_combinatie "twee uitstaande contracten komen allebei terug" \
-  "$(bundel "$GOED" "$GOED2")" "h1 contract_state_proposed nee
-h2 contract_state_proposed nee"
+  "$(bundel "$GOED" "$GOED2")" "h1 contract_state_proposed nee -
+h2 contract_state_proposed nee -"
 
 echo
 echo "== fsc_contract_beoordeling: de eisen buiten de grant =="
@@ -488,7 +499,7 @@ assert_getal "nul wordt afgewezen" 0 "(afgewezen)"
 # Bash leest een voorloopnul als octaal; `$((x * 08))` breekt af midden in de lus.
 assert_getal "voorloopnul wordt afgewezen" 08 "(afgewezen)"
 assert_getal "eenheden erachter worden afgewezen" 15s "(afgewezen)"
-assert_getal "negatief wordt afgewezen" -- "(afgewezen)"
+assert_getal "negatief wordt afgewezen" -1 "(afgewezen)"
 assert_getal "leeg wordt afgewezen" "" "(afgewezen)"
 
 echo

--- a/demo/environment/lib/test-fsc-contract.sh
+++ b/demo/environment/lib/test-fsc-contract.sh
@@ -14,10 +14,11 @@ source "$HERE/fsc-harness.sh"
 # shellcheck source=fsc-contract.sh
 source "$HERE/fsc-contract.sh"
 
-fails=0
-
+fsc_errlog_init
 fsc_have_jq
 [ "$HAVE_JQ" -eq 1 ] || { echo "FAIL: jq is vereist voor deze fixture-tests." >&2; exit 1; }
+
+fails=0
 
 # Vaste testidentiteiten. De waarden zelf doen er niet toe, alleen dat ze van elkaar verschillen.
 SVC=berichtenmagazijn
@@ -30,26 +31,45 @@ THUMB="$(printf 'a%.0s' $(seq 1 64))"
 
 DIENSTEN="$(fsc_json_lijst "$SVC")"
 CONSUMERS="$(fsc_json_lijst "$CONS")"
+GROEP=moza-fbs-test
+MAXGELDIG=316224000
 
 # --- fixtures ------------------------------------------------------------------------------------
 
-# grant <service> <service-peer> <consumer-peer> [type]: één grant-object.
+# grant <service> <service-peer> <consumer-peer> [grant-type] [identificatie-type]: één grant-object,
+# in de vorm die de consumer-helft daadwerkelijk indient.
 grant() {
   jq -nc --arg svc "$1" --arg sp "$2" --arg cp "$3" --arg t "${4:-GRANT_TYPE_SERVICE_CONNECTION}" \
-         --arg thumb "$THUMB" '
+         --arg it "${5:-OUTWAY_IDENTIFICATION_TYPE_PUBLIC_KEY_THUMBPRINT}" --arg thumb "$THUMB" '
     { type: $t,
       service: { name: $svc, peer_id: $sp },
-      outway: { peer_id: $cp, identification: { public_key_thumbprint: $thumb } } }'
+      outway: { peer_id: $cp, identification: { type: $it, public_key_thumbprint: $thumb } } }'
 }
 
 # contract <hash> <state> <has_revoked> <getekend-door-provider> <grant-json...>
+#
+# `signatures.accept` draagt ALTIJD de consumer, want zo ziet een echt ingediend contract eruit: de
+# manager van de consumer tekent server-side bij de POST. Een fixture met een lege `accept` zou het
+# verschil verbergen tussen "heeft ONZE handtekening" en "heeft een handtekening" — precies de
+# vergissing die de provider elk contract als al-getekend zou laten zien, waardoor hij nooit tekent.
+#
+# Ook group_id, hash_algorithm en validity horen erbij: die wegen sinds de uitbreiding mee in de
+# toets, en een fixture zonder die velden zou een andere weiger-grond raken dan de test bedoelt.
 contract() {
   local h="$1" st="$2" rv="$3" ondertekend="$4"; shift 4
   printf '%s\n' "$@" | jq -sc --arg h "$h" --arg st "$st" --argjson rv "$rv" \
-        --argjson sig "$ondertekend" --arg prov "$PROV" '
+        --argjson sig "$ondertekend" --arg prov "$PROV" --arg cons "$CONS" --arg groep "$GROEP" '
     { hash: $h, state: $st, has_revoked: $rv,
-      signatures: { accept: (if $sig then {($prov): true} else {} end) },
-      content: { grants: . } }'
+      signatures: { accept: ({($cons): true} + (if $sig then {($prov): true} else {} end)) },
+      content: { group_id: $groep, hash_algorithm: "HASH_ALGORITHM_SHA3_512",
+                 validity: { not_before: 1000, not_after: (1000 + 315360000) },
+                 grants: . } }'
+}
+
+# contract_ruw <json-patch>: een contract met een afwijkende content, voor de eisen buiten de grant.
+contract_ruw() {
+  contract hx CONTRACT_STATE_PROPOSED false false "$(grant "$SVC" "$PROV" "$CONS")" \
+    | jq -c "$1"
 }
 
 bundel() { printf '%s\n' "$@" | jq -sc '{ contracts: . }'; }
@@ -66,17 +86,26 @@ assert_gelijk() {
   fi
 }
 
+beoordeel() {
+  fsc_contract_beoordeling "$1" "$PROV" "${2:-$DIENSTEN}" "${3:-$CONSUMERS}" "$GROEP" "$MAXGELDIG"
+}
+
 # assert_beoordeling <desc> <json> <soort> <verwacht> [diensten-json] [consumers-json]
 assert_beoordeling() {
   local desc="$1" json="$2" soort="$3" verwacht="$4" d="${5:-$DIENSTEN}" c="${6:-$CONSUMERS}"
-  assert_gelijk "$desc" "$verwacht" \
-    "$(fsc_contract_regels "$(fsc_contract_beoordeling "$json" "$PROV" "$d" "$c")" "$soort")"
+  assert_gelijk "$desc" "$verwacht" "$(fsc_contract_regels "$(beoordeel "$json" "$d" "$c")" "$soort")"
+}
+
+# assert_weiger_regel <desc> <json> <verwachte volledige regel>: strikter dan op een fragment
+# matchen, want zo is "juiste reden, verkeerd contract" wél te onderscheiden.
+assert_weiger_regel() {
+  assert_gelijk "$1" "$3" "$(fsc_contract_regels "$(beoordeel "$2")" WEIGER)"
 }
 
 # assert_weigerreden <desc> <json> <fragment>: de weigering noemt deze grond.
 assert_weigerreden() {
   local desc="$1" json="$2" fragment="$3" reden
-  reden="$(fsc_contract_regels "$(fsc_contract_beoordeling "$json" "$PROV" "$DIENSTEN" "$CONSUMERS")" WEIGER)"
+  reden="$(fsc_contract_regels "$(beoordeel "$json")" WEIGER)"
 
   case "$reden" in
     *"$fragment"*) echo "OK: $desc" ;;
@@ -203,6 +232,146 @@ assert_combinatie "ingetrokken telt niet mee" "$(bundel "$INGETROKKEN")" ""
 assert_combinatie "twee uitstaande contracten komen allebei terug" \
   "$(bundel "$GOED" "$GOED2")" "h1 contract_state_proposed nee
 h2 contract_state_proposed nee"
+
+echo
+echo "== fsc_contract_beoordeling: de eisen buiten de grant =="
+
+# Zonder deze vier bepaalt de tegenpartij in zijn eentje hoe lang en onder welke voorwaarden het
+# contract geldt; de allowlist zegt daar niets over.
+assert_weiger_regel "vreemde group_id: niet tekenen" \
+  "$(bundel "$(contract_ruw '.content.group_id = "andere-groep"')")" \
+  "hx hoort bij group andere-groep, niet bij de onze"
+assert_weiger_regel "afwijkend hash-algoritme: niet tekenen" \
+  "$(bundel "$(contract_ruw '.content.hash_algorithm = "HASH_ALGORITHM_SHA1"')")" \
+  "hx hash-algoritme HASH_ALGORITHM_SHA1 wijkt af"
+assert_weiger_regel "geen geldigheidsduur: niet tekenen" \
+  "$(bundel "$(contract_ruw 'del(.content.validity)')")" \
+  "hx draagt geen geldigheidsduur"
+assert_weiger_regel "geldigheidsduur boven het maximum: niet tekenen" \
+  "$(bundel "$(contract_ruw '.content.validity.not_after = 1000 + 999999999')")" \
+  "hx geldigheidsduur 999999999s overschrijdt het maximum van ${MAXGELDIG}s"
+
+# Precies op de grens hoort het nog wél te mogen: een off-by-one hier zou de normale
+# tienjaars-aanvraag van de consumer-helft weigeren.
+assert_beoordeling "geldigheidsduur precies op het maximum mag" \
+  "$(bundel "$(contract_ruw ".content.validity.not_after = 1000 + ${MAXGELDIG}")")" TEKEN "hx ${CONS}"
+
+# DOMAIN_NAME is een zwakkere binding dan een thumbprint; die hoort een provider niet te tekenen.
+assert_weiger_regel "andere outway-identificatie: niet tekenen" \
+  "$(bundel "$(contract hi CONTRACT_STATE_PROPOSED false false \
+      "$(grant "$SVC" "$PROV" "$CONS" GRANT_TYPE_SERVICE_CONNECTION OUTWAY_IDENTIFICATION_TYPE_DOMAIN_NAME)")")" \
+  "hi outway-identificatie OUTWAY_IDENTIFICATION_TYPE_DOMAIN_NAME is geen thumbprint"
+
+echo
+echo "== fsc_contract_beoordeling: volgorde en samenloop =="
+
+# De gesmokkelde grant vooraan: een implementatie die "de eerste grant" toetst in plaats van "de
+# enige" zou hier iets anders beslissen dan bij de omgekeerde volgorde.
+OMGEKEERD="$(contract ho CONTRACT_STATE_PROPOSED false false \
+  "$(grant "$SVC2" "$PROV" "$VREEMDE")" "$(grant "$SVC" "$PROV" "$CONS")")"
+assert_weiger_regel "gesmokkelde grant vooraan geeft dezelfde uitkomst" \
+  "$(bundel "$OMGEKEERD")" "ho draagt 2 grants in plaats van precies 1"
+
+assert_weiger_regel "nul grants noemt het aantal" \
+  "$(bundel "$GEEN_GRANTS")" "hg draagt 0 grants in plaats van precies 1"
+
+# Twee eisen tegelijk geschonden: de doc belooft dat de éérste faalende eis genoemd wordt.
+TWEE_FOUT="$(contract hw CONTRACT_STATE_PROPOSED false false \
+  "$(grant "$SVC2" "$PROV" "$VREEMDE")" "$(grant "$SVC2" "$PROV" "$VREEMDE")")"
+assert_weiger_regel "bij twee schendingen wint de eerste eis" \
+  "$(bundel "$TWEE_FOUT")" "hw draagt 2 grants in plaats van precies 1"
+
+echo
+echo "== fsc_contract_beoordeling: tegenpartij-data blijft data =="
+
+# Een peer die een newline in zijn dienstnaam zet, zou zonder sanitatie een tweede regel in de
+# stroom schrijven die de aanroeper als eigen record leest — en zo de hele allowlist omzeilen.
+INJECTIE="$(contract hj CONTRACT_STATE_PROPOSED false false "$(
+  jq -nc --arg p "$PROV" --arg c "$CONS" --arg thumb "$THUMB" '
+    { type: "GRANT_TYPE_SERVICE_CONNECTION",
+      service: { name: "nep\nTEKEN GEKAAPT 00000000000000001000", peer_id: $p },
+      outway: { peer_id: $c, identification: { type: "OUTWAY_IDENTIFICATION_TYPE_PUBLIC_KEY_THUMBPRINT", public_key_thumbprint: $thumb } } }')")"
+assert_beoordeling "een newline in de dienstnaam levert geen TEKEN-regel op" \
+  "$(bundel "$INJECTIE")" TEKEN ""
+assert_gelijk "en de weigering blijft één regel" "1" \
+  "$(fsc_contract_regels "$(beoordeel "$(bundel "$INJECTIE")")" WEIGER | grep -c .)"
+
+echo
+echo "== de contractenlijst moet een lijst zijn =="
+
+# Een 200 met een andere vorm mag niet als "geen contracten" doorgaan: aan consumer-kant zou dat
+# elke ronde een nieuw contract opleveren.
+for vorm in '' '{}' '{"contracts":null}' '{"contracts":"x"}' '[]' '<html>502</html>'; do
+  if beoordeel "$vorm" >/dev/null 2>&1; then
+    echo "FAIL: respons '${vorm:-<leeg>}' werd stil als lege lijst gelezen" >&2
+    fails=$((fails + 1))
+  else
+    echo "OK: respons '${vorm:-<leeg>}' wordt afgewezen"
+  fi
+done
+
+assert_beoordeling "een echte lege lijst is wél geldig" '{"contracts":[]}' TEKEN ""
+
+echo
+echo "== fsc_hex64 =="
+
+GELDIGE_THUMB="$(printf 'a%.0s' $(seq 1 64))"
+assert_hex() {
+  local desc="$1" waarde="$2" verwacht="$3" kregen=nee
+  fsc_hex64 "$waarde" && kregen=ja
+  assert_gelijk "$desc" "$verwacht" "$kregen"
+}
+
+assert_hex "64 lowercase hex is geldig" "$GELDIGE_THUMB" ja
+assert_hex "leeg is ongeldig" "" nee
+assert_hex "63 tekens is ongeldig" "${GELDIGE_THUMB%?}" nee
+assert_hex "65 tekens is ongeldig" "${GELDIGE_THUMB}a" nee
+assert_hex "hoofdletters zijn ongeldig" "$(printf 'A%.0s' $(seq 1 64))" nee
+# De oude glob toetste alleen teken 1; deze twee kwamen er toen doorheen.
+assert_hex "niet-hex ná het eerste teken is ongeldig" "a$(printf 'z%.0s' $(seq 1 63))" nee
+assert_hex "een aanhalingsteken erin is ongeldig" "a\",\"x\":\"$(printf 'a%.0s' $(seq 1 56))" nee
+
+echo
+echo "== fsc_lijst_naar_json en fsc_json_lijst =="
+
+assert_gelijk "één dienst" '["a"]' "$(fsc_lijst_naar_json T a | tr -d '\n')"
+assert_gelijk "meerdere op spaties" '["a","b"]' "$(fsc_lijst_naar_json T "a  b" | tr -d '\n')"
+# Een allowlist over meerdere regels: `read -r -a` zou hier alles na regel 1 laten vallen, en dat
+# versmalt de autorisatiegrens zonder dat iemand het merkt.
+assert_gelijk "meerdere over regels" '["a","b","c"]' "$(fsc_lijst_naar_json T "$(printf 'a\nb c')" | tr -d '\n')"
+assert_gelijk "tabs tellen ook als scheiding" '["a","b"]' "$(fsc_lijst_naar_json T "$(printf 'a\tb')" | tr -d '\n')"
+
+for leeg in "" " " "$(printf '\n\n')"; do
+  if fsc_lijst_naar_json T "$leeg" >/dev/null 2>&1; then
+    echo "FAIL: lege lijst '${leeg}' werd geaccepteerd" >&2
+    fails=$((fails + 1))
+  else
+    echo "OK: lege lijst wordt afgewezen"
+  fi
+done
+
+# De grens waar operator-env een jq-argument wordt.
+assert_gelijk "aanhalingstekens worden ge-escaped" '["a\"b"]' "$(fsc_json_lijst 'a"b' | tr -d '\n')"
+assert_gelijk "geen argumenten geeft een lege array" '[]' "$(fsc_json_lijst)"
+
+echo
+echo "== fsc_contract_manager_ok =="
+
+assert_manager() {
+  local desc="$1" verwacht="$2"; shift 2
+  local kregen=nee
+  fsc_contract_manager_ok "$@" 2>/dev/null && kregen=ja
+  assert_gelijk "$desc" "$verwacht" "$kregen"
+}
+
+assert_manager "https wordt geaccepteerd" ja https://manager:9443
+assert_manager "http wordt geweigerd" nee http://manager:9443
+assert_manager "leeg wordt geweigerd" nee ""
+# De reden dat deze functie bestaat: curl leest een argument dat met `-` begint als optie, en
+# `-K/pad` maakt er een lees-je-config-uit-dit-bestand van.
+assert_manager "een curl-optie wordt geweigerd" nee -K/tmp/kwaadaardig
+# Met twee argumenten: een implementatie die na de eerste stopt, zou de tweede missen.
+assert_manager "een ongeldig tweede adres wordt ook geweigerd" nee https://manager:9443 http://andere:9443
 
 echo
 echo "== de helften kennen elkaars manager niet =="

--- a/demo/environment/lib/test-fsc-contract.sh
+++ b/demo/environment/lib/test-fsc-contract.sh
@@ -163,6 +163,30 @@ VREEMDE_CONS="$(contract hc CONTRACT_STATE_PROPOSED false false "$(grant "$SVC" 
 assert_beoordeling "onbekende consumer: niet tekenen" "$(bundel "$VREEMDE_CONS")" TEKEN ""
 assert_weigerreden "en de reden noemt de consumer" "$(bundel "$VREEMDE_CONS")" "staat niet op de lijst"
 
+# Een gedelegeerde dienst zet een delegator-claim in het token en verandert welke handtekeningen
+# vereist zijn. Wij bieden die niet aan.
+assert_weiger_regel "gedelegeerde dienst: niet tekenen" \
+  "$(bundel "$(contract_ruw '.content.grants[0].service.type = "SERVICE_TYPE_DELEGATED_SERVICE"')")" \
+  "hx dienst-type SERVICE_TYPE_DELEGATED_SERVICE is geen gewone dienst"
+assert_beoordeling "een gewone dienst mag expliciet ook" \
+  "$(bundel "$(contract_ruw '.content.grants[0].service.type = "SERVICE_TYPE_SERVICE"')")" TEKEN "hx ${CONS}"
+
+# `properties` schrijft claims die onze eigen manager in het token zet en die onze inway en de dienst
+# erachter te zien krijgen — door de tegenpartij opgesteld. Blind mee-ondertekenen is dezelfde fout
+# als een tweede grant mee-ondertekenen.
+assert_weiger_regel "grant met properties: niet tekenen" \
+  "$(bundel "$(contract_ruw '.content.grants[0].properties = {"rol": "beheerder"}')")" \
+  "hx draagt grant-properties die wij niet ondertekenen"
+assert_beoordeling "een leeg properties-object is onschadelijk" \
+  "$(bundel "$(contract_ruw '.content.grants[0].properties = {}')")" TEKEN "hx ${CONS}"
+
+# Een contract dat wij eerder afwezen draagt onze accept-handtekening niet, dus zonder filter komt
+# het elke ronde terug als kandidaat en tekenen we alsnog wat we bewust weigerden.
+assert_beoordeling "een eerder afgewezen contract komt niet terug" \
+  "$(bundel "$(contract_ruw '.has_rejected = true')")" TEKEN ""
+assert_beoordeling "en levert ook geen weigering op" \
+  "$(bundel "$(contract_ruw '.has_rejected = true')")" WEIGER ""
+
 echo
 echo "== fsc_contract_beoordeling: allowlists met meer dan één waarde =="
 
@@ -417,6 +441,73 @@ done
 # De grens waar operator-env een jq-argument wordt.
 assert_gelijk "aanhalingstekens worden ge-escaped" '["a\"b"]' "$(fsc_json_lijst 'a"b' | tr -d '\n')"
 assert_gelijk "geen argumenten geeft een lege array" '[]' "$(fsc_json_lijst)"
+
+echo
+echo "== een rij die geen object is =="
+
+# Zonder aparte typecheck laat élke veldtoets zo'n rij het hele programma afbreken, en dan wordt in
+# die ronde geen enkel legitiem contract getekend.
+for rot in '"oeps"' '42' '[]' 'null'; do
+  gemengd="$(printf '%s\n' "$GOED" "$rot" | jq -sc '{contracts: .}')"
+  uitkomst="$(beoordeel "$gemengd")" && rc=0 || rc=$?
+
+  assert_gelijk "rij ${rot}: het goede contract blijft over" "h1 ${CONS}" \
+    "$(fsc_contract_regels "$uitkomst" TEKEN)"
+  assert_gelijk "  en de beoordeling zelf slaagt" "0" "$rc"
+done
+
+echo
+echo "== eerder getekend, nu afgekeurd: niet stil =="
+
+# Wordt een typefout in FSC_DIENSTEN gecorrigeerd ná de eerste tekenronde, of daalt de bovengrens,
+# dan valt een contract dat wij al tekenden buiten de toets. Dat is geen besluit meer, maar wel iets
+# waarvan de operator moet weten — anders meldt de provider "nog niets binnen" terwijl het er ligt.
+GETEKEND_VERLOPEN="$(contract hv CONTRACT_STATE_VALID false true "$(grant "$SVC" "$PROV" "$CONS")" \
+  | jq -c ".content.validity.not_after = ${NU} - 1")"
+assert_beoordeling "een verlopen eigen contract levert een AANDACHT-regel op" \
+  "$(bundel "$GETEKEND_VERLOPEN")" AANDACHT "hv is al verlopen"
+assert_beoordeling "en geen WEIGER" "$(bundel "$GETEKEND_VERLOPEN")" WEIGER ""
+
+# Het publicatiecontract voor onze eigen dienst draagt onze handtekening en haalt de toets ook niet;
+# dát hoort wél stil te blijven, anders staat de log elke ronde vol.
+assert_beoordeling "een getekend publicatiecontract blijft stil" "$(bundel "$PUBLICATIE")" AANDACHT ""
+
+echo
+echo "== fsc_getal_vereist =="
+
+assert_getal() {
+  local desc="$1" waarde="$2" verwacht="$3" kregen
+  kregen="$(fsc_getal_vereist T "$waarde" 2>/dev/null)" || kregen="(afgewezen)"
+  assert_gelijk "$desc" "$verwacht" "$kregen"
+}
+
+assert_getal "gewoon getal" 15 15
+assert_getal "meercijferig" 3600 3600
+# Nul zou de lus zonder pauze laten draaien — precies de hot loop waar de controle voor bestaat.
+assert_getal "nul wordt afgewezen" 0 "(afgewezen)"
+# Bash leest een voorloopnul als octaal; `$((x * 08))` breekt af midden in de lus.
+assert_getal "voorloopnul wordt afgewezen" 08 "(afgewezen)"
+assert_getal "eenheden erachter worden afgewezen" 15s "(afgewezen)"
+assert_getal "negatief wordt afgewezen" -- "(afgewezen)"
+assert_getal "leeg wordt afgewezen" "" "(afgewezen)"
+
+echo
+echo "== fsc_hash_ok =="
+
+assert_hash() {
+  local desc="$1" waarde="$2" verwacht="$3" kregen=nee
+  fsc_hash_ok "$waarde" && kregen=ja
+  assert_gelijk "$desc" "$verwacht" "$kregen"
+}
+
+assert_hash "een echte FSC-hash" '$1$4$k4rwlWTsCM_j89Fc3nrbnQa9-KB43' ja
+assert_hash "leeg" "" nee
+# `.` en `..` bestaan uit toegestane tekens maar verleggen het pad: curl normaliseert ze weg.
+assert_hash "een punt" "." nee
+assert_hash "twee punten" ".." nee
+assert_hash "een schuine streep" "a/b" nee
+assert_hash "witruimte" "a b" nee
+assert_hash "een newline" "$(printf 'a\nb')" nee
 
 echo
 echo "== fsc_contract_manager_ok =="

--- a/demo/environment/lib/test-fsc-contract.sh
+++ b/demo/environment/lib/test-fsc-contract.sh
@@ -33,6 +33,9 @@ DIENSTEN="$(fsc_json_lijst "$SVC")"
 CONSUMERS="$(fsc_json_lijst "$CONS")"
 GROEP=moza-fbs-test
 MAXGELDIG=316224000
+# Vaste "nu": de geldigheidstoets meet vanaf het heden, dus zonder een gepinde klok zou de suite
+# afhangen van wanneer hij draait.
+NU=1000000000
 
 # --- fixtures ------------------------------------------------------------------------------------
 
@@ -58,11 +61,12 @@ grant() {
 contract() {
   local h="$1" st="$2" rv="$3" ondertekend="$4"; shift 4
   printf '%s\n' "$@" | jq -sc --arg h "$h" --arg st "$st" --argjson rv "$rv" \
-        --argjson sig "$ondertekend" --arg prov "$PROV" --arg cons "$CONS" --arg groep "$GROEP" '
+        --argjson sig "$ondertekend" --arg prov "$PROV" --arg cons "$CONS" --arg groep "$GROEP" \
+        --argjson nu "$NU" '
     { hash: $h, state: $st, has_revoked: $rv,
       signatures: { accept: ({($cons): true} + (if $sig then {($prov): true} else {} end)) },
       content: { group_id: $groep, hash_algorithm: "HASH_ALGORITHM_SHA3_512",
-                 validity: { not_before: 1000, not_after: (1000 + 315360000) },
+                 validity: { not_before: ($nu - 60), not_after: ($nu + 315360000) },
                  grants: . } }'
 }
 
@@ -87,7 +91,7 @@ assert_gelijk() {
 }
 
 beoordeel() {
-  fsc_contract_beoordeling "$1" "$PROV" "${2:-$DIENSTEN}" "${3:-$CONSUMERS}" "$GROEP" "$MAXGELDIG"
+  fsc_contract_beoordeling "$1" "$PROV" "${2:-$DIENSTEN}" "${3:-$CONSUMERS}" "$GROEP" "$MAXGELDIG" "$NU"
 }
 
 # assert_beoordeling <desc> <json> <soort> <verwacht> [diensten-json] [consumers-json]
@@ -168,8 +172,10 @@ BREED_C="$(fsc_json_lijst "$CONS2" "$CONS")"
 
 assert_beoordeling "tweede dienst uit een bredere lijst telt mee" \
   "$(bundel "$ANDERE_DIENST")" TEKEN "hd ${CONS}" "$BREED_D" "$CONSUMERS"
+# Let op de handtekening: een contract van CONS2 draagt de accept van CONS2, niet die van CONS.
 assert_beoordeling "tweede consumer uit een bredere lijst telt mee" \
-  "$(bundel "$(contract hb CONTRACT_STATE_PROPOSED false false "$(grant "$SVC" "$PROV" "$CONS2")")")" \
+  "$(bundel "$(contract hb CONTRACT_STATE_PROPOSED false false "$(grant "$SVC" "$PROV" "$CONS2")" \
+      | jq -c --arg c "$CONS2" '.signatures.accept = {($c): true}')")" \
   TEKEN "hb ${CONS2}" "$DIENSTEN" "$BREED_C"
 assert_beoordeling "een waarde buiten de bredere lijst blijft geweigerd" \
   "$(bundel "$VREEMDE_CONS")" TEKEN "" "$BREED_D" "$BREED_C"
@@ -229,6 +235,23 @@ assert_combinatie "een andere outway-thumbprint is een ander contract" "$(bundel
 
 assert_combinatie "een contract met twee grants hoort niet bij deze combinatie" "$(bundel "$SMOKKEL")" ""
 assert_combinatie "ingetrokken telt niet mee" "$(bundel "$INGETROKKEN")" ""
+# Ook hier mag één misvormde rij de rest niet meenemen: de consumer zou zijn eigen contract dan niet
+# meer zien en elke ronde een nieuw indienen.
+#
+# De exit-status hoort er expliciet bij. jq streamt, dus de goede regel is al uitgestuurd vóór de
+# fout op de rotte rij — alleen op de uitvoer toetsen zou dus slagen terwijl de aanroeper
+# (`eigen_contracten`, onder `pipefail`) de run juist als mislukt afbreekt.
+for rot in '{"hash":"rot","content":"x"}' \
+           '{"hash":"rot","content":{"grants":[42]}}' \
+           '{"hash":"rot","content":{"grants":42}}'; do
+  gemengd="$(printf '%s\n' "$GOED" "$rot" | jq -sc '{contracts: .}')"
+  uitkomst="$(fsc_contract_voor_combinatie "$gemengd" "$SVC" "$PROV" "$CONS" "$THUMB")" && rc=0 || rc=$?
+
+  assert_gelijk "naast $(printf '%s' "$rot" | cut -c1-34)… blijft het uitstaande contract zichtbaar" \
+    "h1 contract_state_proposed nee" "$uitkomst"
+  assert_gelijk "  en de matcher zelf slaagt (exit 0)" "0" "$rc"
+done
+
 assert_combinatie "twee uitstaande contracten komen allebei terug" \
   "$(bundel "$GOED" "$GOED2")" "h1 contract_state_proposed nee
 h2 contract_state_proposed nee"
@@ -247,14 +270,38 @@ assert_weiger_regel "afwijkend hash-algoritme: niet tekenen" \
 assert_weiger_regel "geen geldigheidsduur: niet tekenen" \
   "$(bundel "$(contract_ruw 'del(.content.validity)')")" \
   "hx draagt geen geldigheidsduur"
-assert_weiger_regel "geldigheidsduur boven het maximum: niet tekenen" \
-  "$(bundel "$(contract_ruw '.content.validity.not_after = 1000 + 999999999')")" \
-  "hx geldigheidsduur 999999999s overschrijdt het maximum van ${MAXGELDIG}s"
-
 # Precies op de grens hoort het nog wél te mogen: een off-by-one hier zou de normale
 # tienjaars-aanvraag van de consumer-helft weigeren.
-assert_beoordeling "geldigheidsduur precies op het maximum mag" \
-  "$(bundel "$(contract_ruw ".content.validity.not_after = 1000 + ${MAXGELDIG}")")" TEKEN "hx ${CONS}"
+assert_beoordeling "looptijd precies op het maximum mag" \
+  "$(bundel "$(contract_ruw ".content.validity.not_after = ${NU} + ${MAXGELDIG}")")" TEKEN "hx ${CONS}"
+
+# Gemeten vanaf nu, niet als vensterlengte: een venster van tien jaar dat pas over jaren begint, is
+# een claim die veel verder reikt dan de grens die de lengte suggereert.
+assert_weiger_regel "venster dat ver in de toekomst begint: niet tekenen" \
+  "$(bundel "$(contract_ruw ".content.validity = {not_before: (${NU} + 200000000), not_after: (${NU} + 200000000 + 315360000)}")")" \
+  "hx loopt nog 515360000s, meer dan het maximum van ${MAXGELDIG}s"
+
+assert_weiger_regel "al verlopen contract: niet tekenen" \
+  "$(bundel "$(contract_ruw ".content.validity.not_after = ${NU} - 1")")" \
+  "hx is al verlopen"
+
+assert_weiger_regel "einddatum vóór begindatum: niet tekenen" \
+  "$(bundel "$(contract_ruw ".content.validity = {not_before: (${NU} + 100), not_after: (${NU} + 50)}")")" \
+  "hx einddatum ligt niet ná de begindatum"
+
+assert_weiger_regel "lege validity: niet tekenen" \
+  "$(bundel "$(contract_ruw '.content.validity = {}')")" \
+  "hx geldigheidsduur is onvolledig (not_before/not_after ontbreekt of is geen getal)"
+
+assert_weiger_regel "validity zonder not_after: niet tekenen" \
+  "$(bundel "$(contract_ruw 'del(.content.validity.not_after)')")" \
+  "hx geldigheidsduur is onvolledig (not_before/not_after ontbreekt of is geen getal)"
+
+# fsc-core wil onder een serviceConnection de handtekening van beide kanten; tekenen vóór de
+# tegenpartij dat deed, is een verplichting aangaan die de ander nog niet is aangegaan.
+assert_weiger_regel "consumer heeft nog niet getekend: wij ook niet" \
+  "$(bundel "$(contract_ruw '.signatures.accept = {}')")" \
+  "hx draagt de handtekening van de consumer nog niet"
 
 # DOMAIN_NAME is een zwakkere binding dan een thumbprint; die hoort een provider niet te tekenen.
 assert_weiger_regel "andere outway-identificatie: niet tekenen" \
@@ -301,7 +348,10 @@ echo "== de contractenlijst moet een lijst zijn =="
 
 # Een 200 met een andere vorm mag niet als "geen contracten" doorgaan: aan consumer-kant zou dat
 # elke ronde een nieuw contract opleveren.
-for vorm in '' '{}' '{"contracts":null}' '{"contracts":"x"}' '[]' '<html>502</html>'; do
+# Een gepagineerde lijst hoort ook af te vallen: alleen pagina 1 lezen zou betekenen dat de consumer
+# zijn eigen contract niet meer ziet zodra de manager er genoeg heeft, en dus elke ronde opnieuw
+# indient.
+for vorm in '' ' ' '{}' '{"contracts":null}' '{"contracts":"x"}' '[]' '<html>502</html>' '{"contracts":[],"next_cursor":"abc"}'; do
   if beoordeel "$vorm" >/dev/null 2>&1; then
     echo "FAIL: respons '${vorm:-<leeg>}' werd stil als lege lijst gelezen" >&2
     fails=$((fails + 1))
@@ -311,6 +361,20 @@ for vorm in '' '{}' '{"contracts":null}' '{"contracts":"x"}' '[]' '<html>502</ht
 done
 
 assert_beoordeling "een echte lege lijst is wél geldig" '{"contracts":[]}' TEKEN ""
+
+echo
+echo "== één misvormde rij mag de rest niet meenemen =="
+
+# Zonder afvangen per contract sloopt één rij met een afwijkend type het hele jq-programma, en dan
+# wordt in die ronde geen enkel legitiem contract meer getekend.
+for rot in '{"hash":"rot","content":"x"}' \
+           '{"hash":"rot","content":{"validity":"morgen"}}' \
+           '{"hash":"rot","content":{"grants":"a"}}' \
+           '{"hash":"rot","signatures":"x"}'; do
+  gemengd="$(printf '%s\n' "$GOED" "$rot" | jq -sc '{ contracts: . }')"
+  assert_gelijk "naast $(printf '%s' "$rot" | cut -c1-38)… blijft het goede contract over" \
+    "h1 ${CONS}" "$(fsc_contract_regels "$(beoordeel "$gemengd")" TEKEN)"
+done
 
 echo
 echo "== fsc_hex64 =="

--- a/demo/environment/logius/deploy/zad/README.md
+++ b/demo/environment/logius/deploy/zad/README.md
@@ -42,7 +42,7 @@ De peer staat daarom in een eigen deployment `fsc-logius`: **wat niet in `test` 
 | `cert-manifest.md` | Runbook: welk cert-bestand op welk `/etc/fsc/...`-pad, per component (UI-only bijlagen). |
 | `verify-zad.md` | Runbook: announce/publiceren/discover ná een geslaagde apply, + de acceptatiecriteria. |
 | `../../../federatie/contracts/zad-runbook.md` | Runbook: het contract-bootstrap-component (`logius-fscbootstrap`, rol consumer) neerzetten — env, cert-attachments, verificatie. |
-| `../../../../../.github/workflows/deploy.yml` (root) | `deploy-test-uitvraag`-job: de DOORLOPENDE image-tag-updates (elke push naar main) — de `uitvraag`-componenten op deployment `test`, de zes `logius-fsc*`-componenten op `fsc-logius`. Niet de eenmalige creatie (die doet `upsert-peer.sh`). |
+| `../../../../../.github/workflows/deploy.yml` (root) | `deploy-test-uitvraag`-job: de DOORLOPENDE image-tag-updates (elke push naar main) — de `uitvraag`-componenten op deployment `test`, de zeven `logius-fsc*`-componenten op `fsc-logius`. Niet de eenmalige creatie (die doet `upsert-peer.sh`). |
 
 ## Volgorde
 

--- a/demo/environment/logius/deploy/zad/README.md
+++ b/demo/environment/logius/deploy/zad/README.md
@@ -41,6 +41,7 @@ De peer staat daarom in een eigen deployment `fsc-logius`: **wat niet in `test` 
 | `upsert-peer.sh` | `validate`/`plan`/`apply` tegen de ZAD v2 Operations Manager API — lokaal/handmatig hulpmiddel voor de eenmalige component-creatie (env/ports/certs) en voor debugging. |
 | `cert-manifest.md` | Runbook: welk cert-bestand op welk `/etc/fsc/...`-pad, per component (UI-only bijlagen). |
 | `verify-zad.md` | Runbook: announce/publiceren/discover ná een geslaagde apply, + de acceptatiecriteria. |
+| `../../../federatie/contracts/zad-runbook.md` | Runbook: het contract-bootstrap-component (`logius-fscbootstrap`, rol consumer) neerzetten — env, cert-attachments, verificatie. |
 | `../../../../../.github/workflows/deploy.yml` (root) | `deploy-test-uitvraag`-job: de DOORLOPENDE image-tag-updates (elke push naar main) — de `uitvraag`-componenten op deployment `test`, de zes `logius-fsc*`-componenten op `fsc-logius`. Niet de eenmalige creatie (die doet `upsert-peer.sh`). |
 
 ## Volgorde

--- a/demo/environment/logius/deploy/zad/upsert-peer.sh
+++ b/demo/environment/logius/deploy/zad/upsert-peer.sh
@@ -14,6 +14,10 @@
 # Twee valkuilen die het gedrag van dit script bepalen:
 # - ZAD past component-config (env_vars/aliases) alleen bij COMPONENT-CREATIE toe, niet bij een
 #   re-POST op een bestaande component. Config wijzigen betekent de component eerst in de UI
+# LET OP: `logius-fscbootstrap` staat wel in de deployment-lijst hieronder (anders haalt een upsert hem
+# eruit) maar krijgt hier geen env en geen poorten: zijn env (FSC_ROL=consumer, allowlist) en zijn
+# cert-attachments zijn UI-werk, zie federatie/contracts/zad-runbook.md.
+#
 #   verwijderen en opnieuw applyen — de cert-attachments raak je daarmee kwijt en moeten opnieuw
 #   gemount worden.
 # - `:upsert-deployment` maakt géén NIEUW deployment aan (geeft wel HTTP 202, maar het deployment
@@ -84,6 +88,9 @@ OUTWAY_IMAGE="docker.io/federatedserviceconnectivity/outway:${IMAGE_TAG}"
 INWAY_IMAGE="docker.io/federatedserviceconnectivity/inway:${IMAGE_TAG}"
 TXLOG_IMAGE="${ZAD_TXLOG_IMAGE:-ghcr.io/minbzk/moza-fsc-testnet-txlog-migrate:${TXLOG_TAG}}"
 POSTGRES_IMAGE="${ZAD_POSTGRES_IMAGE:-docker.io/library/postgres:17}"   # self-hosted DB (spiegelt deploy/local)
+# De contract-bootstrap komt uit DEZE repo (build-contract-bootstrap in deploy.yml), niet uit
+# repo A, en volgt dus niet de FSC-versietag.
+BOOTSTRAP_IMAGE="${ZAD_BOOTSTRAP_IMAGE:-ghcr.io/minbzk/fbs-fsc-contract-bootstrap:main}"
 
 # Concrete hostnamen voor déze (vaste) deployment — zowel voor de plan-/apply-output als, direct,
 # voor de inter-component-adressen in de env_vars-blobs. Geen $DEPLOYMENT_NAME-substitutie: de
@@ -265,9 +272,9 @@ component_body() {  # $1=name $2=image $3=ports_json $4=env  [$5=services_json=[
 
 DEPLOY_BODY="$(jq -n --arg d "${DEPLOYMENT}" --arg cf "${CLONE_FROM}" \
   --arg mgr "${MANAGER_IMAGE}" --arg ctl "${CONTROLLER_IMAGE}" --arg outway "${OUTWAY_IMAGE}" \
-  --arg inway "${INWAY_IMAGE}" --arg txlog "${TXLOG_IMAGE}" --arg pg "${POSTGRES_IMAGE}" \
+  --arg inway "${INWAY_IMAGE}" --arg txlog "${TXLOG_IMAGE}" --arg pg "${POSTGRES_IMAGE}" --arg boot "${BOOTSTRAP_IMAGE}" \
   '{deploymentName:$d, domain_format:"component-deployment-project",
-    components:[{reference:"logius-fscpg", image:$pg}, {reference:"logius-fscmgr", image:$mgr}, {reference:"logius-fscctl", image:$ctl}, {reference:"logius-fscoutway", image:$outway}, {reference:"logius-fscinway", image:$inway}, {reference:"logius-fsctxlog", image:$txlog}]}
+    components:[{reference:"logius-fscpg", image:$pg}, {reference:"logius-fscmgr", image:$mgr}, {reference:"logius-fscctl", image:$ctl}, {reference:"logius-fscoutway", image:$outway}, {reference:"logius-fscinway", image:$inway}, {reference:"logius-fsctxlog", image:$txlog}, {reference:"logius-fscbootstrap", image:$boot}]}
    + (if $cf=="" then {} else {cloneFrom:$cf, forceClone:false} end)')"
 
 # Poorten per component (ports[0] = ingress). manager/controller exposen naast de ingress hun interne

--- a/demo/environment/logius/deploy/zad/upsert-peer.sh
+++ b/demo/environment/logius/deploy/zad/upsert-peer.sh
@@ -90,7 +90,10 @@ TXLOG_IMAGE="${ZAD_TXLOG_IMAGE:-ghcr.io/minbzk/moza-fsc-testnet-txlog-migrate:${
 POSTGRES_IMAGE="${ZAD_POSTGRES_IMAGE:-docker.io/library/postgres:17}"   # self-hosted DB (spiegelt deploy/local)
 # De contract-bootstrap komt uit DEZE repo (build-contract-bootstrap in deploy.yml), niet uit
 # repo A, en volgt dus niet de FSC-versietag.
-BOOTSTRAP_IMAGE="${ZAD_BOOTSTRAP_IMAGE:-ghcr.io/minbzk/fbs-fsc-contract-bootstrap:main}"
+# Geen kale `:main`-default: de deploy-workflow pusht uitsluitend `main-<sha7>` en `pr-<n>-<sha7>`,
+# dus `:main` bestaat niet en zou een ImagePullBackOff opleveren tot de eerstvolgende deploy hem
+# overschrijft. Zet de tag expliciet, of laat het component met rust — `deploy.yml` houdt hem bij.
+BOOTSTRAP_IMAGE="${ZAD_BOOTSTRAP_IMAGE:-__ZET_ZAD_BOOTSTRAP_IMAGE__}"
 
 # Concrete hostnamen voor déze (vaste) deployment — zowel voor de plan-/apply-output als, direct,
 # voor de inter-component-adressen in de env_vars-blobs. Geen $DEPLOYMENT_NAME-substitutie: de

--- a/demo/environment/logius/pki/gen-csr.sh
+++ b/demo/environment/logius/pki/gen-csr.sh
@@ -38,7 +38,7 @@ ORG="Logius"
 OIN="00000000000000001000"                                # = subject.serialNumber = Peer ID
 # endpoint:component-korte-naam (de ZAD-component + Service heet `<deployment>-<short>`). Volgorde
 # bepaalt de uitvoer-volgorde; spiegelt de LOG*_SVC-namen in upsert-peer.sh.
-ENDPOINTS=( "manager:logius-fscmgr" "outway:logius-fscoutway" "inway:logius-fscinway" "controller:logius-fscctl" "txlog:logius-fsctxlog" )
+ENDPOINTS=( "manager:logius-fscmgr" "outway:logius-fscoutway" "inway:logius-fscinway" "controller:logius-fscctl" "txlog:logius-fsctxlog" "bootstrap:logius-fscbootstrap" )
 
 # Genereer per endpoint de csr.json. SAN-volgorde: peer-identiteit (alleen manager) ->
 # <endpoint>.<peer>.fsc-test.local -> externe mesh-host -> Service-kortnaam -> Service-FQDN.

--- a/demo/environment/logius/pki/issue.sh
+++ b/demo/environment/logius/pki/issue.sh
@@ -44,12 +44,20 @@ done
 find "${BASE_DIR}/peers" -name csr.json -print0 | while IFS= read -r -d '' CSR; do
   REL="$(dirname "${CSR#"${BASE_DIR}/peers/"}")"   # <peer>/<endpoint>
   PEER="${REL%%/*}"
+  ENDPOINT="${REL##*/}"
   GROUP_OUT="${BASE_DIR}/out/${REL}"
   INT_OUT="${BASE_DIR}/internal/${REL}"
   ICA_DIR="${BASE_DIR}/internal/${PEER}/ca"
 
   # GROUP (extern, group-intermediate). Hecht intermediate aan voor de keten.
-  if [ -s "${GROUP_OUT}/cert.pem" ] && [ -s "${GROUP_OUT}/key.pem" ] && [ "${FORCE}" -eq 0 ]; then
+  #
+  # Niet voor client-only endpoints. Een group-cert is de identiteit waarmee een component zich in
+  # de mesh als deze peer voordoet; wie hem niet nodig heeft, hoort hem ook niet te krijgen. De
+  # contract-bootstrap praat alleen met de interne manager-API van zijn eigen peer en bedient zelf
+  # geen TLS, dus hij komt met het internal-cert hieronder toe.
+  if [ "${ENDPOINT}" = bootstrap ]; then
+    echo "skip group ${REL} (client-only endpoint)"
+  elif [ -s "${GROUP_OUT}/cert.pem" ] && [ -s "${GROUP_OUT}/key.pem" ] && [ "${FORCE}" -eq 0 ]; then
     echo "skip group ${REL} (geen -f)"
   else
     mkdir -p "${GROUP_OUT}"

--- a/demo/environment/logius/pki/peers/logius/bootstrap/csr.json
+++ b/demo/environment/logius/pki/peers/logius/bootstrap/csr.json
@@ -1,0 +1,20 @@
+{
+  "CN": "bootstrap.logius.fsc-test.local",
+  "key": {
+    "algo": "rsa",
+    "size": 4096
+  },
+  "hosts": [
+    "bootstrap.logius.fsc-test.local",
+    "logius-fscbootstrap-fsc-logius-mpfb-8wh.rig.prd1.gn2.quattro.rijksapps.nl",
+    "fsc-logius-logius-fscbootstrap",
+    "fsc-logius-logius-fscbootstrap.rig-prd-mpfb-8wh.svc.cluster.local"
+  ],
+  "serialnumber": "00000000000000001000",
+  "names": [
+    {
+      "O": "Logius",
+      "C": "NL"
+    }
+  ]
+}

--- a/demo/environment/logius/pki/zad-bundle.sh
+++ b/demo/environment/logius/pki/zad-bundle.sh
@@ -22,6 +22,10 @@ env_for() {
     out/*/cert.pem)         echo "TLS_GROUP_CERT (+ TLS_GROUP_TOKEN_CERT, TLS_GROUP_CONTRACT_CERT)" ;;
     out/*/key.pem)          echo "TLS_GROUP_KEY (+ TLS_GROUP_TOKEN_KEY, TLS_GROUP_CONTRACT_KEY)" ;;
     internal/*/ca/root.pem) echo "TLS_ROOT_CERT (+ TLS_INTERNAL_UNAUTHENTICATED_ROOT_CERT)" ;;
+    # Vóór de algemene internal-regels: het bootstrap-component is geen FSC-binary en leest geen
+    # TLS_*-variabelen, maar gebruikt hetzelfde internal-cert als client naar de manager-API.
+    internal/*/bootstrap/cert.pem) echo "FSC_{CONSUMER,PROVIDER}_CERT (client-cert contract-bootstrap)" ;;
+    internal/*/bootstrap/key.pem)  echo "FSC_{CONSUMER,PROVIDER}_KEY" ;;
     internal/*/cert.pem)    echo "TLS_CERT (+ TLS_INTERNAL_UNAUTHENTICATED_CERT)" ;;
     internal/*/key.pem)     echo "TLS_KEY (+ TLS_INTERNAL_UNAUTHENTICATED_KEY)" ;;
     *)                      echo "?" ;;

--- a/demo/environment/magazijn-a/deploy/zad/README.md
+++ b/demo/environment/magazijn-a/deploy/zad/README.md
@@ -44,7 +44,7 @@ ingress-URL — `ZAD_MAGAZIJNA_DEPLOYMENT` (default `test`) bepaalt welke, zie
 | `cert-manifest.md` | Runbook: welk cert-bestand op welk `/etc/fsc/...`-pad, per component (UI-only bijlagen). |
 | `verify-zad.md` | Runbook: announce/publiceren/discover ná een geslaagde apply, + de acceptatiecriteria. |
 | `../../../federatie/contracts/zad-runbook.md` | Runbook: het contract-bootstrap-component (`magazijna-fscbootstrap`, rol provider) neerzetten — env, cert-attachments, verificatie. |
-| `../../../../../.github/workflows/deploy.yml` (root) | `deploy-test-magazijnen`-job: de DOORLOPENDE image-tag-updates (elke push naar main). Twee stappen — `magazijna`/`magazijnb` op deployment `test`, de vijf `magazijna-fsc*`-componenten op `fsc-magazijna`. Niet de eenmalige creatie (die doet `upsert-peer.sh`). |
+| `../../../../../.github/workflows/deploy.yml` (root) | `deploy-test-magazijnen`-job: de DOORLOPENDE image-tag-updates (elke push naar main). Twee stappen — `magazijna`/`magazijnb` op deployment `test`, de zes `magazijna-fsc*`-componenten op `fsc-magazijna`. Niet de eenmalige creatie (die doet `upsert-peer.sh`). |
 
 ## Volgorde
 

--- a/demo/environment/magazijn-a/deploy/zad/README.md
+++ b/demo/environment/magazijn-a/deploy/zad/README.md
@@ -43,6 +43,7 @@ ingress-URL — `ZAD_MAGAZIJNA_DEPLOYMENT` (default `test`) bepaalt welke, zie
 | `upsert-peer.sh` | `validate`/`plan`/`apply` tegen de ZAD v2 Operations Manager API — lokaal/handmatig hulpmiddel voor de eenmalige component-creatie (env/ports/certs) en voor debugging. |
 | `cert-manifest.md` | Runbook: welk cert-bestand op welk `/etc/fsc/...`-pad, per component (UI-only bijlagen). |
 | `verify-zad.md` | Runbook: announce/publiceren/discover ná een geslaagde apply, + de acceptatiecriteria. |
+| `../../../federatie/contracts/zad-runbook.md` | Runbook: het contract-bootstrap-component (`magazijna-fscbootstrap`, rol provider) neerzetten — env, cert-attachments, verificatie. |
 | `../../../../../.github/workflows/deploy.yml` (root) | `deploy-test-magazijnen`-job: de DOORLOPENDE image-tag-updates (elke push naar main). Twee stappen — `magazijna`/`magazijnb` op deployment `test`, de vijf `magazijna-fsc*`-componenten op `fsc-magazijna`. Niet de eenmalige creatie (die doet `upsert-peer.sh`). |
 
 ## Volgorde

--- a/demo/environment/magazijn-a/deploy/zad/upsert-peer.sh
+++ b/demo/environment/magazijn-a/deploy/zad/upsert-peer.sh
@@ -27,6 +27,10 @@
 #   ./deploy/zad/upsert-peer.sh validate                          # read-only auth-check
 #   ./deploy/zad/upsert-peer.sh plan   [deployment] [tag]         # toont bodies, muteert niet
 #   ./deploy/zad/upsert-peer.sh apply  [deployment] [tag]         # muteert + pollt tasks
+# LET OP: `magazijna-fscbootstrap` staat wel in de deployment-lijst hieronder (anders haalt een
+# upsert hem eruit) maar krijgt hier geen env en geen poorten: zijn env (FSC_ROL=provider, de
+# allowlist) en zijn cert-attachments zijn UI-werk, zie federatie/contracts/zad-runbook.md.
+
 set -euo pipefail
 
 MODE="${1:?usage: upsert-peer.sh <validate|plan|apply> [deployment=fsc-magazijna] [tag=v2.5.2]}"
@@ -80,6 +84,9 @@ CONTROLLER_IMAGE="${ZAD_CONTROLLER_IMAGE:-ghcr.io/minbzk/moza-fsc-testnet-contro
 INWAY_IMAGE="docker.io/federatedserviceconnectivity/inway:${IMAGE_TAG}"
 TXLOG_IMAGE="${ZAD_TXLOG_IMAGE:-ghcr.io/minbzk/moza-fsc-testnet-txlog-migrate:${TXLOG_TAG}}"
 POSTGRES_IMAGE="${ZAD_POSTGRES_IMAGE:-docker.io/library/postgres:17}"   # self-hosted DB (spiegelt deploy/local)
+# De contract-bootstrap komt uit DEZE repo (build-contract-bootstrap in deploy.yml), niet uit
+# repo A, en volgt dus niet de FSC-versietag.
+BOOTSTRAP_IMAGE="${ZAD_BOOTSTRAP_IMAGE:-ghcr.io/minbzk/fbs-fsc-contract-bootstrap:main}"
 
 # Concrete hostnamen voor déze (vaste) deployment — zowel voor de plan-/apply-output als, direct,
 # voor de inter-component-adressen in de env_vars-blobs. Geen $DEPLOYMENT_NAME-substitutie: de
@@ -238,9 +245,9 @@ component_body() {  # $1=name $2=image $3=ports_json $4=env  [$5=services_json=[
 
 DEPLOY_BODY="$(jq -n --arg d "${DEPLOYMENT}" --arg cf "${CLONE_FROM}" \
   --arg mgr "${MANAGER_IMAGE}" --arg ctl "${CONTROLLER_IMAGE}" --arg inway "${INWAY_IMAGE}" \
-  --arg txlog "${TXLOG_IMAGE}" --arg pg "${POSTGRES_IMAGE}" \
+  --arg txlog "${TXLOG_IMAGE}" --arg pg "${POSTGRES_IMAGE}" --arg boot "${BOOTSTRAP_IMAGE}" \
   '{deploymentName:$d, domain_format:"component-deployment-project",
-    components:[{reference:"magazijna-fscpg", image:$pg}, {reference:"magazijna-fscmgr", image:$mgr}, {reference:"magazijna-fscctl", image:$ctl}, {reference:"magazijna-fscinway", image:$inway}, {reference:"magazijna-fsctxlog", image:$txlog}]}
+    components:[{reference:"magazijna-fscpg", image:$pg}, {reference:"magazijna-fscmgr", image:$mgr}, {reference:"magazijna-fscctl", image:$ctl}, {reference:"magazijna-fscinway", image:$inway}, {reference:"magazijna-fsctxlog", image:$txlog}, {reference:"magazijna-fscbootstrap", image:$boot}]}
    + (if $cf=="" then {} else {cloneFrom:$cf, forceClone:false} end)')"
 
 # Poorten per component (ports[0] = ingress). manager/controller exposen naast de ingress hun interne

--- a/demo/environment/magazijn-a/deploy/zad/upsert-peer.sh
+++ b/demo/environment/magazijn-a/deploy/zad/upsert-peer.sh
@@ -86,7 +86,10 @@ TXLOG_IMAGE="${ZAD_TXLOG_IMAGE:-ghcr.io/minbzk/moza-fsc-testnet-txlog-migrate:${
 POSTGRES_IMAGE="${ZAD_POSTGRES_IMAGE:-docker.io/library/postgres:17}"   # self-hosted DB (spiegelt deploy/local)
 # De contract-bootstrap komt uit DEZE repo (build-contract-bootstrap in deploy.yml), niet uit
 # repo A, en volgt dus niet de FSC-versietag.
-BOOTSTRAP_IMAGE="${ZAD_BOOTSTRAP_IMAGE:-ghcr.io/minbzk/fbs-fsc-contract-bootstrap:main}"
+# Geen kale `:main`-default: de deploy-workflow pusht uitsluitend `main-<sha7>` en `pr-<n>-<sha7>`,
+# dus `:main` bestaat niet en zou een ImagePullBackOff opleveren tot de eerstvolgende deploy hem
+# overschrijft. Zet de tag expliciet, of laat het component met rust — `deploy.yml` houdt hem bij.
+BOOTSTRAP_IMAGE="${ZAD_BOOTSTRAP_IMAGE:-__ZET_ZAD_BOOTSTRAP_IMAGE__}"
 
 # Concrete hostnamen voor déze (vaste) deployment — zowel voor de plan-/apply-output als, direct,
 # voor de inter-component-adressen in de env_vars-blobs. Geen $DEPLOYMENT_NAME-substitutie: de

--- a/demo/environment/magazijn-a/pki/gen-csr.sh
+++ b/demo/environment/magazijn-a/pki/gen-csr.sh
@@ -34,7 +34,7 @@ PEER="magazijn-a"
 OIN="00000000000000100000"                                # = subject.serialNumber = Peer ID
 # endpoint:component-korte-naam (de ZAD-component + Service heet `<deployment>-<short>`). Volgorde
 # bepaalt de uitvoer-volgorde; spiegelt de MGZ*_SVC-namen in upsert-peer.sh.
-ENDPOINTS=( "manager:magazijna-fscmgr" "controller:magazijna-fscctl" "inway:magazijna-fscinway" "txlog:magazijna-fsctxlog" )
+ENDPOINTS=( "manager:magazijna-fscmgr" "controller:magazijna-fscctl" "inway:magazijna-fscinway" "txlog:magazijna-fsctxlog" "bootstrap:magazijna-fscbootstrap" )
 
 # Genereer per endpoint de csr.json. SAN-volgorde: peer-identiteit (alleen manager) ->
 # <endpoint>.<peer>.fsc-test.local -> externe mesh-host -> Service-kortnaam -> Service-FQDN.

--- a/demo/environment/magazijn-a/pki/issue.sh
+++ b/demo/environment/magazijn-a/pki/issue.sh
@@ -44,12 +44,20 @@ done
 find "${BASE_DIR}/peers" -name csr.json -print0 | while IFS= read -r -d '' CSR; do
   REL="$(dirname "${CSR#"${BASE_DIR}/peers/"}")"   # <peer>/<endpoint>
   PEER="${REL%%/*}"
+  ENDPOINT="${REL##*/}"
   GROUP_OUT="${BASE_DIR}/out/${REL}"
   INT_OUT="${BASE_DIR}/internal/${REL}"
   ICA_DIR="${BASE_DIR}/internal/${PEER}/ca"
 
   # GROUP (extern, group-intermediate). Hecht intermediate aan voor de keten.
-  if [ -s "${GROUP_OUT}/cert.pem" ] && [ -s "${GROUP_OUT}/key.pem" ] && [ "${FORCE}" -eq 0 ]; then
+  #
+  # Niet voor client-only endpoints. Een group-cert is de identiteit waarmee een component zich in
+  # de mesh als deze peer voordoet; wie hem niet nodig heeft, hoort hem ook niet te krijgen. De
+  # contract-bootstrap praat alleen met de interne manager-API van zijn eigen peer en bedient zelf
+  # geen TLS, dus hij komt met het internal-cert hieronder toe.
+  if [ "${ENDPOINT}" = bootstrap ]; then
+    echo "skip group ${REL} (client-only endpoint)"
+  elif [ -s "${GROUP_OUT}/cert.pem" ] && [ -s "${GROUP_OUT}/key.pem" ] && [ "${FORCE}" -eq 0 ]; then
     echo "skip group ${REL} (geen -f)"
   else
     mkdir -p "${GROUP_OUT}"

--- a/demo/environment/magazijn-a/pki/peers/magazijn-a/bootstrap/csr.json
+++ b/demo/environment/magazijn-a/pki/peers/magazijn-a/bootstrap/csr.json
@@ -1,0 +1,20 @@
+{
+  "CN": "bootstrap.magazijn-a.fsc-test.local",
+  "key": {
+    "algo": "rsa",
+    "size": 4096
+  },
+  "hosts": [
+    "bootstrap.magazijn-a.fsc-test.local",
+    "magazijna-fscbootstrap-fsc-magazijna-mpfm-w3h.rig.prd1.gn2.quattro.rijksapps.nl",
+    "fsc-magazijna-magazijna-fscbootstrap",
+    "fsc-magazijna-magazijna-fscbootstrap.rig-prd-mpfm-w3h.svc.cluster.local"
+  ],
+  "serialnumber": "00000000000000100000",
+  "names": [
+    {
+      "O": "magazijn-a",
+      "C": "NL"
+    }
+  ]
+}

--- a/demo/environment/magazijn-a/pki/zad-bundle.sh
+++ b/demo/environment/magazijn-a/pki/zad-bundle.sh
@@ -22,6 +22,10 @@ env_for() {
     out/*/cert.pem)         echo "TLS_GROUP_CERT (+ TLS_GROUP_TOKEN_CERT, TLS_GROUP_CONTRACT_CERT)" ;;
     out/*/key.pem)          echo "TLS_GROUP_KEY (+ TLS_GROUP_TOKEN_KEY, TLS_GROUP_CONTRACT_KEY)" ;;
     internal/*/ca/root.pem) echo "TLS_ROOT_CERT (+ TLS_INTERNAL_UNAUTHENTICATED_ROOT_CERT)" ;;
+    # Vóór de algemene internal-regels: het bootstrap-component is geen FSC-binary en leest geen
+    # TLS_*-variabelen, maar gebruikt hetzelfde internal-cert als client naar de manager-API.
+    internal/*/bootstrap/cert.pem) echo "FSC_{CONSUMER,PROVIDER}_CERT (client-cert contract-bootstrap)" ;;
+    internal/*/bootstrap/key.pem)  echo "FSC_{CONSUMER,PROVIDER}_KEY" ;;
     internal/*/cert.pem)    echo "TLS_CERT (+ TLS_INTERNAL_UNAUTHENTICATED_CERT)" ;;
     internal/*/key.pem)     echo "TLS_KEY (+ TLS_INTERNAL_UNAUTHENTICATED_KEY)" ;;
     *)                      echo "?" ;;

--- a/docs/plans/2026-08-15-contract-bootstrap-zad-gesplitst.md
+++ b/docs/plans/2026-08-15-contract-bootstrap-zad-gesplitst.md
@@ -1,0 +1,168 @@
+# Contract-bootstrap op ZAD: gesplitst per peer
+
+**Status:** Concept
+
+## Context
+
+De contract-bootstrap uit #200 zet lokaal één wederzijds ondertekend
+`ServiceConnectionGrant`-contract op tussen de uitvraag-peer (consumer) en elk magazijn
+(provider). Eén script praat daarbij met **twee** managers: het POST bij de consumer en
+accepteert bij de provider.
+
+Op ZAD kan dat niet. Elk deployment krijgt een gerenderde
+`<deployment>-tenant-baseline-network-policy` met `podSelector: {deployment: <naam>}`:
+
+- **ingress** alleen van pods met hetzelfde `deployment`-label, de `rig`-ingresscontroller,
+  `rig-prd-operations` en `rig-prd-backup`;
+- **egress** alleen naar kube-dns, hetzelfde deployment, die twee namespaces,
+  `<project>-infrastructure`, en `0.0.0.0/0` beperkt tot TCP 443/80.
+
+De isolatie loopt dus per **deployment**, niet per project. Daar komt bij dat de
+manager-internal-API (`:9443` authenticated, `:9444` unauthenticated) géén route heeft — de
+ingress publiceert alleen backend-poort `:8443`, de mesh-poort met `ssl-passthrough`. De twee
+peers zitten bovendien in aparte namespaces (`rig-prd-mpfb-8wh` / `rig-prd-mpfm-w3h`).
+
+Eén proces dat beide managers aanspreekt bestaat op ZAD dus niet, en er is geen configuratie
+die dat oplost: netwerkpolicies zijn op ZAD niet aanpasbaar.
+
+## Gewenst resultaat
+
+Elke peer bootstrapt zijn eigen kant tegen zijn **eigen** manager. Het contract kruist via de
+FSC-mesh, precies de weg die de managers al gebruiken. De contract-API van geen enkele peer
+wordt daarvoor van buiten bereikbaar gemaakt.
+
+## Rolverdeling
+
+De bestaande stroom valt uiteen langs de manager-grens:
+
+| Stap | Manager | Rol na de splitsing |
+|------|---------|---------------------|
+| Outway-thumbprint berekenen | — (lokaal bestand) | consumer |
+| Bestaat er al een geldig contract? | provider | **verhuist naar consumer** (zie hieronder) |
+| `POST /v1/contracts` | consumer | consumer |
+| Wachten tot het contract bij de provider staat | provider | provider (pollt zijn eigen lijst) |
+| `PUT /v1/contracts/{hash}/accept` | provider | provider |
+| Her-distributie van de accept-handtekening forceren | provider | provider |
+| Wachten tot de consumer het contract geldig ziet | consumer | consumer |
+
+De twee helften coördineren niet met elkaar; ze convergeren. De consumer dient in en wacht;
+de provider ziet het contract via de mesh binnenkomen en tekent. Beide draaien herhaald, dus
+de volgorde waarin ze starten doet er niet toe.
+
+**De existence-check verhuist naar de consumer-kant.** Nu draait hij tegen de contractenlijst
+van de provider. Dat kan straks niet meer, en het hoeft ook niet: hetzelfde contract staat na
+de mesh-sync op beide managers. De consumer is bovendien de juiste kant om het aan af te
+lezen — daar haalt de outway zijn grant vandaan.
+
+Wel verandert de betekenis van een randgeval. Bij de provider zag de check alleen contracten
+die de mesh gehaald hadden; bij de consumer telt ook een contract dat net is ingediend en nog
+nergens anders bestaat. De matcher filtert daarom op geldige, niet-ingetrokken contracten —
+een net ingediend, nog niet geaccepteerd contract is niet `valid` en telt dus niet mee als
+"bestaat al". Dat is precies het gedrag dat we willen: anders zou een gestrande indiening
+elke volgende run laten denken dat het werk gedaan is.
+
+## De provider tekent niet blind
+
+Nu is de accept een gerichte handeling: het script weet welk hash het zelf net heeft laten
+indienen. Na de splitsing kent de provider dat hash niet — hij vindt een contract in zijn
+lijst en moet zelf besluiten of hij tekent. Dat is een autorisatiebesluit, en de peer die het
+contract aanbiedt bepaalt de inhoud ervan.
+
+Een contract draagt een **lijst** grants. Alleen kijken of er een grant in zit die ons bevalt
+is daarom niet genoeg: een tegenpartij kan een tweede grant meesturen die we per ongeluk
+mee-ondertekenen. De regel is dus dat het contract als geheel moet kloppen.
+
+De provider tekent een contract alleen als **alle** volgende dingen gelden:
+
+1. het contract draagt **precies één** grant;
+2. die grant is van type `GRANT_TYPE_SERVICE_CONNECTION`;
+3. `grant.service.peer_id` is de **eigen** OIN;
+4. `grant.service.name` staat in de lijst diensten die deze peer aanbiedt;
+5. `grant.outway.peer_id` staat in de lijst toegestane consumer-OIN's;
+6. het contract is nog niet door ons getekend en niet ingetrokken.
+
+Faalt er één, dan laat de provider het contract met rust en meldt dat. Niet-tekenen is de
+veilige uitkomst: zonder handtekening werkt het contract niet.
+
+De thumbprint in de grant wordt **niet** getoetst. De provider kan hem niet onafhankelijk
+verifiëren — hij heeft het outway-cert van de consumer niet — en hij hoeft dat ook niet: de
+thumbprint zegt welke outway van díé consumer de dienst mag afnemen, en welke dat zijn is aan
+de consumer. Wat de provider bewaakt is dat het om zijn eigen dienst gaat en om een consumer
+die hij kent.
+
+## Idempotentie
+
+Blijft state-loos, op dezelfde grond als in #200: het bestaan van een contract wordt afgeleid
+uit de contracten zelf.
+
+- **Consumer:** service + provider-OIN + eigen OIN + thumbprint samen zijn de identiteit.
+  Bestaat er een geldig contract voor die combinatie, dan is er niets te doen. Bij meer dan
+  één trekt hij de overtollige in en houdt het gesorteerd-eerste hash aan — stabiel over runs.
+- **Provider:** tekent alleen wat nog niet getekend is. Een tweede ronde vindt niets meer.
+
+Beide helften draaien op ZAD in een lus. Herhaling is dus geen randgeval maar de normale
+werking, en dat is precies waarom de idempotentie niet op een state-bestand mag leunen.
+
+## Lokaal hetzelfde pad
+
+`bootstrap.sh` wordt de lokale orkestrator: hij draait de consumer-helft en daarna de
+provider-helft, elk met **alleen** de env van zijn eigen kant. De gedeelde stappen verhuizen
+naar `lib/fsc-contract.sh`.
+
+Dat is niet alleen ontdubbeling. Het lokale pad draait daarmee exact de code die op ZAD
+draait, dus de bestaande federatie-smoke toetst de gesplitste implementatie in plaats van een
+variant ervan. Zonder dat zou de ZAD-code alleen op ZAD bewezen kunnen worden, en daar is de
+terugkoppeling traag.
+
+De scheiding wordt afgedwongen door constructie: elke helft krijgt alleen de variabelen van
+zijn eigen kant. Een aanroep naar de overkant kan niet per ongeluk blijven staan — er is geen
+adres, cert of CA voor.
+
+## ZAD-bedrading
+
+**Vorm.** ZAD kent alleen langlopende componenten en staat geen component-args toe. De
+bootstrap wordt dus een component met een eigen image, waarvan het entrypoint de rol uit env
+leest, de lus draait en daarna blijft draaien. Een herstart is onschadelijk: de eerste ronde
+constateert dan dat het werk al gedaan is.
+
+**Image.** `fbs-fsc-contract-bootstrap`, gebouwd uit de contracts-directory: een kleine basis
+plus `bash`, `curl`, `jq` en `openssl` — dezelfde afhankelijkheden die de scripts lokaal ook
+hebben. Gebouwd en gepusht door dezelfde job-vorm als `fbs-externe-stubs`.
+
+**Componenten.** Eén per peer, in de deployment van die peer, zodat de
+NetworkPolicy-voorwaarde "zelfde `deployment`-label" geldt:
+
+| Deployment | Component | Rol |
+|------------|-----------|-----|
+| `fsc-logius` (`mpfb-8wh`) | `logius-fscbootstrap` | consumer |
+| `fsc-magazijna` (`mpfm-w3h`) | `magazijna-fscbootstrap` | provider |
+
+**Client-cert.** De internal-API op `:9443` is mTLS. De component krijgt een eigen
+internal-cert (`bootstrap`) uit `pki/issue.sh`, niet het cert van een andere component: wie
+een cert deelt, deelt een identiteit, en dan is in het txlog niet meer te zien wie wat deed.
+
+**Thumbprint.** De consumer-helft heeft de thumbprint van zijn outway nodig. Op ZAD komt die
+uit env in plaats van uit een bestand, zodat het outway-group-cert niet aan een tweede
+component hoeft te hangen. De waarde is stabiel zolang het sleutelpaar dat is; bij rotatie
+binnen hetzelfde sleutelpaar verandert hij niet. Het runbook zegt hoe je hem berekent.
+
+**Handwerk dat blijft.** Cert-attachments zijn UI-only — de v2-API kloont ze niet — dus de
+eenmalige creatie van beide componenten en het koppelen van de certs gaat via het runbook,
+zoals bij de bestaande peer-componenten. `deploy.yml` doet daarna alleen tag-updates.
+
+## Wat hier niet in zit
+
+Het datapad van de app naar de outway. Dat loopt op ZAD tegen dezelfde deployment-isolatie
+aan, maar heeft de mesh niet als uitweg: de uitvraag moet er buitenlangs, via de publieke
+outway-route, en die is als enige van de drie niet `ssl-passthrough` maar edge-terminated.
+Dat vraagt een eigen afweging en een eigen issue.
+
+## Verificatie
+
+- De federatie-smoke blijft groen: één contract, wederzijds geldig, herhaalde run levert geen
+  tweede op.
+- Een smoke op de splitsing: elke helft raakt alleen zijn eigen manager aan, en de twee samen
+  convergeren ongeacht de volgorde waarin ze draaien.
+- Weiger-gevallen op de autorisatie-invariant: een contract met twee grants, met een vreemde
+  dienst, met een onbekende consumer-OIN en met een vreemde provider-OIN wordt niet getekend.
+- De ZAD-kant is pas na een deploy-ronde bewezen; tot dan draagt het runbook de stappen.

--- a/docs/plans/2026-08-15-contract-bootstrap-zad-gesplitst.md
+++ b/docs/plans/2026-08-15-contract-bootstrap-zad-gesplitst.md
@@ -1,6 +1,6 @@
 # Contract-bootstrap op ZAD: gesplitst per peer
 
-**Status:** Concept
+**Status:** Uitgevoerd
 
 ## Context
 
@@ -40,7 +40,7 @@ De bestaande stroom valt uiteen langs de manager-grens:
 | Outway-thumbprint berekenen | — (lokaal bestand) | consumer |
 | Bestaat er al een geldig contract? | provider | **verhuist naar consumer** (zie hieronder) |
 | `POST /v1/contracts` | consumer | consumer |
-| Wachten tot het contract bij de provider staat | provider | provider (pollt zijn eigen lijst) |
+| Wachten tot het contract bij de provider staat | provider | vervalt — de provider-helft kijkt bij elke aanroep één keer in zijn eigen lijst; het herhalen zit in de aanroeper |
 | `PUT /v1/contracts/{hash}/accept` | provider | provider |
 | Her-distributie van de accept-handtekening forceren | provider | provider |
 | Wachten tot de consumer het contract geldig ziet | consumer | consumer |
@@ -54,12 +54,12 @@ van de provider. Dat kan straks niet meer, en het hoeft ook niet: hetzelfde cont
 de mesh-sync op beide managers. De consumer is bovendien de juiste kant om het aan af te
 lezen — daar haalt de outway zijn grant vandaan.
 
-Wel verandert de betekenis van een randgeval. Bij de provider zag de check alleen contracten
-die de mesh gehaald hadden; bij de consumer telt ook een contract dat net is ingediend en nog
-nergens anders bestaat. De matcher filtert daarom op geldige, niet-ingetrokken contracten —
-een net ingediend, nog niet geaccepteerd contract is niet `valid` en telt dus niet mee als
-"bestaat al". Dat is precies het gedrag dat we willen: anders zou een gestrande indiening
-elke volgende run laten denken dat het werk gedaan is.
+Wel verandert de betekenis van een randgeval. Bij de provider zag de check alleen contracten die
+de mesh gehaald hadden; bij de consumer telt ook een contract dat net is ingediend en nog nergens
+anders bestaat. De matcher geeft die bewust wél terug, met hun state erbij. Alleen op "geldig"
+filteren zou hier averechts werken: in de gesplitste opzet zit er tijd tussen indienen en tekenen,
+en in dat gat zou elke ronde er nóg een contract bij posten. De consumer-helft leest de state dus
+zelf: geldig én door de provider getekend is klaar, alles daartussen is wachten.
 
 ## De provider tekent niet blind
 
@@ -74,21 +74,35 @@ mee-ondertekenen. De regel is dus dat het contract als geheel moet kloppen.
 
 De provider tekent een contract alleen als **alle** volgende dingen gelden:
 
-1. het contract draagt **precies één** grant;
-2. die grant is van type `GRANT_TYPE_SERVICE_CONNECTION`;
-3. `grant.service.peer_id` is de **eigen** OIN;
-4. `grant.service.name` staat in de lijst diensten die deze peer aanbiedt;
-5. `grant.outway.peer_id` staat in de lijst toegestane consumer-OIN's;
-6. het contract is nog niet door ons getekend en niet ingetrokken.
+1. het contract hoort bij onze eigen group;
+2. het gebruikt het afgesproken hash-algoritme — dat bindt de content aan de handtekening;
+3. het draagt een geldigheidsduur, en die blijft onder een bovengrens;
+4. het draagt **precies één** grant;
+5. die grant is van type `GRANT_TYPE_SERVICE_CONNECTION`;
+6. `grant.service.peer_id` is de **eigen** OIN;
+7. `grant.service.name` staat in de lijst diensten die deze peer aanbiedt;
+8. de outway wordt geïdentificeerd op public-key-thumbprint en niet op domeinnaam;
+9. `grant.outway.peer_id` staat in de lijst toegestane consumer-OIN's;
+10. het contract is nog niet door ons getekend en niet ingetrokken.
 
 Faalt er één, dan laat de provider het contract met rust en meldt dat. Niet-tekenen is de
 veilige uitkomst: zonder handtekening werkt het contract niet.
 
-De thumbprint in de grant wordt **niet** getoetst. De provider kan hem niet onafhankelijk
-verifiëren — hij heeft het outway-cert van de consumer niet — en hij hoeft dat ook niet: de
-thumbprint zegt welke outway van díé consumer de dienst mag afnemen, en welke dat zijn is aan
-de consumer. Wat de provider bewaakt is dat het om zijn eigen dienst gaat en om een consumer
-die hij kent.
+De punten 1 tot en met 3 gaan niet over de grant maar over het contract eromheen. Zonder die
+drie bepaalt de allowlist wel *wie* er mag afnemen, maar bepaalt de tegenpartij in zijn eentje
+*hoe lang* en onder welke voorwaarden.
+
+De **waarde** van de thumbprint wordt niet getoetst, het **type** wel (punt 8). De waarde kan de
+provider niet onafhankelijk verifiëren — hij heeft het outway-cert van de consumer niet — en dat
+hoeft ook niet: die wordt aan zijn eigen kant cryptografisch afgedwongen op een later moment. De
+outway haalt zijn token bij de manager van de provider, die de presentatie tegen de thumbprint in
+de grant houdt, en de inway verifieert `cnf.x5t#S256` tegen het verbindingscertificaat.
+
+Twee dingen zijn geen eigenschap van het contract maar van de verwerking, en horen er toch bij.
+Elke waarde uit het contract komt van de tegenpartij en gaat een regelgebaseerde stroom in; een
+newline in een dienstnaam zou daar een tweede record schrijven dat de aanroeper als eigen regel
+leest, en zo de hele toets omzeilen. Stuurtekens worden daarom vervangen. En een hash of OIN uit
+die stroom gaat een URL-pad in, dus de vorm ervan wordt gecontroleerd voordat er een call op volgt.
 
 ## Idempotentie
 
@@ -114,9 +128,11 @@ draait, dus de bestaande federatie-smoke toetst de gesplitste implementatie in p
 variant ervan. Zonder dat zou de ZAD-code alleen op ZAD bewezen kunnen worden, en daar is de
 terugkoppeling traag.
 
-De scheiding wordt afgedwongen door constructie: elke helft krijgt alleen de variabelen van
-zijn eigen kant. Een aanroep naar de overkant kan niet per ongeluk blijven staan — er is geen
-adres, cert of CA voor.
+De scheiding wordt afgedwongen en niet alleen afgesproken: elke helft start met `env -u` op de
+adres- en certificaatvariabelen van de overkant. Een aanroep naar de overkant kan daardoor niet
+per ongeluk blijven staan — er is geen adres, cert of CA voor. Het is een denylist, dus een
+nieuwe variabele van de overkant moet er expliciet bij; de fixture-test bewaakt dat geen van
+beide helften de namen van de overkant noemt.
 
 ## ZAD-bedrading
 
@@ -125,9 +141,10 @@ bootstrap wordt dus een component met een eigen image, waarvan het entrypoint de
 leest, de lus draait en daarna blijft draaien. Een herstart is onschadelijk: de eerste ronde
 constateert dan dat het werk al gedaan is.
 
-**Image.** `fbs-fsc-contract-bootstrap`, gebouwd uit de contracts-directory: een kleine basis
-plus `bash`, `curl`, `jq` en `openssl` — dezelfde afhankelijkheden die de scripts lokaal ook
-hebben. Gebouwd en gepusht door dezelfde job-vorm als `fbs-externe-stubs`.
+**Image.** `fbs-fsc-contract-bootstrap`: een kleine basis plus `bash`, `curl`, `jq` en `openssl` —
+dezelfde afhankelijkheden die de scripts lokaal ook hebben. De build-context is
+`demo/environment/` en niet de contracts-map zelf, want de scripts leunen op `../../lib`. Gebouwd
+en gepusht door dezelfde job-vorm als `fbs-externe-stubs`.
 
 **Componenten.** Eén per peer, in de deployment van die peer, zodat de
 NetworkPolicy-voorwaarde "zelfde `deployment`-label" geldt:


### PR DESCRIPTION
> **Gestapeld op #200** (contract uitvraag↔magazijn, waar #206 inmiddels in zit). Hertargeten op
> `main` zodra die gemerged is. Vierde van vier: A federatie-harness (#197) → B contract (#200) →
> C lokale keten (#206) → **D deze**.

## Aanleiding

#200 zet lokaal één wederzijds ondertekend `ServiceConnectionGrant`-contract op. Eén script praat
daarbij met **twee** managers: het POST bij de consumer en accepteert bij de provider. Op ZAD kan
dat niet, en dat is niet met configuratie op te lossen.

Uitgezocht op de gerenderde GitOps-manifests: elk deployment krijgt een
`<deployment>-tenant-baseline-network-policy` met `podSelector: {deployment: <naam>}`. Ingress komt
alleen van pods met hetzelfde `deployment`-label, de `rig`-ingresscontroller, `rig-prd-operations`
en `rig-prd-backup`; egress gaat alleen naar kube-dns, hetzelfde deployment, die twee namespaces,
`<project>-infrastructure`, en `0.0.0.0/0` beperkt tot TCP 443/80. De isolatie loopt dus per
**deployment**, niet per project. Daar komt bij dat de manager-internal-API (`:9443`, `:9444`) geen
route heeft — de ingress publiceert alleen `:8443`, de mesh-poort.

## De kern: twee helften, elk één manager

De consumer-helft dient in bij zijn eigen manager en stelt vast dat het contract geldig wordt. De
provider-helft tekent wat er via de mesh binnenkomt. Ze coördineren niet, ze convergeren — wie van
de twee als eerste draait doet er niet toe.

Dat is geen concessie. Het contract kruist via de weg die de managers onderling toch al gebruiken,
en de contract-API van elke peer blijft onbereikbaar van buiten. De ingress-uitweg die #206 voor het
datapad nodig heeft, heeft D1 dus niet.

`bootstrap.sh` blijft de lokale aanroeper van diezelfde twee helften — geen aparte, eenvoudigere
variant. Wat lokaal getoetst wordt, is de code die op ZAD draait. De scheiding wordt afgedwongen en
niet alleen afgesproken: elke helft start met `env -u` op de adres- en certificaat-variabelen van de
overkant, dus een teruggeslopen call naar de overkant faalt hier en niet pas op ZAD.

## De provider tekent niet blind

Vóór de splitsing was de accept een gerichte handeling: het script kende het hash dat het zelf net
had ingediend. Nu vindt de provider een contract in zijn lijst en moet hij zelf besluiten of hij
tekent — een autorisatiebesluit, waarbij de inhoud van het contract van de tegenpartij komt.

Een contract draagt een **lijst** grants. Toetsen of er een grant in zit die ons bevalt is daarom
niet genoeg: wie een tweede grant meestuurt, krijgt die anders mee-ondertekend. De eis is dus
"precies één grant, en die klopt". Verder: type `GRANT_TYPE_SERVICE_CONNECTION`, `service.peer_id`
is de eigen OIN, de dienstnaam staat in `FSC_DIENSTEN` en de consumer in `FSC_CONSUMERS`. Faalt er
één, dan blijft het contract ongetekend — en daarmee werkt het niet, wat de bedoelde uitkomst is.

De thumbprint wordt bewust niet getoetst: de provider heeft het outway-cert van de consumer niet en
kan hem niet onafhankelijk verifiëren. Welke outway van díé consumer mag afnemen, is aan de consumer.

## Bewijs

| Assert | Uitkomst |
|---|---|
| autorisatie | elke eis apart: twee grants, nul grants, ander grant-type, dienst van een andere peer, dienst buiten de lijst, consumer buiten de lijst — plus dat de weigering de juiste grond noemt |
| allowlists | met méér dan één dienst/consumer, want een lijst van één verbergt "geeft de enige terug" i.p.v. "kiest per sleutel" |
| stilte waar het hoort | een al getekend contract dat de toets niet haalt (het servicePublication-contract voor dezelfde dienst) levert geen weigering op, anders staat de log elke ronde vol |
| scheiding | statisch: geen van beide helften noemt de manager-, cert- of CA-variabelen van de overkant. Draait in CI, dus ook zonder federatie |
| configuratiefouten | in het image gemeten: ontbrekende env, lege allowlist en een manager-adres dat met `-` begint eindigen alledrie op exit 2 en de lus stopt — geen component dat draait en niets doet |
| stoppen | `docker stop` in 1s in plaats van de stop-timeout uitzitten |

Mutatietoets op de autorisatie-invariant: de grant-aantal-eis weghalen maakt 4 tests rood, de
consumer-allowlist weghalen 5. De asserts kunnen dus falen.

`smoke-contract-split.sh` toetst de convergentie tegen een draaiende federatie: elke helft apart,
daarna een tweede ronde die niets toevoegt en precies één geldig contract overlaat.

## ZAD-bedrading

Eén image (`fbs-fsc-contract-bootstrap`), twee rollen; ZAD staat geen component-args toe, dus de rol
komt uit `FSC_ROL`. Een component per peer, in de deployment van díé peer:
`logius-fscbootstrap` (consumer) en `magazijna-fscbootstrap` (provider). Het bootstrap-endpoint
krijgt een eigen internal-cert — wie een cert deelt, deelt een identiteit — en bewust **geen**
group-cert: het bedient zelf geen TLS en hoort zich niet in de mesh als de peer te kunnen voordoen.

`contracts/zad-runbook.md` draagt de eenmalige creatie en de cert-attachments (UI-only; de v2-API
kloont ze niet).

## Wat hier niet in zit

**Het datapad app → outway (D2).** Dat loopt tegen dezelfde deployment-isolatie aan, maar heeft de
mesh niet als uitweg: de uitvraag moet er buitenlangs, via de publieke outway-route, en die is als
enige van de drie niet `ssl-passthrough` maar edge-terminated.

> **TODO** — netwerkpolicies zijn op ZAD niet configureerbaar. Hetzelfde bleek al bij een ander
> ticket; daarvoor wordt een issue aangemaakt en dit geval hoort daarbij. De outway is de component
> die namens de peer diens identiteit meegeeft, dus wie hem via die route bereikt, spreekt als die
> peer. Dat vraagt een expliciete afweging in dat issue.

## Vóór de merge nog te bevestigen

De provider eist `service.type == SERVICE_TYPE_SERVICE`. De discriminator is in de spec verplicht en
de consumer-helft stuurt hem mee, maar of een echte OpenFSC-manager hem ook teruggeeft in
`GET /v1/contracts` is niet geverifieerd — protojson laat een enum op zijn nulwaarde weg tenzij
`EmitUnpopulated` aanstaat. Doet hij dat niet, dan tekent de provider niets meer. Eén `curl` tegen
een draaiende manager beslist dit; de tests bewijzen het strikte gedrag, niet de aanname.

Zelfde categorie, kleiner: een zelfreferentieel contract (consumer = provider) zou als "door ons
getekend" gelden op grond van onze consumer-handtekening. Onbereikbaar zolang logius alleen de
consumer-rol draait, maar het wordt een permanente uitgang 4 zodra die peer ook provider wordt.

## Bekende beperking

De accept-push naar de consumer is best-effort (begrensde backoff, geen cron-retry). De
provider-helft stuurt daarom na elke accept één keer na. Strandt de push dáárna alsnog, dan kan geen
van beide helften dat verhelpen: de consumer ziet het probleem maar kan de her-distributie niet
aanroepen (provider-endpoint), en de provider kan hem aanroepen maar het probleem niet zien. Lokaal
loste één script dat op door bij beide managers te kijken; op ZAD kan dat niet. De uitweg staat in
het runbook: `FSC_FORCEER_DISTRIBUTIE=1` voor één ronde.

De ZAD-kant zelf is pas na een deploy-ronde bewezen.

## Vijf reviewrondes

De eerste twee vonden fouten in het oorspronkelijke ontwerp, waaronder twee autorisatie-bypasses via
newline-injectie — één per kant. De laatste drie vonden vooral fouten in de fixes daarvóór: een
paginering-guard op het verkeerde veld, een numerieke guard die nul doorliet, en twee keer een
kapotte toestand die als succes naar buiten kwam. Beide van die laatste zaten in de exit-ladder van
de provider-helft, en die had geen test — die is er nu, met de regressie als eigen regel.

🤖 Gegenereerd met [Claude Code](https://claude.com/claude-code)

