### PR TITLE
Previews opruimen ook als een PR niet in main mergt

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -1,0 +1,310 @@
+# Ruimt de preview van een PR op: de `pr-<n>`-deployment in elk van de drie ZAD-projecten, de
+# GitHub-omgeving en -deployments, de deploy-comment en de ghcr-versies van die PR.
+#
+# WAAROM EEN EIGEN WORKFLOW EN NIET IN deploy.yml: die filtert met `branches: [main]` op de
+# DOELbranch, zodat een gestapelde PR geen preview krijgt en geen stale required checks
+# achterlaat. Datzelfde filter sloeg ook toe op het sluiten: werd een PR ná zijn preview-deploy
+# weggericht van main (base op een feature-branch gezet en daar gemerged), dan matchte het
+# close-event het filter niet, draaide de workflow niet en bleef de `pr-<n>`-deployment in alle
+# drie de projecten staan — plus de ghcr-tags, de omgeving en de comment. Zo lekten pr-188,
+# pr-195, pr-199 en pr-201. Teardown heeft dat filter niet nodig: er zijn geen checks die groen
+# kunnen komen te staan, en opruimen van iets dat niet bestaat is een no-op ("not found" is een
+# geldige uitkomst). Deze workflow triggert daarom op élk sluiten, ongeacht de doelbranch.
+#
+# `workflow_dispatch` staat erbij om een gemiste opruiming alsnog te kunnen draaien; deploy.yml
+# had die knop niet, waardoor de enige uitweg handwerk tegen de OM-API was.
+#
+# DESTRUCTIEF: de deployment-DELETE draait Argo `prune` + `Delete` en, voor projecten met de
+# `postgresql-database`-service, `database_cleanup` — de databank van die deployment gaat mee. Dat
+# is precies de bedoeling voor een `pr-<n>`-preview, maar draai deze workflow NOOIT met een
+# PR-nummer dat niet bij een preview hoort. De naam is altijd `pr-<n>`; `test` en de
+# `fsc-*`-peer-deployments zijn met dit contract onbereikbaar.
+#
+# Repo-secrets (Settings → Secrets and variables → Actions):
+#   ZAD_API_KEY_UITVRAAG    — API-key project mpfb-8wh
+#   ZAD_API_KEY_PROFIEL     — API-key project mpfpsm-lcl (externe-stubs)
+#   ZAD_API_KEY_MAGAZIJNEN  — API-key project mpfm-w3h
+#   GH_ADMIN_TOKEN          — PAT met Administration: write op deze repo (fine-grained), of een
+#                             classic token met `repo`-scope én admin op de repo. GITHUB_TOKEN mag
+#                             omgevingen niet verwijderen, en de naam mag niet met `GITHUB_`
+#                             beginnen — die prefix is gereserveerd. Mist het token de
+#                             administration-rechten, dan antwoordt GitHub 404 (niet 403) op de
+#                             DELETE: onderscheiden van "bestond al niet" kan alleen door daarna
+#                             te controleren óf de omgeving nog bestaat. Dat doet de
+#                             verificatiestap hieronder; zonder die stap bleef het bij een
+#                             `::warning::` in een groene job en groeide de lijst omgevingen
+#                             ongemerkt door (73 stuks vóór deze workflow bestond).
+
+name: Cleanup ZAD preview
+
+on:
+  # GEEN `branches`-filter: zie de toelichting bovenaan. Alleen `closed` — een gesloten PR is het
+  # enige moment waarop een preview overbodig wordt (heropenen deployt opnieuw via deploy.yml).
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR-nummer waarvan de preview opgeruimd moet worden (bv. 195)"
+        required: true
+        type: string
+
+# Least-privilege default; de jobs die schrijven declareren dat zelf.
+permissions: read-all
+
+env:
+  PROJECT_UITVRAAG: mpfb-8wh
+  PROJECT_EXTERNE_STUBS: mpfpsm-lcl
+  PROJECT_MAGAZIJNEN: mpfm-w3h
+  # De ZAD-delete duurde gemeten ~4 minuten (Argo prune + database_cleanup); de action-default van
+  # 300 s is daarvoor te krap.
+  CLEANUP_TASK_TIMEOUT: "900"
+  # Zelfde header als waarmee de deploy-action zijn comment plaatst; anders vindt de opruiming hem
+  # niet.
+  COMMENT_HEADER: "## 🚀 Preview Deployment"
+
+jobs:
+  # Eén plek waar het PR-nummer vandaan komt en gevalideerd wordt, zodat de drie
+  # project-jobs en de image-sweep het niet elk apart hoeven te herleiden.
+  doel:
+    # Een PR uit een fork krijgt geen preview: de deploy-action heeft secrets nodig en die deelt
+    # GitHub niet met fork-workflows. Er valt dan dus niets op te ruimen, en zonder deze uitsluiting
+    # zou élk sluiten van een fork-PR een rode run opleveren op een ontbrekend secret.
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      pr: ${{ steps.doel.outputs.pr }}
+      owner: ${{ steps.doel.outputs.owner }}
+    steps:
+      - name: Bepaal en controleer het doel
+        id: doel
+        env:
+          # Bij een close-event komt het nummer uit het event, bij een handmatige run uit de input.
+          PR_NUMMER: ${{ github.event.pull_request.number || inputs.pr }}
+          # Alleen de aanwezigheid is hier zichtbaar; de waarde blijft in de jobs die hem gebruiken.
+          ADMIN_TOKEN_AANWEZIG: ${{ secrets.GH_ADMIN_TOKEN != '' }}
+        run: |
+          set -euo pipefail
+
+          # Het nummer bepaalt de naam van de te verwijderen deployment (`pr-<n>`) en de
+          # ghcr-tag-prefix. Een vrij tekstveld uit `workflow_dispatch` mag daar nooit
+          # ongefilterd in: alleen cijfers, zodat er geen andere deployment (bv. `test`) of
+          # bredere tag-prefix uit te construeren is.
+          if ! printf '%s' "$PR_NUMMER" | grep -qE '^[0-9]+$'; then
+            echo "::error::PR-nummer '$PR_NUMMER' is geen getal — opruimen afgebroken."
+            exit 1
+          fi
+
+          # Vroeg en luid falen: zonder dit token kan de omgeving niet verwijderd worden, en het
+          # sluiten van een PR is een moment waarop niemand meelet.
+          if [ "$ADMIN_TOKEN_AANWEZIG" != "true" ]; then
+            echo "::error::GH_ADMIN_TOKEN ontbreekt — de omgeving pr-$PR_NUMMER kan niet opgeruimd worden. Zet de repo-secret (PAT met Administration: write)."
+            exit 1
+          fi
+
+          {
+            echo "pr=$PR_NUMMER"
+            # GHCR eist lowercase in de owner.
+            echo "owner=${GITHUB_REPOSITORY_OWNER,,}"
+          } >> "$GITHUB_OUTPUT"
+
+  # Per project een eigen (parallelle) job. De GitHub-omgeving en -deployments horen bij de PR en
+  # niet bij een project, dus ruimt alleen de uitvraag-job die op — de andere twee zetten het uit.
+  cleanup-preview-uitvraag:
+    needs: doel
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Zelfde groep als de deploy-job van dit project + deze PR in deploy.yml: opruimen mag een
+    # lopende deploy niet onder handen wegtrekken. Concurrency-groepen zijn repo-breed, dus de
+    # verhuizing naar een eigen workflow verandert daar niets aan — de naam moet wél gelijk blijven.
+    # `needs`-outputs mogen hier niet gebruikt worden, vandaar dezelfde expressie als in `doel`.
+    concurrency:
+      group: zad-uitvraag-pr-${{ github.event.pull_request.number || inputs.pr }}
+      cancel-in-progress: false
+    permissions:
+      deployments: write
+      pull-requests: write
+    steps:
+      - name: Cleanup uitvraag-project
+        uses: RijksICTGilde/zad-actions/cleanup@b844c76eba3502b40a19be868cdf0586e322f4b8 # v4
+        with:
+          api-key: ${{ secrets.ZAD_API_KEY_UITVRAAG }}
+          project-id: ${{ env.PROJECT_UITVRAAG }}
+          deployment-name: pr-${{ needs.doel.outputs.pr }}
+          task-timeout: ${{ env.CLEANUP_TASK_TIMEOUT }}
+          delete-github-env: "true"
+          delete-github-deployments: "true"
+          delete-container: "false"
+          comment-header: ${{ env.COMMENT_HEADER }}
+          github-admin-token: ${{ secrets.GH_ADMIN_TOKEN }}
+
+      # De action meldt een mislukte omgeving-delete alleen als `::warning::` en houdt de job
+      # groen; bovendien is een 404 daar niet te onderscheiden van "bestond al niet". Wat de
+      # omgeving betreft is de enige betrouwbare toets: bestaat hij daarna nog?
+      - name: Verifieer dat de GitHub-omgeving weg is
+        env:
+          # Lezen kan met het automatische token; verwijderen vereist de administration-rechten.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ADMIN_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+          OMGEVING: pr-${{ needs.doel.outputs.pr }}
+        run: |
+          set -euo pipefail
+
+          bestaat() {
+            gh api "repos/$GITHUB_REPOSITORY/environments/$OMGEVING" --silent >/dev/null 2>&1
+          }
+
+          if ! bestaat; then
+            echo "Omgeving $OMGEVING is verwijderd."
+            exit 0
+          fi
+
+          echo "::notice::Omgeving $OMGEVING bestaat nog — tweede poging met GH_ADMIN_TOKEN."
+          GH_TOKEN="$ADMIN_TOKEN" gh api "repos/$GITHUB_REPOSITORY/environments/$OMGEVING" -X DELETE || true
+
+          if bestaat; then
+            echo "::error::Omgeving $OMGEVING is niet verwijderd. GitHub antwoordt 404 op de DELETE wanneer het token de rechten mist, dus dit is vrijwel altijd een rechtenprobleem: geef GH_ADMIN_TOKEN 'Administration: write' op deze repo (fine-grained) of 'repo'-scope plus repo-admin (classic). Herdraai daarna deze workflow via workflow_dispatch met het nummer uit $OMGEVING."
+            exit 1
+          fi
+
+          echo "Omgeving $OMGEVING is bij de tweede poging verwijderd."
+
+      # De comment-opruiming ín de action hangt aan `github.event_name == 'pull_request'` en slaat
+      # bij een handmatige run dus over. Juist dan is er iets in te halen: een gemiste opruiming
+      # laat de deploy-comment op een gesloten PR staan.
+      - name: Verwijder de deploy-comment (handmatige run)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMMER: ${{ needs.doel.outputs.pr }}
+        run: |
+          set -euo pipefail
+
+          # De header via `jq --arg` i.p.v. in het jq-programma interpoleren: de tekst bevat
+          # aanhalingstekens-onvriendelijke tekens (`#`, emoji) en hoort data te zijn, geen code.
+          ids=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMMER/comments" --paginate \
+            | jq -r --arg h "$COMMENT_HEADER" '.[] | select(.body | startswith($h)) | .id')
+
+          if [ -z "$ids" ]; then
+            echo "Geen deploy-comment op PR $PR_NUMMER."
+            exit 0
+          fi
+
+          for id in $ids; do
+            gh api "repos/$GITHUB_REPOSITORY/issues/comments/$id" -X DELETE
+            echo "Comment $id verwijderd."
+          done
+
+  cleanup-preview-externe-stubs:
+    needs: doel
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: zad-externe-stubs-pr-${{ github.event.pull_request.number || inputs.pr }}
+      cancel-in-progress: false
+    steps:
+      - name: Cleanup externe-stubs-project
+        uses: RijksICTGilde/zad-actions/cleanup@b844c76eba3502b40a19be868cdf0586e322f4b8 # v4
+        with:
+          api-key: ${{ secrets.ZAD_API_KEY_PROFIEL }}
+          project-id: ${{ env.PROJECT_EXTERNE_STUBS }}
+          deployment-name: pr-${{ needs.doel.outputs.pr }}
+          task-timeout: ${{ env.CLEANUP_TASK_TIMEOUT }}
+          delete-github-env: "false"
+          delete-container: "false"
+          # Zonder pull-requests: write kan deze job geen comment verwijderen; dat doet de
+          # uitvraag-job, die de rechten wél heeft. Zonder deze uitzetting zou de action hier
+          # elke run een mislukte poging loggen.
+          delete-pr-comment: "false"
+
+  cleanup-preview-magazijnen:
+    needs: doel
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: zad-magazijnen-pr-${{ github.event.pull_request.number || inputs.pr }}
+      cancel-in-progress: false
+    steps:
+      - name: Cleanup magazijnen-project
+        uses: RijksICTGilde/zad-actions/cleanup@b844c76eba3502b40a19be868cdf0586e322f4b8 # v4
+        with:
+          api-key: ${{ secrets.ZAD_API_KEY_MAGAZIJNEN }}
+          project-id: ${{ env.PROJECT_MAGAZIJNEN }}
+          deployment-name: pr-${{ needs.doel.outputs.pr }}
+          task-timeout: ${{ env.CLEANUP_TASK_TIMEOUT }}
+          delete-github-env: "false"
+          delete-container: "false"
+          delete-pr-comment: "false"
+
+  # Ruimt ALLE images van de PR op: één ghcr-versie per commit, niet alleen de laatste. De
+  # tags van deze PR zijn te herkennen aan de prefix `pr-<n>-`; het afsluitende koppelteken
+  # is essentieel, anders zou het sluiten van PR 16 de images van PR 168 meenemen.
+  #
+  # Bewust niet de `delete-container`-stap van zad-actions: die verwijdert één exacte tag, wat
+  # met unieke tags per commit alle tussenversies zou laten staan. Ook bewust géén
+  # package-brede fallback bij "cannot delete the last tagged version" (die de action wél
+  # heeft): dat zou een preview-cleanup het hele package laten verwijderen inclusief de
+  # main-images. De `main-<sha7>`-tags zorgen ervoor dat die situatie zich niet voordoet.
+  #
+  # RACE bij sluiten tijdens een lopende build (~85 s venster): de build-jobs in deploy.yml zitten
+  # in hun eigen concurrency-groep (anders zouden ze elkaar blokkeren), dus deze sweep wacht niet
+  # op een nog draaiende build van een eerdere push. Sluit iemand de PR vlak na een push, dan kan
+  # de sweep vóór die push af zijn en blijft één ghcr-versie achter. Gevolg is één weesversie, geen
+  # kapotte deploy; opruimen kan door deze workflow te herdraaien via workflow_dispatch.
+  cleanup-preview-images:
+    needs: doel
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      packages: write
+    steps:
+      - name: Verwijder de ghcr-versies van deze PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG: ${{ needs.doel.outputs.owner }}
+          PREFIX: pr-${{ needs.doel.outputs.pr }}-
+          # Overgangsgeval: PR's die al liepen vóór de unieke tags bestonden, hebben nog een
+          # kale `pr-<n>`-versie in ghcr staan. Die valt niet onder de prefix, dus expliciet
+          # meenemen — anders blijft hij achter zodra zo'n PR sluit.
+          LEGACY_TAG: pr-${{ needs.doel.outputs.pr }}
+        run: |
+          set -euo pipefail
+          fail=0
+
+          # Expliciete lijst, bewust niet afgeleid uit alle org-packages: de prefix `pr-<n>-`
+          # is niet uniek binnen de organisatie, dus een brede sweep zou images van een
+          # gelijkgenummerde PR in een andere repo kunnen wissen. Houd deze lijst in sync met
+          # de `build`-matrix, `build-externe-stubs` en `build-contract-bootstrap` in deploy.yml;
+          # een vergeten package laat weesversies achter.
+          for pkg in fbs-berichtenuitvraag fbs-berichtenmagazijn fbs-externe-stubs fbs-fsc-contract-bootstrap; do
+            if ! versions=$(gh api --paginate "orgs/$ORG/packages/container/$pkg/versions?per_page=100"); then
+              echo "::warning::Kon de versies van $pkg niet ophalen — images van deze PR blijven mogelijk staan."
+              fail=1
+              continue
+            fi
+
+            # --paginate levert per pagina een eigen array; jq verwerkt ze als losse inputs.
+            ids=$(printf '%s' "$versions" | jq -r --arg p "$PREFIX" --arg legacy "$LEGACY_TAG" \
+              '.[] | select(.metadata.container.tags | any(startswith($p) or . == $legacy)) | .id')
+
+            if [ -z "$ids" ]; then
+              echo "$pkg: geen versies met tag $LEGACY_TAG of prefix $PREFIX."
+              continue
+            fi
+
+            for id in $ids; do
+              if gh api "orgs/$ORG/packages/container/$pkg/versions/$id" -X DELETE; then
+                echo "$pkg: versie $id verwijderd."
+              else
+                echo "::warning::$pkg: versie $id niet verwijderd."
+                fail=1
+              fi
+            done
+          done
+
+          # Achterblijvende images zijn geen reden om de PR-afsluiting te blokkeren, maar het
+          # moet wel als rode job zichtbaar zijn — anders groeit de ghcr-berg ongemerkt door.
+          exit "$fail"

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -5,20 +5,26 @@
 # DOELbranch, zodat een gestapelde PR geen preview krijgt en geen stale required checks
 # achterlaat. Datzelfde filter sloeg ook toe op het sluiten: werd een PR ná zijn preview-deploy
 # weggericht van main (base op een feature-branch gezet en daar gemerged), dan matchte het
-# close-event het filter niet, draaide de workflow niet en bleef de `pr-<n>`-deployment in alle
-# drie de projecten staan — plus de ghcr-tags, de omgeving en de comment. Zo lekten pr-188,
-# pr-195, pr-199 en pr-201. Teardown heeft dat filter niet nodig: er zijn geen checks die groen
-# kunnen komen te staan, en opruimen van iets dat niet bestaat is een no-op ("not found" is een
-# geldige uitkomst). Deze workflow triggert daarom op élk sluiten, ongeacht de doelbranch.
+# close-event het filter niet en bleef de hele preview staan. Teardown heeft dat filter niet
+# nodig: geen van deze jobs is een required context op main, dus ze kunnen geen merge vrijgeven.
+# Deze workflow triggert daarom op élk sluiten, ongeacht de doelbranch.
 #
-# `workflow_dispatch` staat erbij om een gemiste opruiming alsnog te kunnen draaien; deploy.yml
-# had die knop niet, waardoor de enige uitweg handwerk tegen de OM-API was.
+# `workflow_dispatch` staat erbij om een gemiste opruiming alsnog te kunnen draaien.
+#
+# ELKE VERWIJDERING WORDT NAGEMETEN. `zad-actions/cleanup` behandelt een mislukte delete als
+# `::warning::` en houdt de step groen (`cleanup-failures are non-fatal` in zijn eigen
+# zad-common.sh), en GitHub antwoordt op een DELETE zonder de juiste rechten met 404 in plaats van
+# 403 — beide onzichtbaar in een groene job, en precies zo groeide de lijst wees-omgevingen en
+# wees-deployments. Na elke opruimstap staat daarom een controle die de resource ópvraagt: alleen
+# een expliciete 404 geldt als "weg", een 200 als "staat er nog" en élke andere uitkomst als "niet
+# geverifieerd". Die laatste twee maken de job rood. `gh api`-exitcodes zijn hiervoor ongeschikt:
+# die zijn 1 bij 404, 403, 429, 5xx én een netwerkfout, waardoor een API-hik als "weg" zou lezen.
 #
 # DESTRUCTIEF: de deployment-DELETE draait Argo `prune` + `Delete` en, voor projecten met de
-# `postgresql-database`-service, `database_cleanup` — de databank van die deployment gaat mee. Dat
-# is precies de bedoeling voor een `pr-<n>`-preview, maar draai deze workflow NOOIT met een
-# PR-nummer dat niet bij een preview hoort. De naam is altijd `pr-<n>`; `test` en de
-# `fsc-*`-peer-deployments zijn met dit contract onbereikbaar.
+# `postgresql-database`-service, `database_cleanup` — de database van die deployment gaat mee. Voor
+# een `pr-<n>`-preview is dat de bedoeling. Vandaar de rem op de handmatige route: het nummer moet
+# een getal zijn (zodat er geen andere deployment-naam als `test` uit te construeren is) én bij een
+# PR horen die daadwerkelijk gesloten is.
 #
 # Repo-secrets (Settings → Secrets and variables → Actions):
 #   ZAD_API_KEY_UITVRAAG    — API-key project mpfb-8wh
@@ -27,13 +33,7 @@
 #   GH_ADMIN_TOKEN          — PAT met Administration: write op deze repo (fine-grained), of een
 #                             classic token met `repo`-scope én admin op de repo. GITHUB_TOKEN mag
 #                             omgevingen niet verwijderen, en de naam mag niet met `GITHUB_`
-#                             beginnen — die prefix is gereserveerd. Mist het token de
-#                             administration-rechten, dan antwoordt GitHub 404 (niet 403) op de
-#                             DELETE: onderscheiden van "bestond al niet" kan alleen door daarna
-#                             te controleren óf de omgeving nog bestaat. Dat doet de
-#                             verificatiestap hieronder; zonder die stap bleef het bij een
-#                             `::warning::` in een groene job en groeide de lijst omgevingen
-#                             ongemerkt door (73 stuks vóór deze workflow bestond).
+#                             beginnen — die prefix is gereserveerd.
 
 name: Cleanup ZAD preview
 
@@ -49,27 +49,28 @@ on:
         required: true
         type: string
 
-# Least-privilege default; de jobs die schrijven declareren dat zelf.
+# Least-privilege default; elke job die schrijft declareert zijn eigen scopes.
 permissions: read-all
 
 env:
   PROJECT_UITVRAAG: mpfb-8wh
   PROJECT_EXTERNE_STUBS: mpfpsm-lcl
   PROJECT_MAGAZIJNEN: mpfm-w3h
-  # De ZAD-delete duurde gemeten ~4 minuten (Argo prune + database_cleanup); de action-default van
-  # 300 s is daarvoor te krap.
+  OM_API: https://operations-manager.rig.prd1.gn2.quattro.rijksapps.nl/api
+  # De ZAD-delete duurt ~4 minuten (Argo prune + database_cleanup) en zit daarmee te dicht op de
+  # action-default van 300 s. 900 s is hetzelfde marge-getal als PREVIEW_TASK_TIMEOUT in deploy.yml;
+  # de job-timeout staat er ruim boven, zodat de CLI zijn eigen diagnose kan afmaken vóórdat GitHub
+  # de job afkapt.
   CLEANUP_TASK_TIMEOUT: "900"
-  # Zelfde header als waarmee de deploy-action zijn comment plaatst; anders vindt de opruiming hem
-  # niet.
+  # Beide workflows geven deze header expliciet mee in plaats van op de action-default te leunen:
+  # drift tussen plaatsende en opruimende kant laat de comment stil achter op gesloten PR's.
   COMMENT_HEADER: "## 🚀 Preview Deployment"
 
 jobs:
-  # Eén plek waar het PR-nummer vandaan komt en gevalideerd wordt, zodat de drie
-  # project-jobs en de image-sweep het niet elk apart hoeven te herleiden.
+  # Eén plek waar het PR-nummer vandaan komt en gevalideerd wordt.
   doel:
     # Een PR uit een fork krijgt geen preview: de deploy-action heeft secrets nodig en die deelt
-    # GitHub niet met fork-workflows. Er valt dan dus niets op te ruimen, en zonder deze uitsluiting
-    # zou élk sluiten van een fork-PR een rode run opleveren op een ontbrekend secret.
+    # GitHub niet met fork-workflows. Er valt dan dus niets op te ruimen.
     if: >-
       github.event_name == 'workflow_dispatch'
       || github.event.pull_request.head.repo.full_name == github.repository
@@ -82,10 +83,9 @@ jobs:
       - name: Bepaal en controleer het doel
         id: doel
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Bij een close-event komt het nummer uit het event, bij een handmatige run uit de input.
           PR_NUMMER: ${{ github.event.pull_request.number || inputs.pr }}
-          # Alleen de aanwezigheid is hier zichtbaar; de waarde blijft in de jobs die hem gebruiken.
-          ADMIN_TOKEN_AANWEZIG: ${{ secrets.GH_ADMIN_TOKEN != '' }}
         run: |
           set -euo pipefail
 
@@ -93,41 +93,76 @@ jobs:
           # ghcr-tag-prefix. Een vrij tekstveld uit `workflow_dispatch` mag daar nooit
           # ongefilterd in: alleen cijfers, zodat er geen andere deployment (bv. `test`) of
           # bredere tag-prefix uit te construeren is.
-          if ! printf '%s' "$PR_NUMMER" | grep -qE '^[0-9]+$'; then
-            echo "::error::PR-nummer '$PR_NUMMER' is geen getal — opruimen afgebroken."
+          case "$PR_NUMMER" in
+            ''|*[!0-9]*)
+              echo "::error::PR-nummer '$PR_NUMMER' is geen getal — opruimen afgebroken."
+              exit 1
+              ;;
+          esac
+
+          # Normaliseren: `0195` zou anders `pr-0195` opruimen (bestaat niet, dus een groene run
+          # die niets doet) terwijl de deploy-jobs `pr-195` gebruiken.
+          nummer=$((10#$PR_NUMMER))
+
+          if [ "$nummer" -eq 0 ]; then
+            echo "::error::PR-nummer 0 bestaat niet — opruimen afgebroken."
             exit 1
           fi
 
-          # Vroeg en luid falen: zonder dit token kan de omgeving niet verwijderd worden, en het
-          # sluiten van een PR is een moment waarop niemand meelet.
-          if [ "$ADMIN_TOKEN_AANWEZIG" != "true" ]; then
-            echo "::error::GH_ADMIN_TOKEN ontbreekt — de omgeving pr-$PR_NUMMER kan niet opgeruimd worden. Zet de repo-secret (PAT met Administration: write)."
-            exit 1
+          # Een handmatige run is de inhaalslag voor een gemiste opruiming, dus bediend door iemand
+          # met haast. Een typefout zou drie keer "not found" opleveren: een volledig groene run die
+          # niets opruimde. Erger is een bestaand nummer van een ópen PR: dat sloopt een levende
+          # preview inclusief database. Vandaar deze twee eisen; bij een close-event zijn ze
+          # per definitie al waar.
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            if ! staat=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$nummer" --jq .state); then
+              echo "::error::PR $nummer bestaat niet in $GITHUB_REPOSITORY — opruimen afgebroken."
+              exit 1
+            fi
+
+            if [ "$staat" != "closed" ]; then
+              echo "::error::PR $nummer is nog $staat — opruimen zou een levende preview slopen, inclusief database. Sluit de PR eerst."
+              exit 1
+            fi
           fi
 
           {
-            echo "pr=$PR_NUMMER"
+            echo "pr=$nummer"
             # GHCR eist lowercase in de owner.
             echo "owner=${GITHUB_REPOSITORY_OWNER,,}"
           } >> "$GITHUB_OUTPUT"
 
   # Per project een eigen (parallelle) job. De GitHub-omgeving en -deployments horen bij de PR en
-  # niet bij een project, dus ruimt alleen de uitvraag-job die op — de andere twee zetten het uit.
+  # niet bij een project, dus `delete-github-env`/`delete-github-deployments` staan alleen in de
+  # uitvraag-job aan (de andere twee laten ze op de action-default `false`).
   cleanup-preview-uitvraag:
     needs: doel
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    # Zelfde groep als de deploy-job van dit project + deze PR in deploy.yml: opruimen mag een
+    timeout-minutes: 20
+    # Zelfde groepsnaam als de deploy-job van dit project + deze PR in deploy.yml: opruimen mag een
     # lopende deploy niet onder handen wegtrekken. Concurrency-groepen zijn repo-breed, dus de
     # verhuizing naar een eigen workflow verandert daar niets aan — de naam moet wél gelijk blijven.
-    # `needs`-outputs mogen hier niet gebruikt worden, vandaar dezelfde expressie als in `doel`.
     concurrency:
-      group: zad-uitvraag-pr-${{ github.event.pull_request.number || inputs.pr }}
+      group: zad-uitvraag-pr-${{ needs.doel.outputs.pr }}
       cancel-in-progress: false
     permissions:
+      contents: read
       deployments: write
       pull-requests: write
     steps:
+      # Pre-flight bewust hier en niet in `doel`: alleen deze job gebruikt het token. Zat de check
+      # in `doel`, dan zou een ontbrekend of verlopen PAT ook de drie ZAD-deletes en de ghcr-sweep
+      # tegenhouden — die hebben het niet nodig, en dan blijven er pods en databases draaien om een
+      # GitHub-omgeving.
+      - name: Controleer GH_ADMIN_TOKEN aanwezig
+        env:
+          GH_ADMIN_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+        run: |
+          if [ -z "$GH_ADMIN_TOKEN" ]; then
+            echo "::error::GH_ADMIN_TOKEN ontbreekt — de GitHub-omgeving kan niet opgeruimd worden. Zet de repo-secret (PAT met Administration: write)."
+            exit 1
+          fi
+
       - name: Cleanup uitvraag-project
         uses: RijksICTGilde/zad-actions/cleanup@b844c76eba3502b40a19be868cdf0586e322f4b8 # v4
         with:
@@ -140,41 +175,15 @@ jobs:
           delete-container: "false"
           comment-header: ${{ env.COMMENT_HEADER }}
           github-admin-token: ${{ secrets.GH_ADMIN_TOKEN }}
-
-      # De action meldt een mislukte omgeving-delete alleen als `::warning::` en houdt de job
-      # groen; bovendien is een 404 daar niet te onderscheiden van "bestond al niet". Wat de
-      # omgeving betreft is de enige betrouwbare toets: bestaat hij daarna nog?
-      - name: Verifieer dat de GitHub-omgeving weg is
-        env:
-          # Lezen kan met het automatische token; verwijderen vereist de administration-rechten.
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ADMIN_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
-          OMGEVING: pr-${{ needs.doel.outputs.pr }}
-        run: |
-          set -euo pipefail
-
-          bestaat() {
-            gh api "repos/$GITHUB_REPOSITORY/environments/$OMGEVING" --silent >/dev/null 2>&1
-          }
-
-          if ! bestaat; then
-            echo "Omgeving $OMGEVING is verwijderd."
-            exit 0
-          fi
-
-          echo "::notice::Omgeving $OMGEVING bestaat nog — tweede poging met GH_ADMIN_TOKEN."
-          GH_TOKEN="$ADMIN_TOKEN" gh api "repos/$GITHUB_REPOSITORY/environments/$OMGEVING" -X DELETE || true
-
-          if bestaat; then
-            echo "::error::Omgeving $OMGEVING is niet verwijderd. GitHub antwoordt 404 op de DELETE wanneer het token de rechten mist, dus dit is vrijwel altijd een rechtenprobleem: geef GH_ADMIN_TOKEN 'Administration: write' op deze repo (fine-grained) of 'repo'-scope plus repo-admin (classic). Herdraai daarna deze workflow via workflow_dispatch met het nummer uit $OMGEVING."
-            exit 1
-          fi
-
-          echo "Omgeving $OMGEVING is bij de tweede poging verwijderd."
+          # Teardown mag niet afhangen van wie de PR opende: een preview van een bot-PR moet net zo
+          # goed weg, en op een deployment die niet bestaat is de delete een no-op. Zonder deze
+          # uitzetting slaat de action bij een bot-auteur álles over en rapporteert groen.
+          skip-bot-prs: "false"
 
       # De comment-opruiming ín de action hangt aan `github.event_name == 'pull_request'` en slaat
       # bij een handmatige run dus over. Juist dan is er iets in te halen: een gemiste opruiming
-      # laat de deploy-comment op een gesloten PR staan.
+      # laat de deploy-comment op een gesloten PR staan. Deze stap staat vóór de controles
+      # hieronder, zodat een mislukte controle hem niet overslaat.
       - name: Verwijder de deploy-comment (handmatige run)
         if: github.event_name == 'workflow_dispatch'
         env:
@@ -183,8 +192,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          # De header via `jq --arg` i.p.v. in het jq-programma interpoleren: de tekst bevat
-          # aanhalingstekens-onvriendelijke tekens (`#`, emoji) en hoort data te zijn, geen code.
+          # De header via `jq --arg` i.p.v. in het jq-programma interpoleren: `#` opent daar een
+          # comment, dus de tekst hoort data te zijn, geen code.
           ids=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMMER/comments" --paginate \
             | jq -r --arg h "$COMMENT_HEADER" '.[] | select(.body | startswith($h)) | .id')
 
@@ -198,12 +207,84 @@ jobs:
             echo "Comment $id verwijderd."
           done
 
+      - name: Controleer dat de ZAD-deployment weg is
+        # Ook draaien als een eerdere stap faalde: dan is juist de vraag wat er is blijven staan.
+        if: ${{ !cancelled() }}
+        env:
+          API_KEY: ${{ secrets.ZAD_API_KEY_UITVRAAG }}
+          PROJECT: ${{ env.PROJECT_UITVRAAG }}
+          DEPLOYMENT: pr-${{ needs.doel.outputs.pr }}
+        run: |
+          set -euo pipefail
+
+          code=$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "X-API-Key: $API_KEY" -H 'Accept: application/json' \
+            "$OM_API/v2/projects/$PROJECT/deployments/$DEPLOYMENT")
+
+          case "$code" in
+            404) echo "Deployment $DEPLOYMENT is weg in $PROJECT." ;;
+            200)
+              echo "::error::$DEPLOYMENT bestaat nog in $PROJECT. Herdraai deze workflow via workflow_dispatch; blijft hij staan, verwijder hem dan met DELETE $OM_API/v2/projects/$PROJECT/$DEPLOYMENT."
+              exit 1
+              ;;
+            *)
+              echo "::error::Kon niet vaststellen of $DEPLOYMENT weg is in $PROJECT (HTTP $code) — de teardown is NIET geverifieerd."
+              exit 1
+              ;;
+          esac
+
+      - name: Controleer dat de GitHub-deployments weg zijn
+        if: ${{ !cancelled() }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OMGEVING: pr-${{ needs.doel.outputs.pr }}
+        run: |
+          set -euo pipefail
+
+          # Zonder `2>/dev/null`: een mislukte read moet deze job rood maken en niet als "geen
+          # deployments" lezen. De action zelf onderdrukt die fout wél, en meldt een mislukte
+          # delete met een gewone `echo` — in de UI dus onzichtbaar.
+          aantal=$(gh api "repos/$GITHUB_REPOSITORY/deployments?environment=$OMGEVING" --jq 'length')
+
+          if [ "$aantal" != "0" ]; then
+            echo "::error::Er staan nog $aantal GitHub-deployments op omgeving $OMGEVING."
+            exit 1
+          fi
+
+          echo "Geen GitHub-deployments meer op $OMGEVING."
+
+      - name: Controleer dat de GitHub-omgeving weg is
+        if: ${{ !cancelled() }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OMGEVING: pr-${{ needs.doel.outputs.pr }}
+        run: |
+          set -euo pipefail
+
+          code=$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/environments/$OMGEVING")
+
+          case "$code" in
+            404) echo "Omgeving $OMGEVING is weg." ;;
+            200)
+              echo "::error::Omgeving $OMGEVING bestaat nog. GitHub antwoordt op een DELETE zonder de juiste rechten met 404, dus de action kan een rechtenprobleem niet van 'bestond al niet' onderscheiden: geef GH_ADMIN_TOKEN 'Administration: write' op deze repo (fine-grained) of 'repo'-scope plus repo-admin (classic) en herdraai deze workflow via workflow_dispatch."
+              exit 1
+              ;;
+            *)
+              echo "::error::Kon niet vaststellen of omgeving $OMGEVING weg is (HTTP $code) — de teardown is NIET geverifieerd."
+              exit 1
+              ;;
+          esac
+
   cleanup-preview-externe-stubs:
     needs: doel
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     concurrency:
-      group: zad-externe-stubs-pr-${{ github.event.pull_request.number || inputs.pr }}
+      group: zad-externe-stubs-pr-${{ needs.doel.outputs.pr }}
       cancel-in-progress: false
     steps:
       - name: Cleanup externe-stubs-project
@@ -213,19 +294,43 @@ jobs:
           project-id: ${{ env.PROJECT_EXTERNE_STUBS }}
           deployment-name: pr-${{ needs.doel.outputs.pr }}
           task-timeout: ${{ env.CLEANUP_TASK_TIMEOUT }}
-          delete-github-env: "false"
           delete-container: "false"
+          skip-bot-prs: "false"
           # Zonder pull-requests: write kan deze job geen comment verwijderen; dat doet de
-          # uitvraag-job, die de rechten wél heeft. Zonder deze uitzetting zou de action hier
-          # elke run een mislukte poging loggen.
+          # uitvraag-job, die de rechten wél heeft.
           delete-pr-comment: "false"
+
+      - name: Controleer dat de ZAD-deployment weg is
+        if: ${{ !cancelled() }}
+        env:
+          API_KEY: ${{ secrets.ZAD_API_KEY_PROFIEL }}
+          PROJECT: ${{ env.PROJECT_EXTERNE_STUBS }}
+          DEPLOYMENT: pr-${{ needs.doel.outputs.pr }}
+        run: |
+          set -euo pipefail
+
+          code=$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "X-API-Key: $API_KEY" -H 'Accept: application/json' \
+            "$OM_API/v2/projects/$PROJECT/deployments/$DEPLOYMENT")
+
+          case "$code" in
+            404) echo "Deployment $DEPLOYMENT is weg in $PROJECT." ;;
+            200)
+              echo "::error::$DEPLOYMENT bestaat nog in $PROJECT. Herdraai deze workflow via workflow_dispatch; blijft hij staan, verwijder hem dan met DELETE $OM_API/v2/projects/$PROJECT/$DEPLOYMENT."
+              exit 1
+              ;;
+            *)
+              echo "::error::Kon niet vaststellen of $DEPLOYMENT weg is in $PROJECT (HTTP $code) — de teardown is NIET geverifieerd."
+              exit 1
+              ;;
+          esac
 
   cleanup-preview-magazijnen:
     needs: doel
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     concurrency:
-      group: zad-magazijnen-pr-${{ github.event.pull_request.number || inputs.pr }}
+      group: zad-magazijnen-pr-${{ needs.doel.outputs.pr }}
       cancel-in-progress: false
     steps:
       - name: Cleanup magazijnen-project
@@ -235,9 +340,34 @@ jobs:
           project-id: ${{ env.PROJECT_MAGAZIJNEN }}
           deployment-name: pr-${{ needs.doel.outputs.pr }}
           task-timeout: ${{ env.CLEANUP_TASK_TIMEOUT }}
-          delete-github-env: "false"
           delete-container: "false"
+          skip-bot-prs: "false"
           delete-pr-comment: "false"
+
+      - name: Controleer dat de ZAD-deployment weg is
+        if: ${{ !cancelled() }}
+        env:
+          API_KEY: ${{ secrets.ZAD_API_KEY_MAGAZIJNEN }}
+          PROJECT: ${{ env.PROJECT_MAGAZIJNEN }}
+          DEPLOYMENT: pr-${{ needs.doel.outputs.pr }}
+        run: |
+          set -euo pipefail
+
+          code=$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "X-API-Key: $API_KEY" -H 'Accept: application/json' \
+            "$OM_API/v2/projects/$PROJECT/deployments/$DEPLOYMENT")
+
+          case "$code" in
+            404) echo "Deployment $DEPLOYMENT is weg in $PROJECT." ;;
+            200)
+              echo "::error::$DEPLOYMENT bestaat nog in $PROJECT. Herdraai deze workflow via workflow_dispatch; blijft hij staan, verwijder hem dan met DELETE $OM_API/v2/projects/$PROJECT/$DEPLOYMENT."
+              exit 1
+              ;;
+            *)
+              echo "::error::Kon niet vaststellen of $DEPLOYMENT weg is in $PROJECT (HTTP $code) — de teardown is NIET geverifieerd."
+              exit 1
+              ;;
+          esac
 
   # Ruimt ALLE images van de PR op: één ghcr-versie per commit, niet alleen de laatste. De
   # tags van deze PR zijn te herkennen aan de prefix `pr-<n>-`; het afsluitende koppelteken
@@ -249,15 +379,14 @@ jobs:
   # heeft): dat zou een preview-cleanup het hele package laten verwijderen inclusief de
   # main-images. De `main-<sha7>`-tags zorgen ervoor dat die situatie zich niet voordoet.
   #
-  # RACE bij sluiten tijdens een lopende build (~85 s venster): de build-jobs in deploy.yml zitten
-  # in hun eigen concurrency-groep (anders zouden ze elkaar blokkeren), dus deze sweep wacht niet
-  # op een nog draaiende build van een eerdere push. Sluit iemand de PR vlak na een push, dan kan
-  # de sweep vóór die push af zijn en blijft één ghcr-versie achter. Gevolg is één weesversie, geen
-  # kapotte deploy; opruimen kan door deze workflow te herdraaien via workflow_dispatch.
+  # RACE bij sluiten tijdens een lopende build: deze job serialiseert niet tegen de build-jobs in
+  # deploy.yml (die hebben elk hun eigen groep, anders blokkeren ze elkaar). Sluit iemand de PR
+  # vlak na een push, dan kan de sweep vóór die build af zijn en blijft één ghcr-versie achter.
+  # Gevolg is één weesversie, geen kapotte deploy; herdraaien via workflow_dispatch ruimt hem op.
   cleanup-preview-images:
     needs: doel
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     permissions:
       packages: write
     steps:
@@ -266,9 +395,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG: ${{ needs.doel.outputs.owner }}
           PREFIX: pr-${{ needs.doel.outputs.pr }}-
-          # Overgangsgeval: PR's die al liepen vóór de unieke tags bestonden, hebben nog een
-          # kale `pr-<n>`-versie in ghcr staan. Die valt niet onder de prefix, dus expliciet
-          # meenemen — anders blijft hij achter zodra zo'n PR sluit.
+          # Overgangsgeval: PR's uit de tijd vóór de per-commit-tags hebben nog een kale
+          # `pr-<n>`-versie in ghcr staan. Die valt niet onder de prefix, dus expliciet meenemen.
           LEGACY_TAG: pr-${{ needs.doel.outputs.pr }}
         run: |
           set -euo pipefail

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -7,18 +7,27 @@
 # weggericht van main (base op een feature-branch gezet en daar gemerged), dan matchte het
 # close-event het filter niet en bleef de hele preview staan. Teardown heeft dat filter niet
 # nodig: geen van deze jobs is een required context op main, dus ze kunnen geen merge vrijgeven.
-# Deze workflow triggert daarom op élk sluiten, ongeacht de doelbranch.
 #
-# `workflow_dispatch` staat erbij om een gemiste opruiming alsnog te kunnen draaien.
+# WAAROM `pull_request_target` EN NIET `pull_request`: dat laatste draait niet als de PR een
+# merge-conflict heeft (GitHub voert de workflow uit op de merge-ref, en die is er dan niet) — en
+# een conflicterende, verlaten stapel-PR is precies het geval dat je wél opgeruimd wilt hebben.
+# Bijkomend: `pull_request_target` draait altijd de versie van dit bestand op de default branch,
+# dus een branch kan zijn eigen teardown niet uitschakelen. De gebruikelijke waarschuwing bij
+# `pull_request_target` (fork-code met secrets) geldt hier niet: er wordt geen enkele PR-inhoud
+# uitgecheckt of uitgevoerd; deze workflow gebruikt alleen het PR-NUMMER.
 #
-# ELKE VERWIJDERING WORDT NAGEMETEN. `zad-actions/cleanup` behandelt een mislukte delete als
-# `::warning::` en houdt de step groen (`cleanup-failures are non-fatal` in zijn eigen
-# zad-common.sh), en GitHub antwoordt op een DELETE zonder de juiste rechten met 404 in plaats van
-# 403 — beide onzichtbaar in een groene job, en precies zo groeide de lijst wees-omgevingen en
-# wees-deployments. Na elke opruimstap staat daarom een controle die de resource ópvraagt: alleen
-# een expliciete 404 geldt als "weg", een 200 als "staat er nog" en élke andere uitkomst als "niet
-# geverifieerd". Die laatste twee maken de job rood. `gh api`-exitcodes zijn hiervoor ongeschikt:
-# die zijn 1 bij 404, 403, 429, 5xx én een netwerkfout, waardoor een API-hik als "weg" zou lezen.
+# ELKE VERWIJDERING DIE STIL KAN MISLUKKEN, WORDT NAGEMETEN. Annotaties (`::warning::`, `::error::`)
+# laten een step niet falen: `zad-actions/cleanup` meldt een mislukte deployment-delete als
+# `::warning::` ("cleanup failures are non-fatal" in zijn zad-common.sh) en de GitHub-kant zelfs met
+# een gewone `echo` zónder annotatie. De job blijft dan groen, en zo groeide de lijst wees-
+# deployments en wees-omgevingen. Na elke opruimstap staat daarom een controle die de resource
+# ópvraagt en alleen een aantoonbare afwezigheid als "weg" accepteert. Die controles vragen de LIJST
+# op in plaats van het item: een 404 op een item-URL betekent óók "onbekend project" of "verkeerd
+# pad", dus dan zou een typefout of een API-versiewissel als "opgeruimd" lezen. Een lijst die met
+# HTTP 200 terugkomt zónder onze naam erin is positief bewijs.
+#
+# De ghcr-sweep en de deploy-comment leunen wél op hun eigen delete-exitcode: die verwijderen we
+# zelf en een niet-2xx is daar een échte fout, geen niet-fatale waarschuwing.
 #
 # DESTRUCTIEF: de deployment-DELETE draait Argo `prune` + `Delete` en, voor projecten met de
 # `postgresql-database`-service, `database_cleanup` — de database van die deployment gaat mee. Voor
@@ -40,7 +49,7 @@ name: Cleanup ZAD preview
 on:
   # GEEN `branches`-filter: zie de toelichting bovenaan. Alleen `closed` — een gesloten PR is het
   # enige moment waarop een preview overbodig wordt (heropenen deployt opnieuw via deploy.yml).
-  pull_request:
+  pull_request_target:
     types: [closed]
   workflow_dispatch:
     inputs:
@@ -53,9 +62,6 @@ on:
 permissions: read-all
 
 env:
-  PROJECT_UITVRAAG: mpfb-8wh
-  PROJECT_EXTERNE_STUBS: mpfpsm-lcl
-  PROJECT_MAGAZIJNEN: mpfm-w3h
   OM_API: https://operations-manager.rig.prd1.gn2.quattro.rijksapps.nl/api
   # De ZAD-delete duurt ~4 minuten (Argo prune + database_cleanup) en zit daarmee te dicht op de
   # action-default van 300 s. 900 s is hetzelfde marge-getal als PREVIEW_TASK_TIMEOUT in deploy.yml;
@@ -63,17 +69,18 @@ env:
   # de job afkapt.
   CLEANUP_TASK_TIMEOUT: "900"
   # Beide workflows geven deze header expliciet mee in plaats van op de action-default te leunen:
-  # drift tussen plaatsende en opruimende kant laat de comment stil achter op gesloten PR's.
+  # deze workflow zoekt de comment op deze tekst, dus drift tussen plaatsen en opruimen laat hem
+  # stil achter op een gesloten PR.
   COMMENT_HEADER: "## 🚀 Preview Deployment"
 
 jobs:
   # Eén plek waar het PR-nummer vandaan komt en gevalideerd wordt.
+  #
+  # Geen fork-uitsluiting: een fork-PR heeft nooit een preview (de deploy-action krijgt geen
+  # secrets), en opruimen van iets dat niet bestaat is een no-op die de controles hieronder als
+  # "afwezig" bevestigen. Een uitzondering zou juist een gat maken zodra er tóch iets van een
+  # fork-PR blijft staan.
   doel:
-    # Een PR uit een fork krijgt geen preview: de deploy-action heeft secrets nodig en die deelt
-    # GitHub niet met fork-workflows. Er valt dan dus niets op te ruimen.
-    if: >-
-      github.event_name == 'workflow_dispatch'
-      || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -92,7 +99,8 @@ jobs:
           # Het nummer bepaalt de naam van de te verwijderen deployment (`pr-<n>`) en de
           # ghcr-tag-prefix. Een vrij tekstveld uit `workflow_dispatch` mag daar nooit
           # ongefilterd in: alleen cijfers, zodat er geen andere deployment (bv. `test`) of
-          # bredere tag-prefix uit te construeren is.
+          # bredere tag-prefix uit te construeren is. De lengtegrens houdt de normalisatie
+          # hieronder binnen het bereik van een 64-bits int; die wrapt anders stil.
           case "$PR_NUMMER" in
             ''|*[!0-9]*)
               echo "::error::PR-nummer '$PR_NUMMER' is geen getal — opruimen afgebroken."
@@ -100,8 +108,14 @@ jobs:
               ;;
           esac
 
-          # Normaliseren: `0195` zou anders `pr-0195` opruimen (bestaat niet, dus een groene run
-          # die niets doet) terwijl de deploy-jobs `pr-195` gebruiken.
+          if [ "${#PR_NUMMER}" -gt 7 ]; then
+            echo "::error::PR-nummer '$PR_NUMMER' heeft meer dan 7 cijfers — opruimen afgebroken."
+            exit 1
+          fi
+
+          # Leidende nullen zijn een plausibele typefout bij handmatig invullen en ondubbelzinnig te
+          # herstellen, dus normaliseren in plaats van weigeren. Zonder dit zou `0195` de niet-
+          # bestaande deployment `pr-0195` opruimen: een groene run die niets doet.
           nummer=$((10#$PR_NUMMER))
 
           if [ "$nummer" -eq 0 ]; then
@@ -110,13 +124,15 @@ jobs:
           fi
 
           # Een handmatige run is de inhaalslag voor een gemiste opruiming, dus bediend door iemand
-          # met haast. Een typefout zou drie keer "not found" opleveren: een volledig groene run die
-          # niets opruimde. Erger is een bestaand nummer van een ópen PR: dat sloopt een levende
-          # preview inclusief database. Vandaar deze twee eisen; bij een close-event zijn ze
-          # per definitie al waar.
+          # met haast. Een typefout zou anders drie keer "niet gevonden" opleveren: een volledig
+          # groene run die niets opruimde. Erger is een bestaand nummer van een ópen PR: dat sloopt
+          # een levende preview inclusief database. Bij een close-event zijn beide eisen per
+          # definitie al waar.
           if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            # `gh api` faalt hier op 404 én op 403/429/5xx; de melding trekt daarom geen conclusie
+            # over de oorzaak. Weigeren is in alle gevallen de veilige kant.
             if ! staat=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$nummer" --jq .state); then
-              echo "::error::PR $nummer bestaat niet in $GITHUB_REPOSITORY — opruimen afgebroken."
+              echo "::error::Kon niet bevestigen dat PR $nummer in $GITHUB_REPOSITORY bestaat (bestaat niet, of GitHub gaf een fout) — opruimen afgebroken."
               exit 1
             fi
 
@@ -132,16 +148,101 @@ jobs:
             echo "owner=${GITHUB_REPOSITORY_OWNER,,}"
           } >> "$GITHUB_OUTPUT"
 
-  # Per project een eigen (parallelle) job. De GitHub-omgeving en -deployments horen bij de PR en
-  # niet bij een project, dus `delete-github-env`/`delete-github-deployments` staan alleen in de
-  # uitvraag-job aan (de andere twee laten ze op de action-default `false`).
-  cleanup-preview-uitvraag:
+  # De ZAD-teardown per project, als matrix: de drie projecten verschillen alleen in id, key en
+  # groepsnaam. Bewust géén drie losse jobs meer — de controlestap eronder was dan drie keer
+  # byte-identiek, en de eerste keer dat iemand hem op twee van de drie bijwerkt is de verificatie
+  # asymmetrisch zonder dat iets dat opmerkt.
+  #
+  # De GitHub-kant (omgeving, deployments, comment) hangt aan de PR en niet aan een project en
+  # staat daarom in een eigen job; alle `delete-*`-schakelaars van de action staan hier uit, zodat
+  # de action precies één ding doet.
+  cleanup-preview-zad:
     needs: doel
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      # Eén falend project mag de teardown van de andere twee niet afbreken.
+      fail-fast: false
+      matrix:
+        include:
+          - naam: uitvraag
+            project: mpfb-8wh
+            key: ZAD_API_KEY_UITVRAAG
+          - naam: externe-stubs
+            project: mpfpsm-lcl
+            key: ZAD_API_KEY_PROFIEL
+          - naam: magazijnen
+            project: mpfm-w3h
+            key: ZAD_API_KEY_MAGAZIJNEN
     # Zelfde groepsnaam als de deploy-job van dit project + deze PR in deploy.yml: opruimen mag een
     # lopende deploy niet onder handen wegtrekken. Concurrency-groepen zijn repo-breed, dus de
-    # verhuizing naar een eigen workflow verandert daar niets aan — de naam moet wél gelijk blijven.
+    # verhuizing naar een eigen workflow verandert daar niets aan — de namen moeten wél gelijk
+    # blijven aan `zad-<naam>-pr-<n>` daar.
+    concurrency:
+      group: zad-${{ matrix.naam }}-pr-${{ needs.doel.outputs.pr }}
+      cancel-in-progress: false
+    steps:
+      - name: Verwijder de ZAD-deployment
+        uses: RijksICTGilde/zad-actions/cleanup@b844c76eba3502b40a19be868cdf0586e322f4b8 # v4
+        with:
+          api-key: ${{ secrets[matrix.key] }}
+          project-id: ${{ matrix.project }}
+          deployment-name: pr-${{ needs.doel.outputs.pr }}
+          task-timeout: ${{ env.CLEANUP_TASK_TIMEOUT }}
+          delete-github-env: "false"
+          delete-github-deployments: "false"
+          delete-container: "false"
+          delete-pr-comment: "false"
+          # Teardown mag niet afhangen van wie de PR opende: een preview van een bot-PR moet net zo
+          # goed weg, en op een deployment die niet bestaat is de delete een no-op. Zonder deze
+          # uitzetting slaat de action bij een bot-auteur álles over en rapporteert groen.
+          skip-bot-prs: "false"
+
+      - name: Controleer dat de ZAD-deployment weg is
+        # Ook draaien als de stap hierboven faalde: dan is juist de vraag wat er is blijven staan.
+        if: ${{ !cancelled() }}
+        env:
+          API_KEY: ${{ secrets[matrix.key] }}
+          PROJECT: ${{ matrix.project }}
+          DEPLOYMENT: pr-${{ needs.doel.outputs.pr }}
+        run: |
+          set -euo pipefail
+
+          # `--max-time` zodat een stille TCP-stall niet tot de job-timeout doorloopt (dan is de
+          # uitkomst 'cancelled' en meet niemand meer iets); `--retry` zodat een 5xx-hik geen
+          # valse rode run oplevert. `|| code=000` vangt een transportfout op, zodat die als
+          # annotatie in de `*`-tak landt in plaats van als kale curl-regel in het steplog.
+          antwoord=$(curl -sS --max-time 30 --retry 3 --retry-connrefused \
+            -H "X-API-Key: $API_KEY" -H 'Accept: application/json' \
+            -w '\n%{http_code}' "$OM_API/v2/projects/$PROJECT/deployments") || antwoord=$'\n000'
+
+          code=${antwoord##*$'\n'}
+          lijst=${antwoord%$'\n'*}
+
+          if [ "$code" != "200" ]; then
+            echo "::error::Kon de deploymentlijst van $PROJECT niet lezen (HTTP $code) — de teardown van $DEPLOYMENT is NIET geverifieerd."
+            exit 1
+          fi
+
+          # `deployments` is in het OM-schema optioneel (een leeg project levert de sleutel niet).
+          if printf '%s' "$lijst" | jq -e --arg d "$DEPLOYMENT" '(.deployments // []) | any(.name == $d)' >/dev/null; then
+            # De DELETE zit bij OM bewust op het korte pad, zónder `/deployments/`.
+            echo "::error::$DEPLOYMENT bestaat nog in $PROJECT. Herdraai deze workflow via workflow_dispatch; blijft hij staan, verwijder hem dan met DELETE $OM_API/v2/projects/$PROJECT/$DEPLOYMENT."
+            exit 1
+          fi
+
+          echo "$DEPLOYMENT staat niet meer in de deploymentlijst van $PROJECT."
+
+  # De GitHub-kant doen we zelf in plaats van via de action: die verwijdert deployments zonder te
+  # pagineren (dus maximaal 30 per run), meldt een mislukking met een gewone `echo`, en kan bij de
+  # omgeving een 404 wegens ontbrekende rechten niet onderscheiden van "bestond al niet". Zelf
+  # verwijderen kost hier een paar regels en levert wél een exitcode én een nameting op.
+  cleanup-preview-github:
+    needs: doel
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # De omgeving hoort bij de uitvraag-deploy (die draagt `environment: pr-<n>`), dus dezelfde
+    # groep: hem weghalen tijdens een lopende deploy zou die deploy onderuit halen.
     concurrency:
       group: zad-uitvraag-pr-${{ needs.doel.outputs.pr }}
       cancel-in-progress: false
@@ -150,51 +251,23 @@ jobs:
       deployments: write
       pull-requests: write
     steps:
-      # Pre-flight bewust hier en niet in `doel`: alleen deze job gebruikt het token. Zat de check
-      # in `doel`, dan zou een ontbrekend of verlopen PAT ook de drie ZAD-deletes en de ghcr-sweep
-      # tegenhouden — die hebben het niet nodig, en dan blijven er pods en databases draaien om een
-      # GitHub-omgeving.
-      - name: Controleer GH_ADMIN_TOKEN aanwezig
-        env:
-          GH_ADMIN_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
-        run: |
-          if [ -z "$GH_ADMIN_TOKEN" ]; then
-            echo "::error::GH_ADMIN_TOKEN ontbreekt — de GitHub-omgeving kan niet opgeruimd worden. Zet de repo-secret (PAT met Administration: write)."
-            exit 1
-          fi
-
-      - name: Cleanup uitvraag-project
-        uses: RijksICTGilde/zad-actions/cleanup@b844c76eba3502b40a19be868cdf0586e322f4b8 # v4
-        with:
-          api-key: ${{ secrets.ZAD_API_KEY_UITVRAAG }}
-          project-id: ${{ env.PROJECT_UITVRAAG }}
-          deployment-name: pr-${{ needs.doel.outputs.pr }}
-          task-timeout: ${{ env.CLEANUP_TASK_TIMEOUT }}
-          delete-github-env: "true"
-          delete-github-deployments: "true"
-          delete-container: "false"
-          comment-header: ${{ env.COMMENT_HEADER }}
-          github-admin-token: ${{ secrets.GH_ADMIN_TOKEN }}
-          # Teardown mag niet afhangen van wie de PR opende: een preview van een bot-PR moet net zo
-          # goed weg, en op een deployment die niet bestaat is de delete een no-op. Zonder deze
-          # uitzetting slaat de action bij een bot-auteur álles over en rapporteert groen.
-          skip-bot-prs: "false"
-
-      # De comment-opruiming ín de action hangt aan `github.event_name == 'pull_request'` en slaat
-      # bij een handmatige run dus over. Juist dan is er iets in te halen: een gemiste opruiming
-      # laat de deploy-comment op een gesloten PR staan. Deze stap staat vóór de controles
-      # hieronder, zodat een mislukte controle hem niet overslaat.
-      - name: Verwijder de deploy-comment (handmatige run)
-        if: github.event_name == 'workflow_dispatch'
+      # Als eerste, want deze stap heeft het admin-token niet nodig: een ontbrekend PAT mag de
+      # comment- en deployment-opruiming niet tegenhouden.
+      - name: Verwijder de deploy-comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMMER: ${{ needs.doel.outputs.pr }}
         run: |
           set -euo pipefail
 
+          # Zelf doen i.p.v. via de action: die pagineert niet, dus op een PR met veel comments valt
+          # de deploy-comment buiten de eerste pagina. `--paginate` zónder `--jq` voegt de pagina's
+          # samen tot één array; de filter staat daarom in een losse `jq`, zodat een mislukte read
+          # als fout doorkomt in plaats van als lege lijst.
+          #
           # De header via `jq --arg` i.p.v. in het jq-programma interpoleren: `#` opent daar een
           # comment, dus de tekst hoort data te zijn, geen code.
-          ids=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMMER/comments" --paginate \
+          ids=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMMER/comments?per_page=100" --paginate \
             | jq -r --arg h "$COMMENT_HEADER" '.[] | select(.body | startswith($h)) | .id')
 
           if [ -z "$ids" ]; then
@@ -207,33 +280,7 @@ jobs:
             echo "Comment $id verwijderd."
           done
 
-      - name: Controleer dat de ZAD-deployment weg is
-        # Ook draaien als een eerdere stap faalde: dan is juist de vraag wat er is blijven staan.
-        if: ${{ !cancelled() }}
-        env:
-          API_KEY: ${{ secrets.ZAD_API_KEY_UITVRAAG }}
-          PROJECT: ${{ env.PROJECT_UITVRAAG }}
-          DEPLOYMENT: pr-${{ needs.doel.outputs.pr }}
-        run: |
-          set -euo pipefail
-
-          code=$(curl -sS -o /dev/null -w '%{http_code}' \
-            -H "X-API-Key: $API_KEY" -H 'Accept: application/json' \
-            "$OM_API/v2/projects/$PROJECT/deployments/$DEPLOYMENT")
-
-          case "$code" in
-            404) echo "Deployment $DEPLOYMENT is weg in $PROJECT." ;;
-            200)
-              echo "::error::$DEPLOYMENT bestaat nog in $PROJECT. Herdraai deze workflow via workflow_dispatch; blijft hij staan, verwijder hem dan met DELETE $OM_API/v2/projects/$PROJECT/$DEPLOYMENT."
-              exit 1
-              ;;
-            *)
-              echo "::error::Kon niet vaststellen of $DEPLOYMENT weg is in $PROJECT (HTTP $code) — de teardown is NIET geverifieerd."
-              exit 1
-              ;;
-          esac
-
-      - name: Controleer dat de GitHub-deployments weg zijn
+      - name: Verwijder de GitHub-deployments en controleer dat ze weg zijn
         if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -241,133 +288,62 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Zonder `2>/dev/null`: een mislukte read moet deze job rood maken en niet als "geen
-          # deployments" lezen. De action zelf onderdrukt die fout wél, en meldt een mislukte
-          # delete met een gewone `echo` — in de UI dus onzichtbaar.
-          aantal=$(gh api "repos/$GITHUB_REPOSITORY/deployments?environment=$OMGEVING" --jq 'length')
+          # Een deployment-record per deploy-run, dus per push: pagineren is nodig, anders blijft er
+          # vanaf de 31e stilletjes een staan. Geen `2>/dev/null`: een mislukte read moet deze job
+          # rood maken en niet als "geen deployments" lezen.
+          ids=$(gh api "repos/$GITHUB_REPOSITORY/deployments?environment=$OMGEVING&per_page=100" \
+            --paginate --jq '.[].id')
 
-          if [ "$aantal" != "0" ]; then
-            echo "::error::Er staan nog $aantal GitHub-deployments op omgeving $OMGEVING."
+          for id in ${ids:-}; do
+            # Een deployment is pas verwijderbaar als hij inactief is.
+            gh api "repos/$GITHUB_REPOSITORY/deployments/$id/statuses" -X POST -f state=inactive --silent
+            gh api "repos/$GITHUB_REPOSITORY/deployments/$id" -X DELETE --silent
+            echo "Deployment $id verwijderd."
+          done
+
+          resterend=$(gh api "repos/$GITHUB_REPOSITORY/deployments?environment=$OMGEVING&per_page=100" \
+            --paginate --jq '.[].id' | wc -l)
+
+          if [ "$resterend" -ne 0 ]; then
+            echo "::error::Er staan nog $resterend GitHub-deployments op omgeving $OMGEVING."
             exit 1
           fi
 
           echo "Geen GitHub-deployments meer op $OMGEVING."
 
-      - name: Controleer dat de GitHub-omgeving weg is
+      - name: Verwijder de GitHub-omgeving en controleer dat hij weg is
         if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ADMIN_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
           OMGEVING: pr-${{ needs.doel.outputs.pr }}
         run: |
           set -euo pipefail
 
-          code=$(curl -sS -o /dev/null -w '%{http_code}' \
-            -H "Authorization: Bearer $GH_TOKEN" \
+          if [ -z "$ADMIN_TOKEN" ]; then
+            echo "::error::GH_ADMIN_TOKEN ontbreekt — de omgeving $OMGEVING kan niet verwijderd worden. Zet de repo-secret (PAT met Administration: write)."
+            exit 1
+          fi
+
+          code=$(curl -sS --max-time 30 --retry 3 --retry-connrefused -o /dev/null \
+            -w '%{http_code}' -X DELETE \
+            -H "Authorization: Bearer $ADMIN_TOKEN" \
             -H 'Accept: application/vnd.github+json' \
             -H 'X-GitHub-Api-Version: 2022-11-28' \
-            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/environments/$OMGEVING")
+            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/environments/$OMGEVING") || code=000
+          echo "DELETE omgeving $OMGEVING gaf HTTP $code."
 
-          case "$code" in
-            404) echo "Omgeving $OMGEVING is weg." ;;
-            200)
-              echo "::error::Omgeving $OMGEVING bestaat nog. GitHub antwoordt op een DELETE zonder de juiste rechten met 404, dus de action kan een rechtenprobleem niet van 'bestond al niet' onderscheiden: geef GH_ADMIN_TOKEN 'Administration: write' op deze repo (fine-grained) of 'repo'-scope plus repo-admin (classic) en herdraai deze workflow via workflow_dispatch."
-              exit 1
-              ;;
-            *)
-              echo "::error::Kon niet vaststellen of omgeving $OMGEVING weg is (HTTP $code) — de teardown is NIET geverifieerd."
-              exit 1
-              ;;
-          esac
+          # De statuscode van die DELETE is geen bewijs: GitHub antwoordt met 404 wanneer het token
+          # de resource niet mag zien, wat niet te onderscheiden is van "bestond al niet". Lezen mag
+          # wél met het automatische token — alleen verwijderen vraagt Administration: write — dus
+          # de lijst is hier de betrouwbare toets.
+          if gh api "repos/$GITHUB_REPOSITORY/environments?per_page=100" --paginate \
+            --jq '.environments[].name' | grep -qxF "$OMGEVING"; then
+            echo "::error::Omgeving $OMGEVING bestaat nog (DELETE gaf HTTP $code). Geef GH_ADMIN_TOKEN 'Administration: write' op deze repo (fine-grained) of 'repo'-scope plus repo-admin (classic) en herdraai deze workflow via workflow_dispatch."
+            exit 1
+          fi
 
-  cleanup-preview-externe-stubs:
-    needs: doel
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    concurrency:
-      group: zad-externe-stubs-pr-${{ needs.doel.outputs.pr }}
-      cancel-in-progress: false
-    steps:
-      - name: Cleanup externe-stubs-project
-        uses: RijksICTGilde/zad-actions/cleanup@b844c76eba3502b40a19be868cdf0586e322f4b8 # v4
-        with:
-          api-key: ${{ secrets.ZAD_API_KEY_PROFIEL }}
-          project-id: ${{ env.PROJECT_EXTERNE_STUBS }}
-          deployment-name: pr-${{ needs.doel.outputs.pr }}
-          task-timeout: ${{ env.CLEANUP_TASK_TIMEOUT }}
-          delete-container: "false"
-          skip-bot-prs: "false"
-          # Zonder pull-requests: write kan deze job geen comment verwijderen; dat doet de
-          # uitvraag-job, die de rechten wél heeft.
-          delete-pr-comment: "false"
-
-      - name: Controleer dat de ZAD-deployment weg is
-        if: ${{ !cancelled() }}
-        env:
-          API_KEY: ${{ secrets.ZAD_API_KEY_PROFIEL }}
-          PROJECT: ${{ env.PROJECT_EXTERNE_STUBS }}
-          DEPLOYMENT: pr-${{ needs.doel.outputs.pr }}
-        run: |
-          set -euo pipefail
-
-          code=$(curl -sS -o /dev/null -w '%{http_code}' \
-            -H "X-API-Key: $API_KEY" -H 'Accept: application/json' \
-            "$OM_API/v2/projects/$PROJECT/deployments/$DEPLOYMENT")
-
-          case "$code" in
-            404) echo "Deployment $DEPLOYMENT is weg in $PROJECT." ;;
-            200)
-              echo "::error::$DEPLOYMENT bestaat nog in $PROJECT. Herdraai deze workflow via workflow_dispatch; blijft hij staan, verwijder hem dan met DELETE $OM_API/v2/projects/$PROJECT/$DEPLOYMENT."
-              exit 1
-              ;;
-            *)
-              echo "::error::Kon niet vaststellen of $DEPLOYMENT weg is in $PROJECT (HTTP $code) — de teardown is NIET geverifieerd."
-              exit 1
-              ;;
-          esac
-
-  cleanup-preview-magazijnen:
-    needs: doel
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    concurrency:
-      group: zad-magazijnen-pr-${{ needs.doel.outputs.pr }}
-      cancel-in-progress: false
-    steps:
-      - name: Cleanup magazijnen-project
-        uses: RijksICTGilde/zad-actions/cleanup@b844c76eba3502b40a19be868cdf0586e322f4b8 # v4
-        with:
-          api-key: ${{ secrets.ZAD_API_KEY_MAGAZIJNEN }}
-          project-id: ${{ env.PROJECT_MAGAZIJNEN }}
-          deployment-name: pr-${{ needs.doel.outputs.pr }}
-          task-timeout: ${{ env.CLEANUP_TASK_TIMEOUT }}
-          delete-container: "false"
-          skip-bot-prs: "false"
-          delete-pr-comment: "false"
-
-      - name: Controleer dat de ZAD-deployment weg is
-        if: ${{ !cancelled() }}
-        env:
-          API_KEY: ${{ secrets.ZAD_API_KEY_MAGAZIJNEN }}
-          PROJECT: ${{ env.PROJECT_MAGAZIJNEN }}
-          DEPLOYMENT: pr-${{ needs.doel.outputs.pr }}
-        run: |
-          set -euo pipefail
-
-          code=$(curl -sS -o /dev/null -w '%{http_code}' \
-            -H "X-API-Key: $API_KEY" -H 'Accept: application/json' \
-            "$OM_API/v2/projects/$PROJECT/deployments/$DEPLOYMENT")
-
-          case "$code" in
-            404) echo "Deployment $DEPLOYMENT is weg in $PROJECT." ;;
-            200)
-              echo "::error::$DEPLOYMENT bestaat nog in $PROJECT. Herdraai deze workflow via workflow_dispatch; blijft hij staan, verwijder hem dan met DELETE $OM_API/v2/projects/$PROJECT/$DEPLOYMENT."
-              exit 1
-              ;;
-            *)
-              echo "::error::Kon niet vaststellen of $DEPLOYMENT weg is in $PROJECT (HTTP $code) — de teardown is NIET geverifieerd."
-              exit 1
-              ;;
-          esac
+          echo "Omgeving $OMGEVING staat niet meer in de lijst."
 
   # Ruimt ALLE images van de PR op: één ghcr-versie per commit, niet alleen de laatste. De
   # tags van deze PR zijn te herkennen aan de prefix `pr-<n>-`; het afsluitende koppelteken
@@ -414,7 +390,8 @@ jobs:
               continue
             fi
 
-            # --paginate levert per pagina een eigen array; jq verwerkt ze als losse inputs.
+            # `--paginate` zónder `--jq` voegt de pagina's samen tot één array; de filter staat
+            # daarom in een losse `jq`, zodat een mislukte read als fout doorkomt.
             ids=$(printf '%s' "$versions" | jq -r --arg p "$PREFIX" --arg legacy "$LEGACY_TAG" \
               '.[] | select(.metadata.container.tags | any(startswith($p) or . == $legacy)) | .id')
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,13 +49,10 @@
 # bij de PR naar main. Een gestapelde PR is inhoudelijk getoetst maar niet security-gescand; weeg
 # dat mee bij het reviewen ervan.
 #
-# OPRUIMEN STAAT IN cleanup-preview.yml, niet hier: dat filter mag niet op teardown drukken.
-# Een PR die ná zijn preview-deploy van main weggericht werd, sloot buiten dit filter en liet zo
-# zijn pr-<n>-deployments, ghcr-tags en omgeving achter. Die workflow triggert daarom op élk
-# sluiten, ongeacht doelbranch, en heeft een workflow_dispatch om een gemiste opruiming in te
-# halen. De omgekeerde beweging — GitHub's automatische retarget náár main bij het mergen van de
-# parent — is veilig: de checks zijn dan afwezig i.p.v. groen, en `strict: true` op main dwingt
-# sowieso een verse run af.
+# OPRUIMEN STAAT IN cleanup-preview.yml: het `branches`-filter hieronder mag niet op teardown
+# drukken (rationale daar). De omgekeerde beweging — GitHub's automatische retarget náár main bij
+# het mergen van de parent — is veilig: de checks zijn dan afwezig i.p.v. groen, en `strict: true`
+# op main dwingt sowieso een verse run af.
 #
 # TIMEOUT-MINUTES OP ELKE JOB: GitHub's default is 360 minuten. Een job die hangt (netwerkstall,
 # vastgelopen Testcontainer, een herintroduceerde wachtlus) houdt dan zes uur een runner bezet
@@ -93,8 +90,8 @@ on:
   push:
     branches: [main]
 
-# Least-privilege default voor GITHUB_TOKEN: read-only op workflow-niveau; jobs die schrijven
-# (build → packages, deploy-preview → pull-requests) declareren dat zelf.
+# Least-privilege default voor GITHUB_TOKEN: read-only op workflow-niveau; elke job die schrijft
+# declareert zijn eigen scopes.
 permissions: read-all
 
 # GEEN workflow-brede concurrency. De toetsende checks draaien sinds #173 als jobs ín deze
@@ -106,7 +103,7 @@ permissions: read-all
 #   * build/toetsing → eigen groep met cancel-in-progress: true (achterhaald werk stoppen);
 #   * deploy → eigen groep PER PROJECT + doel-deployment met cancel-in-progress: false
 #     (nooit halverwege afbreken; per project apart zodat de drie parallelle jobs elkaar niet
-#     blokkeren, wat met één gedeelde groep wél zou gebeuren). De opruim-jobs in
+#     blokkeren, wat met één gedeelde groep wél zou gebeuren). De drie project-opruim-jobs in
 #     cleanup-preview.yml zitten in dezelfde groepen.
 
 env:
@@ -134,6 +131,10 @@ env:
   # application to be created" komt daarentegen van OM zelf (Argo-Application-wait) en wordt
   # NIET door deze waarde beïnvloed — die deploys landen alsnog gezond; opnieuw draaien volstaat.
   PREVIEW_TASK_TIMEOUT: '900'
+  # Beide workflows geven deze header expliciet mee in plaats van op de action-default te leunen:
+  # cleanup-preview.yml zoekt de comment op deze tekst, dus drift tussen plaatsen en opruimen laat
+  # hem stil achter op een gesloten PR.
+  COMMENT_HEADER: '## 🚀 Preview Deployment'
 
 jobs:
   # Bepaalt in één keer wát er voor deze revisie moet draaien. Levert vier onafhankelijke
@@ -148,10 +149,8 @@ jobs:
   # Twee gevallen rollen niet uit:
   # - Wijzigingen die de uitgerolde applicatie niet raken (docs, bruno, demo, demo-console).
   # - PR's van een bot: `zad-actions` weigert die zelf (`skip-bot-prs`, default true), dus de
-  #   preview komt er toch niet. Zonder deze uitsluiting bouwden en pushten we er wél drie
-  #   images voor die nooit een pod bereiken — en de cleanup slaat bot-PR's óók over, dus die
-  #   bleven permanent in ghcr staan (zichtbaar aan `pr-143` en `pr-167` van gesloten
-  #   Dependabot-PR's).
+  #   preview komt er toch niet. Zonder deze uitsluiting bouwden en pushten we er wél images voor
+  #   die nooit een pod bereiken.
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -299,7 +298,8 @@ jobs:
   # per commit.
   #
   # Elke build krijgt zo zijn eigen tag; `cleanup-preview-images` in cleanup-preview.yml ruimt ze
-  # bij PR-sluiten allemaal op — op prefix, plus de kale `pr-<n>` van vóór deze wijziging.
+  # bij PR-sluiten allemaal op — op prefix, plus de kale `pr-<n>` uit de tijd vóór de
+  # per-commit-tags.
   meta:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -470,7 +470,8 @@ jobs:
   # De uitkomst is daarmee fail-safe — hij wordt opnieuw bepaald, niet aangenomen.
   checks-test:
     needs: changes
-    # `${{ }}` verplicht: een scalar die met `!` begint is in YAML een gereserveerde indicator.
+    # `!` mag geen plain scalar beginnen (YAML-tagindicator), vandaar `${{ }}`; een blokscalar
+    # (`>-`, zoals bij `checks-fuzz`) werkt net zo goed.
     if: ${{ !cancelled() }}
     uses: ./.github/workflows/test.yml
     with:
@@ -618,6 +619,7 @@ jobs:
           deployment-name: pr-${{ github.event.pull_request.number }}
           clone-from: test
           comment-on-pr: 'true'
+          comment-header: ${{ env.COMMENT_HEADER }}
           wait-for-ready: 'false'
           task-timeout: ${{ env.PREVIEW_TASK_TIMEOUT }}
           components: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,11 +49,13 @@
 # bij de PR naar main. Een gestapelde PR is inhoudelijk getoetst maar niet security-gescand; weeg
 # dat mee bij het reviewen ervan.
 #
-# BEKENDE BEPERKING: wordt een PR ná een preview-deploy handmatig weggericht van main, dan valt
-# hij buiten dit filter en ruimt het sluiten zijn pr-<n>-deployments en ghcr-tags niet meer op.
-# Handmatig opruimen (of de base terugzetten vóór het sluiten). De omgekeerde beweging —
-# GitHub's automatische retarget náár main bij het mergen van de parent — is veilig: de checks
-# zijn dan afwezig i.p.v. groen, en `strict: true` op main dwingt sowieso een verse run af.
+# OPRUIMEN STAAT IN cleanup-preview.yml, niet hier: dat filter mag niet op teardown drukken.
+# Een PR die ná zijn preview-deploy van main weggericht werd, sloot buiten dit filter en liet zo
+# zijn pr-<n>-deployments, ghcr-tags en omgeving achter. Die workflow triggert daarom op élk
+# sluiten, ongeacht doelbranch, en heeft een workflow_dispatch om een gemiste opruiming in te
+# halen. De omgekeerde beweging — GitHub's automatische retarget náár main bij het mergen van de
+# parent — is veilig: de checks zijn dan afwezig i.p.v. groen, en `strict: true` op main dwingt
+# sowieso een verse run af.
 #
 # TIMEOUT-MINUTES OP ELKE JOB: GitHub's default is 360 minuten. Een job die hangt (netwerkstall,
 # vastgelopen Testcontainer, een herintroduceerde wachtlus) houdt dan zes uur een runner bezet
@@ -65,8 +67,7 @@
 #   ZAD_API_KEY_UITVRAAG    — API-key project mpfb-8wh
 #   ZAD_API_KEY_PROFIEL     — API-key project mpfpsm-lcl (externe-stubs)
 #   ZAD_API_KEY_MAGAZIJNEN  — API-key project mpfm-w3h
-#   GH_ADMIN_TOKEN          — PAT met repo-admin (env-cleanup; GITHUB_TOKEN mag dat niet;
-#                             naam zónder `GITHUB_`-prefix — die is gereserveerd)
+# (GH_ADMIN_TOKEN hoort bij het opruimen en staat beschreven in cleanup-preview.yml.)
 
 name: Deploy ZAD
 
@@ -85,12 +86,15 @@ on:
   # toetsing. Alleen de deploy valt weg. Samen dekken de twee filters elke PR precies één keer.
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, closed]
+    # Geen `closed`: het sluiten van een PR heeft hier niets te doen sinds het opruimen in
+    # cleanup-preview.yml staat. Elke job zou eraan moeten ontsnappen met een
+    # `action != 'closed'`-clausule, en de run zelf zou een lege, volledig overgeslagen run zijn.
+    types: [opened, synchronize, reopened]
   push:
     branches: [main]
 
 # Least-privilege default voor GITHUB_TOKEN: read-only op workflow-niveau; jobs die schrijven
-# (build → packages, cleanup → deployments/packages/pull-requests) declareren dat zelf.
+# (build → packages, deploy-preview → pull-requests) declareren dat zelf.
 permissions: read-all
 
 # GEEN workflow-brede concurrency. De toetsende checks draaien sinds #173 als jobs ín deze
@@ -100,9 +104,10 @@ permissions: read-all
 # halverwege afgebroken kunnen worden, wat een deployment in een inconsistente staat achterlaat.
 # Beide eisen tegelijk kan alleen per job:
 #   * build/toetsing → eigen groep met cancel-in-progress: true (achterhaald werk stoppen);
-#   * deploy/cleanup → eigen groep PER PROJECT + doel-deployment met cancel-in-progress: false
+#   * deploy → eigen groep PER PROJECT + doel-deployment met cancel-in-progress: false
 #     (nooit halverwege afbreken; per project apart zodat de drie parallelle jobs elkaar niet
-#     blokkeren, wat met één gedeelde groep wél zou gebeuren).
+#     blokkeren, wat met één gedeelde groep wél zou gebeuren). De opruim-jobs in
+#     cleanup-preview.yml zitten in dezelfde groepen.
 
 env:
   REGISTRY: ghcr.io
@@ -148,8 +153,6 @@ jobs:
   #   bleven permanent in ghcr staan (zichtbaar aan `pr-143` en `pr-167` van gesloten
   #   Dependabot-PR's).
   changes:
-    # Op een close-event slaan alle consumenten over, dus dan valt er niets te bepalen.
-    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -295,8 +298,8 @@ jobs:
   # herstart, en die komt niet vanzelf. Op main speelde het niet: `main-<sha7>` wijzigt al
   # per commit.
   #
-  # Elke build krijgt zo zijn eigen tag; `cleanup-preview-images` ruimt ze bij PR-sluiten
-  # allemaal op — op prefix, plus de kale `pr-<n>` van vóór deze wijziging.
+  # Elke build krijgt zo zijn eigen tag; `cleanup-preview-images` in cleanup-preview.yml ruimt ze
+  # bij PR-sluiten allemaal op — op prefix, plus de kale `pr-<n>` van vóór deze wijziging.
   meta:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -330,12 +333,11 @@ jobs:
           fi
           echo "owner=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
 
-  # Bouw + push de service-images met jib (geen Dockerfile). Niet op PR-close, en niet wanneer
-  # `changes` de keten heeft uitgesloten: zo'n revisie deployt toch niet, dus twee volledige
-  # Maven/jib-builds + push kosten dan alleen rekentijd, netwerk en een ghcr-versie die nooit
-  # een pod bereikt.
+  # Bouw + push de service-images met jib (geen Dockerfile). Niet wanneer `changes` de keten heeft
+  # uitgesloten: zo'n revisie deployt toch niet, dus twee volledige Maven/jib-builds + push kosten
+  # dan alleen rekentijd, netwerk en een ghcr-versie die nooit een pod bereikt.
   build:
-    if: github.event_name == 'push' || (github.event.action != 'closed' && needs.changes.outputs.deploy == 'true')
+    if: github.event_name == 'push' || needs.changes.outputs.deploy == 'true'
     needs: [meta, changes]
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -391,7 +393,7 @@ jobs:
   # tag-hergebruikstrategie vergen die daarmee botst. De prijs is een herbouw per commit; de
   # opbrengst van een filter weegt daar niet tegenop zolang de per-commit-tag de basis is.
   build-externe-stubs:
-    if: github.event_name == 'push' || (github.event.action != 'closed' && needs.changes.outputs.deploy == 'true')
+    if: github.event_name == 'push' || needs.changes.outputs.deploy == 'true'
     needs: [meta, changes]
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -420,7 +422,7 @@ jobs:
   # verkeer binnen hetzelfde deployment toe. Eén image, twee rollen — welke, leest het entrypoint
   # uit FSC_ROL in de component-env.
   build-contract-bootstrap:
-    if: github.event_name == 'push' || (github.event.action != 'closed' && needs.changes.outputs.run == 'true')
+    if: github.event_name == 'push' || needs.changes.outputs.run == 'true'
     needs: [meta, changes]
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -457,8 +459,6 @@ jobs:
   # dan moet de required context mee. Een required context die nooit meer verschijnt, blokkeert
   # elke merge.
   #
-  # `github.event.action != 'closed'`: de close-trigger is er voor de cleanup-jobs, daar valt
-  # niets te toetsen.
   # De caller-jobs staan bewust ALTIJD aan; het overslaan gebeurt binnen de aangeroepen
   # workflow. Een overgeslagen caller-job draait die workflow namelijk nooit, waardoor de
   # geneste check-run (`checks-test / test`) niet bestaat — en een required context die niet
@@ -470,9 +470,8 @@ jobs:
   # De uitkomst is daarmee fail-safe — hij wordt opnieuw bepaald, niet aangenomen.
   checks-test:
     needs: changes
-    if: >-
-      !cancelled()
-      && (github.event_name == 'push' || github.event.action != 'closed')
+    # `${{ }}` verplicht: een scalar die met `!` begint is in YAML een gereserveerde indicator.
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/test.yml
     with:
       wijzigingen-relevant: ${{ needs.changes.outputs.run }}
@@ -485,9 +484,7 @@ jobs:
 
   checks-detekt:
     needs: changes
-    if: >-
-      !cancelled()
-      && (github.event_name == 'push' || github.event.action != 'closed')
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/detekt.yml
     with:
       wijzigingen-relevant: ${{ needs.changes.outputs.run }}
@@ -497,7 +494,6 @@ jobs:
       security-events: write
 
   checks-pins:
-    if: github.event_name == 'push' || github.event.action != 'closed'
     uses: ./.github/workflows/pin-consistency.yml
     # pull-requests: write voor de melding over een verouderde fuzz-basis-image-pin; een
     # aangeroepen workflow kan nooit meer krijgen dan de caller-job toekent.
@@ -512,7 +508,6 @@ jobs:
     if: >-
       !cancelled()
       && github.event_name == 'pull_request'
-      && github.event.action != 'closed'
     uses: ./.github/workflows/cflite_pr.yml
     with:
       fuzz-relevant: ${{ needs.changes.outputs.fuzz }}
@@ -532,12 +527,11 @@ jobs:
     # `!cancelled()` i.p.v. de impliciete success(): een overgeslagen `checks-fuzz` (push naar main)
     # zou deze job anders meeslepen in 'skipped' en de deploy stilzwijgend blokkeren. Bij een
     # geannuleerde run hoeft de poort juist niet meer te oordelen.
-    # Niet op PR-close (teardown, geen deploy) en niet wanneer `changes` de keten heeft
-    # uitgesloten (docs-only of bot-PR) — dan valt er niets te bewaken.
+    # Niet wanneer `changes` de keten heeft uitgesloten (docs-only of bot-PR) — dan valt er niets
+    # te bewaken.
     if: >-
       !cancelled()
-      && (github.event_name == 'push'
-          || (github.event.action != 'closed' && needs.changes.outputs.deploy == 'true'))
+      && (github.event_name == 'push' || needs.changes.outputs.deploy == 'true')
     needs: [changes, checks-test, checks-detekt, checks-pins, checks-fuzz]
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -594,14 +588,15 @@ jobs:
   # (redis) die op dat pad nooit 2xx geven → de wachtlus zou timen out. Aanzetten
   # kan pas met een per-component health-endpoint of een Quarkus-only deployment; tot dan 'false'.
   deploy-preview-uitvraag:
-    if: github.event_name == 'pull_request' && github.event.action != 'closed' && needs.changes.outputs.deploy == 'true'
+    if: github.event_name == 'pull_request' && needs.changes.outputs.deploy == 'true'
     needs: [meta, build, build-externe-stubs, gate, changes]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # Eén ZAD-taak tegelijk op deze deployment; een nieuwe push wacht op de lopende i.p.v. die af
     # te breken — een halverwege afgebroken ZAD-deploy laat de deployment in een inconsistente
-    # staat achter. De cleanup-job voor hetzelfde project + dezelfde PR deelt deze groep, zodat een
-    # PR-close een lopende deploy niet onder handen wegtrekt.
+    # staat achter. De cleanup-job in cleanup-preview.yml draagt voor hetzelfde project + dezelfde
+    # PR dezelfde groepsnaam (concurrency-groepen zijn repo-breed), zodat een PR-close een lopende
+    # deploy niet onder handen wegtrekt.
     concurrency:
       group: zad-uitvraag-pr-${{ github.event.pull_request.number }}
       cancel-in-progress: false
@@ -632,7 +627,7 @@ jobs:
             ]
 
   deploy-preview-externe-stubs:
-    if: github.event_name == 'pull_request' && github.event.action != 'closed' && needs.changes.outputs.deploy == 'true'
+    if: github.event_name == 'pull_request' && needs.changes.outputs.deploy == 'true'
     needs: [meta, build, build-externe-stubs, gate, changes]
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -659,7 +654,7 @@ jobs:
             ]
 
   deploy-preview-magazijnen:
-    if: github.event_name == 'pull_request' && github.event.action != 'closed' && needs.changes.outputs.deploy == 'true'
+    if: github.event_name == 'pull_request' && needs.changes.outputs.deploy == 'true'
     needs: [meta, build, build-externe-stubs, gate, changes]
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -683,151 +678,6 @@ jobs:
               {"name": "magazijna", "image": "${{ env.REGISTRY }}/${{ needs.meta.outputs.owner }}/fbs-berichtenmagazijn:${{ needs.meta.outputs.tag }}"},
               {"name": "magazijnb", "image": "${{ env.REGISTRY }}/${{ needs.meta.outputs.owner }}/fbs-berichtenmagazijn:${{ needs.meta.outputs.tag }}"}
             ]
-
-  # Opruimen bij PR-sluiten: per project een eigen (parallelle) job die zijn eigen deployment
-  # opruimt. De GitHub-environment (één per PR) ruimt alleen de uitvraag-job op; de andere
-  # zetten delete-github-env uit. De images gaan in één aparte job (cleanup-preview-images):
-  # de `delete-container`-stap van zad-actions verwijdert precies één exacte tag per package,
-  # en een PR heeft er sinds de unieke tags één per commit.
-  cleanup-preview-uitvraag:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    # Zelfde groep als de deploy-job van dit project + deze PR: opruimen mag een lopende deploy
-    # niet onder handen wegtrekken.
-    concurrency:
-      group: zad-uitvraag-pr-${{ github.event.pull_request.number }}
-      cancel-in-progress: false
-    permissions:
-      deployments: write
-      pull-requests: write
-    steps:
-      # Pre-flight: een ontbrekende GH_ADMIN_TOKEN zou de env-/deployment-cleanup pas
-      # diep in de action laten falen (low-visibility moment bij PR-close). Faal hier luid.
-      - name: Controleer GH_ADMIN_TOKEN aanwezig
-        env:
-          GH_ADMIN_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
-        run: |
-          if [ -z "$GH_ADMIN_TOKEN" ]; then
-            echo "::error::GH_ADMIN_TOKEN ontbreekt — env-/deployment-cleanup kan niet draaien. Zet de repo-secret (PAT met repo-admin)."
-            exit 1
-          fi
-      - name: Cleanup uitvraag-project
-        uses: RijksICTGilde/zad-actions/cleanup@b844c76eba3502b40a19be868cdf0586e322f4b8 # v4
-        with:
-          api-key: ${{ secrets.ZAD_API_KEY_UITVRAAG }}
-          project-id: ${{ env.PROJECT_UITVRAAG }}
-          deployment-name: pr-${{ github.event.pull_request.number }}
-          delete-github-env: 'true'
-          delete-github-deployments: 'true'
-          delete-container: 'false'
-          github-admin-token: ${{ secrets.GH_ADMIN_TOKEN }}
-
-  cleanup-preview-externe-stubs:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    concurrency:
-      group: zad-externe-stubs-pr-${{ github.event.pull_request.number }}
-      cancel-in-progress: false
-    steps:
-      - name: Cleanup externe-stubs-project
-        uses: RijksICTGilde/zad-actions/cleanup@b844c76eba3502b40a19be868cdf0586e322f4b8 # v4
-        with:
-          api-key: ${{ secrets.ZAD_API_KEY_PROFIEL }}
-          project-id: ${{ env.PROJECT_EXTERNE_STUBS }}
-          deployment-name: pr-${{ github.event.pull_request.number }}
-          delete-github-env: 'false'
-          delete-container: 'false'
-
-  cleanup-preview-magazijnen:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    concurrency:
-      group: zad-magazijnen-pr-${{ github.event.pull_request.number }}
-      cancel-in-progress: false
-    steps:
-      - name: Cleanup magazijnen-project
-        uses: RijksICTGilde/zad-actions/cleanup@b844c76eba3502b40a19be868cdf0586e322f4b8 # v4
-        with:
-          api-key: ${{ secrets.ZAD_API_KEY_MAGAZIJNEN }}
-          project-id: ${{ env.PROJECT_MAGAZIJNEN }}
-          deployment-name: pr-${{ github.event.pull_request.number }}
-          delete-github-env: 'false'
-          delete-container: 'false'
-
-  # Ruimt ALLE images van de PR op: één ghcr-versie per commit, niet alleen de laatste. De
-  # tags van deze PR zijn te herkennen aan de prefix `pr-<n>-`; het afsluitende koppelteken
-  # is essentieel, anders zou het sluiten van PR 16 de images van PR 168 meenemen.
-  #
-  # Bewust niet de `delete-container`-stap van zad-actions: die verwijdert één exacte tag, wat
-  # met unieke tags per commit alle tussenversies zou laten staan. Ook bewust géén
-  # package-brede fallback bij "cannot delete the last tagged version" (die de action wél
-  # heeft): dat zou een preview-cleanup het hele package laten verwijderen inclusief de
-  # main-images. De `main-<sha7>`-tags zorgen ervoor dat die situatie zich niet voordoet.
-  #
-  # RACE bij sluiten tijdens een lopende build (~85 s venster): sinds de workflow-brede
-  # concurrency naar job-niveau verhuisde (#173) wachten de jobs van een close-run niet meer op
-  # een nog draaiende build van een eerdere push. Sluit iemand de PR vlak na een push, dan kan
-  # deze sweep vóór die push af zijn en blijft één ghcr-versie achter. De build-jobs joinen niet
-  # in deze groep, want ze hebben er per service al één (anders zouden ze elkaar blokkeren).
-  # Gevolg is één weesversie, geen kapotte deploy; opruimen kan door deze job te herdraaien.
-  cleanup-preview-images:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    needs: meta
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      packages: write
-    steps:
-      - name: Verwijder de ghcr-versies van deze PR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ORG: ${{ needs.meta.outputs.owner }}
-          PREFIX: pr-${{ github.event.pull_request.number }}-
-          # Overgangsgeval: PR's die al liepen vóór de unieke tags bestonden, hebben nog een
-          # kale `pr-<n>`-versie in ghcr staan. Die valt niet onder de prefix, dus expliciet
-          # meenemen — anders blijft hij achter zodra zo'n PR sluit.
-          LEGACY_TAG: pr-${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          fail=0
-
-          # Expliciete lijst, bewust niet afgeleid uit alle org-packages: de prefix `pr-<n>-`
-          # is niet uniek binnen de organisatie, dus een brede sweep zou images van een
-          # gelijkgenummerde PR in een andere repo kunnen wissen. Houd deze lijst in sync met
-          # de `build`-matrix, `build-externe-stubs` en `build-contract-bootstrap`; een vergeten
-          # package laat weesversies achter.
-          for pkg in fbs-berichtenuitvraag fbs-berichtenmagazijn fbs-externe-stubs fbs-fsc-contract-bootstrap; do
-            if ! versions=$(gh api --paginate "orgs/$ORG/packages/container/$pkg/versions?per_page=100"); then
-              echo "::warning::Kon de versies van $pkg niet ophalen — images van deze PR blijven mogelijk staan."
-              fail=1
-              continue
-            fi
-
-            # --paginate levert per pagina een eigen array; jq verwerkt ze als losse inputs.
-            ids=$(printf '%s' "$versions" | jq -r --arg p "$PREFIX" --arg legacy "$LEGACY_TAG" \
-              '.[] | select(.metadata.container.tags | any(startswith($p) or . == $legacy)) | .id')
-
-            if [ -z "$ids" ]; then
-              echo "$pkg: geen versies met tag $LEGACY_TAG of prefix $PREFIX."
-              continue
-            fi
-
-            for id in $ids; do
-              if gh api "orgs/$ORG/packages/container/$pkg/versions/$id" -X DELETE; then
-                echo "$pkg: versie $id verwijderd."
-              else
-                echo "::warning::$pkg: versie $id niet verwijderd."
-                fail=1
-              fi
-            done
-          done
-
-          # Achterblijvende images zijn geen reden om de PR-afsluiting te blokkeren, maar het
-          # moet wel als rode job zichtbaar zijn — anders groeit de ghcr-berg ongemerkt door.
-          exit "$fail"
 
   # Push naar main → per project de `test`-deployment (de baseline waarvan previews klonen;
   # env/secrets configureer je daar in Operations Manager). Per project een eigen parallelle job.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,9 +175,13 @@ een directe `kubectl`- of live-OM-wijziging aan een draaiende deployment wordt
 teruggedraaid naar wat in Git staat. Reactiveren/schalen moet dus via OM (dat commit
 naar de Git-repo die Argo volgt), niet handmatig in de cluster of in de gerenderde repo.
 
-**Projecten (project-id = OM-project, ook in `.github/workflows/deploy.yml`-env):**
+**Projecten (project-id = OM-project; staat in de env van `.github/workflows/deploy.yml` én in de
+matrix van `.github/workflows/cleanup-preview.yml` — wijzig een id op beide plekken, anders
+verifieert de opruiming de afwezigheid in een project dat niet bestaat):**
 `berichtenuitvraag` = `mpfb-8wh`, `magazijnen` = `mpfm-w3h`, `externe-stubs` = `mpfpsm-lcl`.
 Deployment-namen: `test` (baseline, push→main) en `pr-<n>` (previews, clone-from `test`).
+Previews worden opgeruimd door `cleanup-preview.yml` bij het sluiten van de PR; een gemiste
+opruiming haal je in met `gh workflow run cleanup-preview.yml -f pr=<n>`.
 
 **Drie GitOps-lagen (allemaal `RijksICTGilde`-repos, `gh api` leest ze — deels private):**
 
@@ -246,6 +250,7 @@ géén uitgeschakeld component**).
 | `bruno/<service-naam>/`                | Bruno-collectie per service (handmatige / exploratieve API-requests tegen de lokale dev-mode) |
 | `compose.yaml`                         | Lokale dev-omgeving (Redis, WireMock, PostgreSQL)               |
 | `.github/workflows/`                   | CI: CodeQL security scanning, Scorecard, Architecture validatie |
+| `.github/workflows/cleanup-preview.yml` | Opruimen van een preview (ZAD-deployments, GitHub-omgeving/-deployments, comment, ghcr-versies); `workflow_dispatch` op PR-nummer |
 | `.github/CODEOWNERS`                   | Code ownership (`@MinBZK/mijnoverheid-zakelijk`)                |
 
 ## Omgevingsvariabelen


### PR DESCRIPTION
## Aanleiding

In de ZAD-projecten staan nog preview-omgevingen van PR's die al gemerged zijn. Die zouden bij het sluiten van de PR automatisch verdwijnen. Dat gebeurde niet, en het bleef onopgemerkt omdat de betrokken jobs groen rapporteerden of helemaal niet draaiden.

Twee losse oorzaken:

1. **Een PR die niet in `main` mergt, ruimt niets op.** Het opruimen hing in `deploy.yml`, en die workflow reageert alleen op PR's met `main` als doel. Wordt een PR ná zijn preview op een andere branch gericht en daar gemerged, dan draait er bij het sluiten geen enkele opruim-taak. De preview blijft in alle drie de projecten staan, samen met de images, de omgeving en de deploy-comment. Zo bleven de previews van #188, #195, #199 en #201 achter.
2. **De GitHub-omgeving werd nooit verwijderd.** Ook bij een verder geslaagde opruiming mislukte die stap, met alleen een waarschuwing in een groene taak. Gevolg: 73 achtergebleven `pr-*`-omgevingen in deze repo, van pr-114 tot pr-205. Oorzaak is een tekort aan rechten op het gebruikte token; GitHub meldt dat als "niet gevonden", wat niet te onderscheiden is van "was al weg".

## Wat er verandert

- Het opruimen krijgt een **eigen workflow** (`cleanup-preview.yml`) die reageert op élk sluiten van een PR, ongeacht de doelbranch. Het doelbranch-filter in `deploy.yml` blijft staan waar het hoort: bij het bouwen en uitrollen.
- Die workflow is ook **handmatig te starten** met een PR-nummer, zodat een gemiste opruiming alsnog kan draaien. Die knop was er niet; de enige uitweg was handwerk tegen de ZAD-API.
- Het verwijderen van de GitHub-omgeving wordt **na afloop gecontroleerd**. Lukt het niet, dan volgt een tweede poging en daarna een rode taak met de precieze oorzaak in de melding, in plaats van een waarschuwing die niemand ziet.
- `deploy.yml` reageert niet langer op het sluiten van een PR — daar valt sinds deze splitsing niets meer te doen — waarmee ook alle uitzonderingsclausules voor dat geval vervallen.

## Acceptatiecriteria

- [x] Het sluiten van een PR ruimt de preview op, ook wanneer die PR in een andere branch dan `main` gemerged wordt.
- [x] Een gemiste opruiming is achteraf handmatig te starten op PR-nummer.
- [x] Een mislukte opruiming van de omgeving levert een rode taak op, met in de melding wat er moet gebeuren.
- [x] Opruimen kan een lopende uitrol van dezelfde PR niet halverwege onderbreken (ongewijzigd gedrag: dezelfde wachtrij-namen).
- [x] Een PR uit een fork levert bij sluiten geen rode taak op (daar bestaat nooit een preview).

## Voor de merge

> [!IMPORTANT]
> Het repo-secret `GH_ADMIN_TOKEN` moet **Administration: write** op deze repo krijgen (fine-grained token), of `repo`-scope plus repo-admin (classic). Zolang dat niet gebeurd is, wordt de opruim-taak bij elke PR-close rood — precies wat de nieuwe controle hoort te doen, maar het is beter dat vóór de merge te regelen.

## Achterstand na de merge

Met de handmatige start op te ruimen, per PR-nummer: de previews van #188, #195, #199 en #201 in de drie projecten, hun achtergebleven images, en de 73 oude omgevingen.

> [!CAUTION]
> Het verwijderen van een deployment is onomkeerbaar: het ruimt ook de bijbehorende database op. Draai dit uitsluitend op een `pr-<n>`-nummer, nooit op de `test`-omgeving. De workflow accepteert alleen een PR-nummer en zet daar zelf `pr-` voor, dus `test` is er niet mee te raken.

## Technische context

- `deploy.yml`: `closed` uit de `pull_request`-trigger, de vier `cleanup-preview-*`-jobs eruit, en de negen `github.event.action != 'closed'`-clausules die daaraan hingen. Geen wijziging aan de required contexts (`deploy-preview-*`, `checks-*`), dus branch protection op `main` blijft ongemoeid.
- `cleanup-preview.yml`: job `doel` valideert het PR-nummer op `^[0-9]+$` (het bepaalt de deployment-naam én de ghcr-tag-prefix, dus vrije tekst uit een handmatige start mag daar niet ongefilterd in) en controleert het token vooraf. Drie project-jobs draaien parallel met dezelfde concurrency-groepen als de deploy-jobs (`zad-<project>-pr-<n>`; groepen zijn repo-breed, dus de verhuizing verandert niets aan de bescherming). De ghcr-sweep is ongewijzigd overgezet. `task-timeout` op 900 s: de ZAD-delete duurde gemeten ~4 minuten, de action-default van 300 s is daarvoor te krap.
- Fork-PR's worden uitgesloten op `head.repo.full_name == github.repository`: zonder secrets komt er nooit een preview, en zonder die uitsluiting zou elke fork-close falen op een ontbrekend secret.
- De comment-verwijdering ín `zad-actions/cleanup` hangt aan `github.event_name == 'pull_request'` en slaat bij een handmatige start over; daarvoor staat er een eigen stap in de uitvraag-job.

## Verificatie

- `actionlint` op beide workflows: geen bevindingen.
- Read-only proef van de scriptlogica tegen de echte API: nummer-validatie weigert `test`, `195; rm -rf /` en leeg; de comment-zoekopdracht vindt de achtergebleven comment op #195; de bestaanscontrole geeft "waar" voor `pr-195` en "onwaar" voor een niet-bestaande omgeving; de image-selectie kiest exact de twee `pr-195-*`-versies.
- Niet lokaal te testen: de ZAD-delete zelf en het verwijderen van de omgeving — die vragen secrets en een echte run. Het sluiten van deze PR is de eerste live-toets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
