### PR TITLE
Notificatie-events door de FSC-keten (#784)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,6 +260,8 @@ géén uitgeschakeld component**).
 | `FBS_REDIS_UNSAFE_ALLOW_PLAINTEXT` | `false` | Zet de TLS-/auth-eis op de berichtenopslag BEWUST uit; logt bij elke boot `REDIS_UNPROTECTED` voor alert-routing |
 | `MAGAZIJN_A_GRANT_HASH` | leeg    | Grant-hash van het valide FSC-contract voor magazijn-a; leeg = geen `Fsc-Grant-Hash`-header, magazijn wordt dan direct/zonder outway aangeroepen |
 | `PROFIEL_SERVICE_GRANT_HASH` | leeg    | Grant-hash van het valide FSC-contract voor de Profiel-service; leeg = geen `Fsc-Grant-Hash`-header, de Profiel-service wordt dan direct/zonder outway aangeroepen |
+| `NOTIFICATIE_URL`      | per profiel | Bestemming van de CloudEvents-push door het magazijn; wijst naar de eigen outway zodra die push door FSC loopt |
+| `NOTIFICATIE_GRANT_HASH` | leeg    | Grant-hash van het valide FSC-contract voor de notificatiedienst; leeg = geen `Fsc-Grant-Hash`-header, de push gaat dan direct/zonder outway. Samen zetten met `NOTIFICATIE_URL`: alleen de hash stuurt FSC-headers naar de oude bestemming en schakelt daar de SSRF-controle uit, alleen de URL levert `service not found` |
 
 ## Plannen
 

--- a/compose.podman-hostnet.yaml
+++ b/compose.podman-hostnet.yaml
@@ -99,6 +99,13 @@ services:
   berichtenmagazijn-a:
     network_mode: host
     ports: !reset []
+    # Het grant-hash voor de notificatie-push komt uit de contract-bootstrap van de federatie
+    # (demo/environment/federatie/contracts/fbs-contracten.sh). Ontbreekt het bestand — geen
+    # federatie op deze machine — dan start de stack gewoon zonder, en levert dit magazijn zijn
+    # events rechtstreeks af: een lege grant-hash betekent "geen FSC-headers".
+    env_file:
+      - path: demo/generated/fsc-grants.env
+        required: false
     depends_on:
       postgres-a:
         condition: service_started
@@ -107,7 +114,10 @@ services:
       QUARKUS_HTTP_HOST: 127.0.0.1
       DB_JDBC_URL: jdbc:postgresql://127.0.0.1:5432/berichtenmagazijn
       AANMELD_URL: http://127.0.0.1:18086/api/v1/aanmeldingen
-      NOTIFICATIE_URL: http://127.0.0.1:18084/events
+      # Default: rechtstreeks via toxiproxy, zodat de storing-knop van de demo werkt. Zet
+      # NOTIFICATIE_URL op de outway van magazijn-a (http://127.20.2.5:8443/events) om deze push
+      # via de FSC-keten te laten lopen; het grant-hash komt dan uit env_file hierboven.
+      NOTIFICATIE_URL: ${NOTIFICATIE_URL:-http://127.0.0.1:18084/events}
       PROFIEL_SERVICE_URL: http://127.0.0.1:8089
 
   berichtenmagazijn-b:

--- a/demo/environment/federatie/README.md
+++ b/demo/environment/federatie/README.md
@@ -166,6 +166,27 @@ magazijn, zodat de uitvraag-outway `berichtenmagazijn` bij elk van hen mag ophal
 
 Een magazijn toevoegen is één naam in `MAGAZIJNEN`.
 
+`fbs-contracten.sh` zet twee soorten contract op: één per magazijn zodat de uitvraag-outway
+`berichtenmagazijn` mag ophalen, en één per pusher zodat het magazijn zijn CloudEvents kwijt kan
+bij `notificatieservice`. Die tweede loopt de andere kant op — het magazijn is daar de afnemer, en
+`logius` de aanbieder. Beide grant-hashes komen in hetzelfde `demo/generated/fsc-grants.env`.
+
+```bash
+./federatie/smoke-notificatie.sh   # bewijst de push: outway magazijn -> inway aanbieder -> stub
+```
+
+Die smoke vereist dat het magazijn zijn events door de outway stuurt:
+
+```bash
+MODUS=hostnet MAGAZIJN_A_URL=http://127.20.1.5:8443 \
+  NOTIFICATIE_URL=http://127.20.2.5:8443/events demo/podman-up.sh
+```
+
+**Zet URL en grant-hash altijd samen.** Het grant-hash komt uit `fsc-grants.env` en de URL uit de
+omgeving; staat de hash wél en de URL niet op de outway, dan stuurt het magazijn FSC-headers naar
+een bestemming die er niets mee doet — en vervalt bovendien de SSRF-controle op die URL. Het
+magazijn logt bij de eerste aflevering welke downstreams zo lopen (`DOWNSTREAM_VIA_OUTWAY`).
+
 ### Twee helften
 
 De bootstrap bestaat uit twee losse scripts: `contracts/bootstrap-consumer.sh` dient het contract in

--- a/demo/environment/federatie/README.md
+++ b/demo/environment/federatie/README.md
@@ -8,7 +8,9 @@ peer.
 Elke peer blijft zelfstandig draaibaar; zie zijn eigen `deploy/local/README.md`. Deze map voegt
 alleen de compositie toe en verandert niets aan het standalone gedrag.
 
-Op dit moment doen `logius` (uitvraag-consumer) en `magazijn-a` (provider) mee.
+Op dit moment doen `logius` en `magazijn-a` mee. Beide dragen twee rollen: `logius` biedt
+`profiel-service` en `notificatieservice` aan en neemt `berichtenmagazijn` af, `magazijn-a` biedt
+`berichtenmagazijn` aan en pusht notificatie-events door zijn eigen outway.
 
 **Linux + podman.** De scripts gebruiken `ss` (iproute2) en `podman`; op macOS draaien ze niet.
 

--- a/demo/environment/federatie/compose/logius.yaml
+++ b/demo/environment/federatie/compose/logius.yaml
@@ -41,6 +41,7 @@ x-hosts-federatie: &hosts-federatie
   - "manager.magazijn-a.fsc-test.local:127.20.2.1"
   - "controller.magazijn-a.fsc-test.local:127.20.2.2"
   - "txlog.magazijn-a.fsc-test.local:127.20.2.3"
+  - "outway.magazijn-a.fsc-test.local:127.20.2.5"
   - "postgres:127.20.0.2"
   - "stub-upstream:127.20.1.6"
 

--- a/demo/environment/federatie/compose/magazijn-a.yaml
+++ b/demo/environment/federatie/compose/magazijn-a.yaml
@@ -30,6 +30,7 @@ x-hosts-federatie: &hosts-federatie
   - "manager.magazijn-a.fsc-test.local:127.20.2.1"
   - "controller.magazijn-a.fsc-test.local:127.20.2.2"
   - "txlog.magazijn-a.fsc-test.local:127.20.2.3"
+  - "outway.magazijn-a.fsc-test.local:127.20.2.5"
   - "postgres:127.20.0.2"
   - "stub-upstream:127.20.2.6"
 
@@ -98,6 +99,15 @@ services:
       MONITORING_ADDRESS: 127.20.2.4:8081
       CONTROLLER_REGISTRATION_API_ADDRESS: https://controller.magazijn-a.fsc-test.local:9443
       MANAGER_INTERNAL_UNAUTHENTICATED_ADDRESS: https://manager.magazijn-a.fsc-test.local:9444
+      TX_LOG_API_ADDRESS: https://txlog.magazijn-a.fsc-test.local:9443
+
+  outway-magazijn-a:
+    extra_hosts: *hosts-federatie
+    environment:
+      LISTEN_ADDRESS: 127.20.2.5:8443
+      MONITORING_ADDRESS: 127.20.2.5:8081
+      CONTROLLER_REGISTRATION_API_ADDRESS: https://controller.magazijn-a.fsc-test.local:9443
+      MANAGER_INTERNAL_ADDRESS: https://manager.magazijn-a.fsc-test.local:9443
       TX_LOG_API_ADDRESS: https://txlog.magazijn-a.fsc-test.local:9443
 
   stub-upstream:

--- a/demo/environment/federatie/contracts/bootstrap-consumer.sh
+++ b/demo/environment/federatie/contracts/bootstrap-consumer.sh
@@ -51,11 +51,10 @@ fsc_contract_manager_ok "$MANAGER" || exit 2
 api() { fsc_contract_api "$MANAGER" "$CERT" "$KEY" "$CA" "$ADRES" "$@"; }
 
 # De lijst is cursor-gepagineerd met een default van honderd en een maximum van duizend, en bevat
-# álles: publicatiecontracten,
-# ingetrokken en afgewezen contracten, van alle peers. In een langlevend deployment groeit dat
-# monotoon, en zodra ons eigen contract van pagina 1 valt zou de consumer elke ronde een nieuw
-# indienen. Een ruime limiet houdt de guard in fsc-contract.sh een vangrail in plaats van een
-# dagelijkse blokkade.
+# álles: publicatiecontracten, ingetrokken en afgewezen contracten, van alle peers. In een
+# langlevend deployment groeit dat monotoon, en zodra ons eigen contract van pagina 1 valt zou de
+# consumer elke ronde een nieuw indienen. fsc_contracten_paginas leest daarom door tot de cursor
+# leeg is; een ruime limiet scheelt daarbij rondjes.
 CONTRACT_LIMIET="$(fsc_getal_hoogstens FSC_CONTRACT_LIMIET "${FSC_CONTRACT_LIMIET:-1000}" 1000)"
 
 # --- 1. Outway-thumbprint -----------------------------------------------------------------------
@@ -87,7 +86,7 @@ echo "consumer: outway public-key-thumbprint = ${THUMB}"
 # --- 2. Staat er al iets uit? -------------------------------------------------------------------
 eigen_contracten() {
   local json
-  json="$(api "${MANAGER}/v1/contracts?limit=${CONTRACT_LIMIET}")" || {
+  json="$(fsc_contracten_paginas api "${MANAGER}/v1/contracts?limit=${CONTRACT_LIMIET}")" || {
     echo "FAIL: kon de eigen contractenlijst niet ophalen: $(fsc_last_error)" >&2
     return 1
   }

--- a/demo/environment/federatie/contracts/bootstrap-provider.sh
+++ b/demo/environment/federatie/contracts/bootstrap-provider.sh
@@ -70,15 +70,15 @@ api() { fsc_contract_api "$MANAGER" "$CERT" "$KEY" "$CA" "$ADRES" "$@"; }
 # De lijst is cursor-gepagineerd met een default van honderd en een maximum van duizend, en bevat
 # álles: publicatiecontracten, ingetrokken en afgewezen contracten, van alle peers. In een langlevend
 # deployment groeit dat monotoon, en zodra ons eigen contract van pagina 1 valt zou de consumer elke
-# ronde een nieuw indienen. Een ruime limiet houdt de guard in fsc-contract.sh een vangrail in plaats
-# van een dagelijkse blokkade. Boven duizend geeft de manager een 400.
+# ronde een nieuw indienen. fsc_contracten_paginas leest daarom door tot de cursor leeg is; een
+# ruime limiet scheelt daarbij rondjes. Boven duizend geeft de manager een 400.
 CONTRACT_LIMIET="$(fsc_getal_hoogstens FSC_CONTRACT_LIMIET "${FSC_CONTRACT_LIMIET:-1000}" 1000)"
 
 DIENSTEN_JSON="$(fsc_lijst_naar_json FSC_DIENSTEN "$DIENSTEN")" || exit 2
 CONSUMERS_JSON="$(fsc_lijst_naar_json FSC_CONSUMERS "$CONSUMERS")" || exit 2
 
 # --- De contracten ophalen en beoordelen ---------------------------------------------------------
-JSON="$(api "${MANAGER}/v1/contracts?limit=${CONTRACT_LIMIET}")" || {
+JSON="$(fsc_contracten_paginas api "${MANAGER}/v1/contracts?limit=${CONTRACT_LIMIET}")" || {
   echo "FAIL: kon de eigen contractenlijst niet ophalen: $(fsc_last_error)" >&2
   exit 1
 }

--- a/demo/environment/federatie/contracts/fbs-contracten.sh
+++ b/demo/environment/federatie/contracts/fbs-contracten.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
-# Zet de contracten op die het uitvraag-systeem nodig heeft: één ServiceConnectionGrant per
-# magazijn, zodat de uitvraag-outway `berichtenmagazijn` bij elk van hen mag afnemen.
+# Zet de contracten op die de FBS-keten nodig heeft, in twee richtingen:
 #
-# Wie meedoet staat in peers.env (`UITVRAAG`, `MAGAZIJNEN`, `MAGAZIJN_DIENST`); dit script vertaalt
-# dat naar de component-adressen en cert-paden en roept per magazijn `bootstrap.sh` aan. Een magazijn
-# toevoegen is daarmee één naam in `MAGAZIJNEN`.
+#   - ophalen: één ServiceConnectionGrant per magazijn, zodat de uitvraag-outway
+#     `berichtenmagazijn` bij elk van hen mag afnemen;
+#   - pushen:  één per magazijn, zodat dat magazijn zijn CloudEvents kwijt kan bij de
+#     notificatiedienst. Daar is het magazijn zelf de consumer.
+#
+# Wie meedoet staat in peers.env (`UITVRAAG`/`MAGAZIJNEN`/`MAGAZIJN_DIENST` en
+# `NOTIFICATIE`/`PUSHERS`/`NOTIFICATIE_DIENST`); dit script vertaalt dat naar de component-adressen
+# en cert-paden en roept per combinatie `bootstrap.sh` aan. Een magazijn toevoegen is daarmee één
+# naam in `MAGAZIJNEN`.
 #
 # Idempotent, ook zonder lokale state: `bootstrap.sh` leidt uit de contracten zelf af of er al een
 # geldig contract voor die combinatie bestaat. Twee keer draaien levert dus geen tweede contract op,
@@ -32,21 +37,25 @@ fsc_have_jq
 : "${UITVRAAG:?geen UITVRAAG in peers.env}"
 : "${MAGAZIJNEN:?geen MAGAZIJNEN in peers.env}"
 : "${MAGAZIJN_DIENST:?geen MAGAZIJN_DIENST in peers.env}"
+: "${NOTIFICATIE:?geen NOTIFICATIE in peers.env}"
+: "${PUSHERS:?geen PUSHERS in peers.env}"
+: "${NOTIFICATIE_DIENST:?geen NOTIFICATIE_DIENST in peers.env}"
 
-CONS_NET="$(fsc_peer_waarde NET "$UITVRAAG")"
-CONS_OIN="$(fsc_peer_waarde OIN "$UITVRAAG")"
-[ -n "$CONS_NET" ] && [ -n "$CONS_OIN" ] || {
-  echo "FAIL: NET_/OIN_ ontbreekt voor de uitvraag-peer '${UITVRAAG}' in peers.env." >&2
-  exit 1
-}
+# Eén env-naam voor alle pushers werkt zolang er één is; een tweede zou de eerste overschrijven in
+# hetzelfde bestand. Dat is een bewuste grens en geen omissie: een tweede pusher is een tweede
+# magazijn-deployment met een eigen omgeving, niet twee hashes in één env-bestand.
+if [ "$(printf '%s\n' $PUSHERS | grep -c .)" -gt 1 ]; then
+  echo "FAIL: PUSHERS bevat meer dan één peer; NOTIFICATIE_GRANT_HASH kan er maar één dragen." >&2
+  exit 2
+fi
 
 FOUTEN=0
 GEDAAN=0
 
 # De demo-stack moet het grant-hash kennen om `Fsc-Grant-Hash` te kunnen zetten, en compose kan dat
-# niet uit een draaiende manager halen. Vandaar een gegenereerd env-bestand dat de uitvraag inleest.
-# Naar `.tmp` en pas aan het eind verplaatsen: een half geschreven bestand zou de uitvraag met een
-# grant-hash van het ene magazijn en niets voor het andere laten starten.
+# niet uit een draaiende manager halen. Vandaar een gegenereerd env-bestand dat de apps inlezen.
+# Naar `.tmp` en pas aan het eind verplaatsen: een half geschreven bestand zou een app met een
+# grant-hash voor de ene bestemming en niets voor de andere laten starten.
 GRANTS="$(cd "${ENVDIR}/.." && pwd)/generated/fsc-grants.env"
 mkdir -p "$(dirname "$GRANTS")"
 : > "$GRANTS.tmp"
@@ -54,82 +63,112 @@ mkdir -p "$(dirname "$GRANTS")"
 # tweede `trap ... EXIT` vervangt die in plaats van hem aan te vullen.
 trap 'rm -f "$GRANTS.tmp" "$ERRLOG"' EXIT
 
+# grant_regel_voor <consumer-peer> <consumer-oin> <thumbprint> <provider-oin> <dienst> <env-naam>:
+# één `<ENV-NAAM>=<hash>`-regel op stdout.
+#
 # Het grant-hash is NIET het contract-hash: de outway routeert op de grant uit `content.grants[]`,
 # en wie het contract-hash op de header zet krijgt structureel 400 UNKNOWN_GRANT_HASH_IN_HEADER.
-CONS_THUMB="$(fsc_outway_thumbprint "${ENVDIR}/${UITVRAAG}/pki/out/${UITVRAAG}/outway/cert.pem")" || {
-  echo "FAIL: kon de outway-thumbprint van '${UITVRAAG}' niet berekenen: $(fsc_last_error)" >&2
-  exit 1
+#
+# De contracten komen van de manager van de CONSUMER: dat is de kant waar de outway zijn grant
+# vandaan haalt. Bij de provider staat hetzelfde contract, maar de consumer praat daar niet mee.
+grant_regel_voor() {
+  local consumer="$1" cons_oin="$2" thumb="$3" prov_oin="$4" dienst="$5" envnaam="$6"
+  local json contract grant cons_net
+
+  cons_net="$(fsc_peer_waarde NET "$consumer")"
+  json="$(fsc_manager_contracts "$ENVDIR" "$consumer" "$(fsc_component_adres "$cons_net" manager)")" || return 1
+  contract="$(fsc_grant_actief "$json" "$dienst" "$prov_oin" "$cons_oin" "$thumb" | sort | head -n1)"
+  [ -n "$contract" ] || return 1
+
+  grant="$(fsc_grant_hash "$json" "$contract" "$dienst" "$thumb")"
+  fsc_grant_bruikbaar "$grant" || return 1
+
+  # Escapen voor compose: een kale `$` in dit bestand wordt als variabele-verwijzing gelezen en
+  # vreet de rest van het hash op. Zie fsc_compose_env_waarde.
+  printf '%s=%s\n' "$envnaam" "$(fsc_compose_env_waarde "$grant")"
 }
 
-# grant_regel_voor <magazijn> <oin>: één `<PEER>_GRANT_HASH=<hash>`-regel op stdout.
+# contract_op <consumer-peer> <provider-peer> <dienst> <env-naam>: zet het contract op en schrijft
+# het grant-hash weg. Werkt in beide richtingen — welke peer de consumer is, staat in peers.env.
+contract_op() {
+  local consumer="$1" provider="$2" dienst="$3" envnaam="$4"
+  local cons_net cons_oin prov_net prov_oin cons_thumb
+
+  cons_net="$(fsc_peer_waarde NET "$consumer")"
+  cons_oin="$(fsc_peer_waarde OIN "$consumer")"
+  prov_net="$(fsc_peer_waarde NET "$provider")"
+  prov_oin="$(fsc_peer_waarde OIN "$provider")"
+
+  if [ -z "$cons_net" ] || [ -z "$cons_oin" ] || [ -z "$prov_net" ] || [ -z "$prov_oin" ]; then
+    echo "FAIL: NET_/OIN_ ontbreekt voor '${consumer}' of '${provider}' in peers.env." >&2
+    return 1
+  fi
+
+  if [ "$prov_oin" = "$cons_oin" ]; then
+    # Een zelfreferentieel contract is geldig FSC (zie logius' consume-service.sh voor de
+    # profiel-service), maar hier zou het betekenen dat aanbieder en afnemer dezelfde identiteit
+    # dragen — dan klopt peers.env niet.
+    echo "FAIL: '${consumer}' en '${provider}' hebben dezelfde OIN (${prov_oin})." >&2
+    return 1
+  fi
+
+  cons_thumb="$(fsc_outway_thumbprint "${ENVDIR}/${consumer}/pki/out/${consumer}/outway/cert.pem")" || {
+    echo "FAIL: kon de outway-thumbprint van '${consumer}' niet berekenen: $(fsc_last_error)" >&2
+    return 1
+  }
+
+  echo "== contract ${consumer} -> ${provider} (${dienst}) =="
+
+  # De interne manager-API zit op het manager-adres van de peer, op de standaardpoort 9443. De
+  # octet-toewijzing staat in federatie/README.md en geldt voor elke peer gelijk.
+  FSC_CONSUMER_OIN="$cons_oin" \
+  FSC_PROVIDER_OIN="$prov_oin" \
+  FSC_SERVICE_NAME="$dienst" \
+  FSC_OUTWAY_CERT="${ENVDIR}/${consumer}/pki/out/${consumer}/outway/cert.pem" \
+  FSC_CONSUMER_MANAGER="https://manager.${consumer}.fsc-test.local:9443" \
+  FSC_CONSUMER_ADRES="$(fsc_component_adres "$cons_net" manager)" \
+  FSC_CONSUMER_CERT="${ENVDIR}/${consumer}/pki/internal/${consumer}/manager/cert.pem" \
+  FSC_CONSUMER_KEY="${ENVDIR}/${consumer}/pki/internal/${consumer}/manager/key.pem" \
+  FSC_CONSUMER_CA="${ENVDIR}/${consumer}/pki/internal/${consumer}/ca/root.pem" \
+  FSC_PROVIDER_MANAGER="https://manager.${provider}.fsc-test.local:9443" \
+  FSC_PROVIDER_ADRES="$(fsc_component_adres "$prov_net" manager)" \
+  FSC_PROVIDER_CERT="${ENVDIR}/${provider}/pki/internal/${provider}/manager/cert.pem" \
+  FSC_PROVIDER_KEY="${ENVDIR}/${provider}/pki/internal/${provider}/manager/key.pem" \
+  FSC_PROVIDER_CA="${ENVDIR}/${provider}/pki/internal/${provider}/ca/root.pem" \
+    "${HERE}/bootstrap.sh" || {
+      echo "FAIL: contract ${consumer} -> ${provider} niet opgezet." >&2
+      return 1
+    }
+
+  grant_regel_voor "$consumer" "$cons_oin" "$cons_thumb" "$prov_oin" "$dienst" "$envnaam" >> "$GRANTS.tmp" || {
+    echo "FAIL: contract staat, maar het grant-hash van ${provider} (${dienst}) is niet af te leiden." >&2
+    return 1
+  }
+}
+
+# Ophalen: de uitvraag-outway mag `berichtenmagazijn` afnemen bij elk magazijn.
 #
 # De env-naam is de peernaam in hoofdletters: `magazijn-a` -> `MAGAZIJN_A_GRANT_HASH`. Dat is
 # precies de naam die application.properties van de uitvraag leest voor het magazijn met die OIN.
 # Hernoem je een peer in peers.env, dan moet die property mee.
-#
-# De contracten komen van de manager van de CONSUMER: dat is de kant waar de outway zijn grant
-# vandaan haalt. Bij de provider staat hetzelfde contract, maar de uitvraag praat daar niet mee.
-grant_regel_voor() {
-  local magazijn="$1" oin="$2" json contract grant naam
-
-  json="$(fsc_manager_contracts "$ENVDIR" "$UITVRAAG" "$(fsc_component_adres "$CONS_NET" manager)")" || return 1
-  contract="$(fsc_grant_actief "$json" "$MAGAZIJN_DIENST" "$oin" "$CONS_OIN" "$CONS_THUMB" | sort | head -n1)"
-  [ -n "$contract" ] || return 1
-
-  grant="$(fsc_grant_hash "$json" "$contract" "$MAGAZIJN_DIENST" "$CONS_THUMB")"
-  fsc_grant_bruikbaar "$grant" || return 1
-
-  naam="$(printf '%s' "$magazijn" | tr '[:lower:]-' '[:upper:]_')"
-  # Escapen voor compose: een kale `$` in dit bestand wordt als variabele-verwijzing gelezen en
-  # vreet de rest van het hash op. Zie fsc_compose_env_waarde.
-  printf '%s_GRANT_HASH=%s\n' "$naam" "$(fsc_compose_env_waarde "$grant")"
-}
-
 for magazijn in $MAGAZIJNEN; do
-  PROV_NET="$(fsc_peer_waarde NET "$magazijn")"
-  PROV_OIN="$(fsc_peer_waarde OIN "$magazijn")"
+  ENVNAAM="$(printf '%s' "$magazijn" | tr '[:lower:]-' '[:upper:]_')_GRANT_HASH"
 
-  if [ -z "$PROV_NET" ] || [ -z "$PROV_OIN" ]; then
-    echo "FAIL: NET_/OIN_ ontbreekt voor magazijn '${magazijn}' in peers.env." >&2
-    FOUTEN=$((FOUTEN + 1))
-    continue
-  fi
-
-  if [ "$PROV_OIN" = "$CONS_OIN" ]; then
-    # Een zelfreferentieel contract is geldig FSC (zie logius' consume-service.sh voor de
-    # profiel-service), maar hier zou het betekenen dat het magazijn dezelfde identiteit draagt
-    # als de uitvraag — dan klopt peers.env niet.
-    echo "FAIL: magazijn '${magazijn}' heeft dezelfde OIN als de uitvraag-peer (${PROV_OIN})." >&2
-    FOUTEN=$((FOUTEN + 1))
-    continue
-  fi
-
-  echo "== contract ${UITVRAAG} -> ${magazijn} (${MAGAZIJN_DIENST}) =="
-
-  # De interne manager-API zit op het manager-adres van de peer, op de standaardpoort 9443. De
-  # octet-toewijzing staat in federatie/README.md en geldt voor elke peer gelijk.
-  if FSC_CONSUMER_OIN="$CONS_OIN" \
-     FSC_PROVIDER_OIN="$PROV_OIN" \
-     FSC_SERVICE_NAME="$MAGAZIJN_DIENST" \
-     FSC_OUTWAY_CERT="${ENVDIR}/${UITVRAAG}/pki/out/${UITVRAAG}/outway/cert.pem" \
-     FSC_CONSUMER_MANAGER="https://manager.${UITVRAAG}.fsc-test.local:9443" \
-     FSC_CONSUMER_ADRES="$(fsc_component_adres "$CONS_NET" manager)" \
-     FSC_CONSUMER_CERT="${ENVDIR}/${UITVRAAG}/pki/internal/${UITVRAAG}/manager/cert.pem" \
-     FSC_CONSUMER_KEY="${ENVDIR}/${UITVRAAG}/pki/internal/${UITVRAAG}/manager/key.pem" \
-     FSC_CONSUMER_CA="${ENVDIR}/${UITVRAAG}/pki/internal/${UITVRAAG}/ca/root.pem" \
-     FSC_PROVIDER_MANAGER="https://manager.${magazijn}.fsc-test.local:9443" \
-     FSC_PROVIDER_ADRES="$(fsc_component_adres "$PROV_NET" manager)" \
-     FSC_PROVIDER_CERT="${ENVDIR}/${magazijn}/pki/internal/${magazijn}/manager/cert.pem" \
-     FSC_PROVIDER_KEY="${ENVDIR}/${magazijn}/pki/internal/${magazijn}/manager/key.pem" \
-     FSC_PROVIDER_CA="${ENVDIR}/${magazijn}/pki/internal/${magazijn}/ca/root.pem" \
-       "${HERE}/bootstrap.sh"; then
+  if contract_op "$UITVRAAG" "$magazijn" "$MAGAZIJN_DIENST" "$ENVNAAM"; then
     GEDAAN=$((GEDAAN + 1))
-    grant_regel_voor "$magazijn" "$PROV_OIN" >> "$GRANTS.tmp" || {
-      echo "FAIL: contract staat, maar het grant-hash van ${magazijn} is niet af te leiden." >&2
-      FOUTEN=$((FOUTEN + 1))
-    }
   else
-    echo "FAIL: contract ${UITVRAAG} -> ${magazijn} niet opgezet." >&2
+    FOUTEN=$((FOUTEN + 1))
+  fi
+
+  echo
+done
+
+# Pushen: elk magazijn mag zijn CloudEvents kwijt bij de notificatiedienst. Andere richting,
+# zelfde machinerie — het magazijn is hier de consumer.
+for pusher in $PUSHERS; do
+  if contract_op "$pusher" "$NOTIFICATIE" "$NOTIFICATIE_DIENST" NOTIFICATIE_GRANT_HASH; then
+    GEDAAN=$((GEDAAN + 1))
+  else
     FOUTEN=$((FOUTEN + 1))
   fi
 
@@ -140,9 +179,9 @@ done
 if [ "$GEDAAN" -eq 0 ] && [ "$FOUTEN" -eq 0 ]; then
   # Ook hier het oude bestand weg, om dezelfde reden als bij de foutuitgang hieronder: een
   # grant-hash van een vorige federatie zou anders blijven staan en de demo-stack een dode grant
-  # laten sturen. `MAGAZIJNEN` met alleen spaties komt langs de `:?`-controle hierboven.
+  # laten sturen. `MAGAZIJNEN`/`PUSHERS` met alleen spaties komt langs de `:?`-controle hierboven.
   rm -f "$GRANTS"
-  echo "FAIL: MAGAZIJNEN is leeg; er is geen enkel contract opgezet." >&2
+  echo "FAIL: MAGAZIJNEN en PUSHERS zijn leeg; er is geen enkel contract opgezet." >&2
   exit 1
 fi
 
@@ -151,7 +190,7 @@ if [ "$FOUTEN" -eq 0 ]; then
   # een contract is ingetrokken of opnieuw uitgegeven, en de uitvraag zou dan een dode grant sturen.
   mv "$GRANTS.tmp" "$GRANTS"
   echo "grant-hashes weggeschreven naar ${GRANTS}."
-  echo "FBS-CONTRACTEN OK (${GEDAAN} magazijn(en))."
+  echo "FBS-CONTRACTEN OK (${GEDAAN} contract(en))."
 else
   # Ook het BESTAANDE bestand weg. Anders overleeft een grant-hash uit een eerdere federatie een
   # mislukte run: na `federatie.sh down` (die de volumes wist) en een nieuwe `up` bestaat die grant
@@ -162,7 +201,7 @@ else
     rm -f "$GRANTS"
     echo "grant-hashes uit een eerdere run verwijderd (${GRANTS})." >&2
     echo "  Let op: compose leest env_file bij het AANMAKEN van een container, dus een al draaiende" >&2
-    echo "  uitvraag houdt de oude grant-hash tot je hem hercreëert (demo/podman-up.sh)." >&2
+    echo "  uitvraag of magazijn houdt de oude grant-hash tot je hem hercreëert (demo/podman-up.sh)." >&2
   fi
 
   echo "FBS-CONTRACTEN ROOD: ${FOUTEN} van $((GEDAAN + FOUTEN)) mislukt." >&2

--- a/demo/environment/federatie/peers.env
+++ b/demo/environment/federatie/peers.env
@@ -48,3 +48,11 @@ NET_magazijn_a=127.20.2
 UITVRAAG=logius
 MAGAZIJNEN="magazijn-a"
 MAGAZIJN_DIENST=berichtenmagazijn
+
+# Wie de notificatiedienst aanbiedt en wie erop pusht. Andersom dan de magazijn-rollen hierboven:
+# het magazijn is hier de áfnemer — het duwt zijn CloudEvents door de eigen outway naar de inway
+# van de aanbieder. Daarmee draagt elke peer twee rollen en toont de federatie dat een peer niet
+# in één rol vastzit.
+NOTIFICATIE=logius
+PUSHERS="magazijn-a"
+NOTIFICATIE_DIENST=notificatieservice

--- a/demo/environment/federatie/smoke-notificatie.sh
+++ b/demo/environment/federatie/smoke-notificatie.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+# Smoke: bewijst dat het magazijn zijn CloudEvents door FSC pusht — berichtenmagazijn-a levert af
+# via zijn eigen outway -> router -> inway van de notificatie-aanbieder -> WireMock-stub, in plaats
+# van rechtstreeks.
+#
+#   1. data-pad — een bericht dat uniek is voor deze run komt als CloudEvent bij de stub aan, met
+#      Content-Type application/cloudevents+json. Een aangekomen event op zichzelf zegt niets:
+#      zonder uniek merk houdt een event uit een eerdere run dit groen;
+#   2. verantwoording — dezelfde transactie staat in beide txlogs, uitgaand bij het magazijn en
+#      inkomend bij de aanbieder. Ging de push rechtstreeks, dan groeit geen van beide;
+#   3. fire-and-forget intact — precies één aflevering. Meer betekent dat het magazijn zijn 202
+#      niet terugkreeg en in de retry-lus zat.
+#
+# Voorwaarden:
+#   - de federatie draait en de contracten staan -> ./federatie.sh up && contracts/fbs-contracten.sh
+#   - de demo-stack draait met het magazijn door de outway:
+#       MODUS=hostnet NOTIFICATIE_URL=http://127.20.2.5:8443/events demo/podman-up.sh
+#
+# Linux + podman: gebruikt `podman` en `curl`.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ENVDIR="$(cd "${HERE}/.." && pwd)"
+
+# shellcheck source=../lib/fsc-harness.sh
+. "${ENVDIR}/lib/fsc-harness.sh"
+# shellcheck source=peers.env
+. "${HERE}/peers.env"
+
+fsc_errlog_init
+
+MAGAZIJN_A_DIRECT="${MAGAZIJN_A_DIRECT:-http://127.0.0.1:8090/api/v1}"
+NOTIFICATIE_STUB="${NOTIFICATIE_STUB:-http://127.0.0.1:8084}"
+# De inway moet de stub als upstream krijgen. Host-adres, want de stub draait in de demo-stack en
+# niet in de peer-stack; in hostnet-modus delen ze de netns.
+NOTIFICATIE_UPSTREAM="${NOTIFICATIE_UPSTREAM:-http://127.0.0.1:8084}"
+# De outbox-poller draait op 60s. Bewust niet verlaagd: dan bewijst deze smoke een configuratie die
+# niemand draait. Vandaar een bovengrens in plaats van een vaste wachttijd.
+PUBLICATIE_TIMEOUT="${PUBLICATIE_TIMEOUT:-150}"
+PUBLICATIE_INTERVAL="${PUBLICATIE_INTERVAL:-5}"
+PROBE_POGINGEN="${PROBE_POGINGEN:-5}"
+PROBE_WACHT="${PROBE_WACHT:-3}"
+
+PUSHER="$(printf '%s' "$PUSHERS" | awk '{print $1}')"
+PUSHER_OIN="$(fsc_peer_waarde OIN "$PUSHER")"
+
+FOUTEN=0
+fout() { echo "FAIL: $*" >&2; FOUTEN=$((FOUTEN + 1)); }
+ok()   { echo "OK: $*"; }
+
+command -v curl >/dev/null 2>&1 || { echo "FAIL: 'curl' is vereist." >&2; exit 1; }
+
+# Elke run een VERSE ontvanger-BSN. Het merk zit in onderwerp en inhoud, maar een vaste BSN zou de
+# journal van de stub met events van eerdere runs vullen en assert 3 (precies één aflevering)
+# breken. De BSN moet door de elfproef komen, anders weigert het magazijn hem en leest dat als een
+# ketenfout.
+nieuwe_bsn() {
+  local cijfers som i c laatste
+
+  while :; do
+    cijfers=""; som=0
+
+    for i in 9 8 7 6 5 4 3 2; do
+      # Eerste cijfer nooit 0: een BSN met een voorloopnul is negen tekens lang maar wordt door
+      # sommige parsers als achtcijferig gelezen.
+      if [ "$i" -eq 9 ]; then c=$((RANDOM % 9 + 1)); else c=$((RANDOM % 10)); fi
+      cijfers="${cijfers}${c}"
+      som=$((som + c * i))
+    done
+
+    # Het negende cijfer telt met gewicht -1; bestaat er geen passend cijfer 0-9, dan opnieuw.
+    for laatste in 0 1 2 3 4 5 6 7 8 9; do
+      if [ $(( (som - laatste) % 11 )) -eq 0 ]; then
+        printf '%s%s' "$cijfers" "$laatste"
+        return 0
+      fi
+    done
+  done
+}
+
+BSN="${NOTIFICATIE_BSN:-$(nieuwe_bsn)}"
+MERK="notifsmoke-$$-$(od -An -N4 -tu4 < /dev/urandom | tr -d ' ')"
+
+# tel_afleveringen [extra-matchers-json]: hoeveel requests met dit merk de stub ontving.
+#
+# WireMock's count-API en niet een grep over de journal: het merk staat in zowel onderwerp als
+# inhoud van de CloudEvent, dus tekstvoorkomens tellen zou afleveringen dubbel tellen — en dat
+# aantal zou meeveranderen met de payload.
+tel_afleveringen() {
+  curl -sS --noproxy '*' --max-time 10 -X POST "${NOTIFICATIE_STUB}/__admin/requests/count" \
+    -H 'Content-Type: application/json' \
+    -d "{\"method\":\"POST\",\"url\":\"/events\",\"bodyPatterns\":[{\"contains\":\"${MERK}\"}]${1:-}}" \
+    2>"$ERRLOG" \
+    | sed -n 's/.*"count"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p'
+}
+
+# --- 0. De inway van de aanbieder wijst naar de notificatie-stub --------------------------------
+# Hier afdwingen en niet als voorwaarde aan de gebruiker laten: de publicatie is idempotent, en wie
+# eerst een andere smoke draait zet de upstream ongemerkt terug.
+echo "== 0. ${NOTIFICATIE} biedt ${NOTIFICATIE_DIENST} aan met de stub als upstream =="
+if fsc_zet_upstream "$ENVDIR" "$NOTIFICATIE" "$NOTIFICATIE_UPSTREAM" "$NOTIFICATIE_DIENST" \
+     >/dev/null 2>"$ERRLOG"; then
+  ok "dienst ${NOTIFICATIE_DIENST} gepubliceerd op de inway van ${NOTIFICATIE}"
+else
+  fout "kon ${NOTIFICATIE_DIENST} niet publiceren: $(fsc_last_error)"
+fi
+
+# Probe door de outway: bewijst dat het contract leeft en dat de dienstwijziging is doorgedrongen,
+# vóór we het van de applicatie afhankelijk maken. Die wijziging propageert asynchroon, dus de
+# eerste pogingen kunnen nog bij de vorige upstream uitkomen.
+GRANT="$(fsc_compose_env_lees "$(cd "${ENVDIR}/.." && pwd)/generated/fsc-grants.env" NOTIFICATIE_GRANT_HASH || true)"
+OUTWAY="http://$(fsc_component_adres "$(fsc_peer_waarde NET "$PUSHER")" outway):8443"
+
+if ! fsc_grant_bruikbaar "$GRANT"; then
+  fout "geen bruikbaar NOTIFICATIE_GRANT_HASH in demo/generated/fsc-grants.env — draai contracts/fbs-contracten.sh"
+else
+  POGING=1
+  DOOR=0
+
+  while [ "$POGING" -le "$PROBE_POGINGEN" ]; do
+    CODE="$(curl -sS -o /dev/null -w '%{http_code}' --noproxy '*' --max-time 10 \
+              -X POST "${OUTWAY}/events" \
+              -H "Fsc-Grant-Hash: ${GRANT}" \
+              -H 'Content-Type: application/cloudevents+json' \
+              -d '{"specversion":"1.0","id":"probe","source":"urn:probe","type":"probe"}' \
+              2>"$ERRLOG" || true)"
+
+    if [ "$CODE" = "202" ]; then
+      DOOR=1
+      break
+    fi
+
+    [ "$POGING" -lt "$PROBE_POGINGEN" ] && sleep "$PROBE_WACHT"
+    POGING=$((POGING + 1))
+  done
+
+  if [ "$DOOR" -eq 1 ]; then
+    ok "de outway van ${PUSHER} bereikt de stub door de inway heen (202, na ${POGING} poging(en))"
+  else
+    fout "de probe door de outway gaf HTTP ${CODE:-<geen>}: $(fsc_last_error)"
+  fi
+fi
+
+# --- Nulmeting op de txlogs ---------------------------------------------------------------------
+# NA de probe, niet ervoor: die gaat zelf door outway en inway en schrijft dus in beide logboeken.
+# Stond de nulmeting ervóór, dan telde die rij als "nieuw" en kon assert 2 nooit rood worden — ook
+# niet als het magazijn buiten de outway om levert, wat deze smoke juist moet uitsluiten.
+if PROJECT="$(fsc_compose_project "${ENVDIR}/${GASTHEER}/deploy/local/docker-compose.yaml")"; then
+  txids() {  # <db> <richting>
+    podman exec "${PROJECT}-postgres-1" psql -U postgres -d "$1" -tA \
+      -c "SELECT transaction_id FROM transactionlog.records
+          WHERE direction = '$2' AND service_name = '${NOTIFICATIE_DIENST}' AND grant_hash IS NOT NULL" \
+      2>"$ERRLOG" | sort -u
+  }
+
+  # Eerst opvangen in variabelen, dan pas vergelijken. In een process substitution is de exitstatus
+  # onzichtbaar: een gestopte postgres of een psql-fout levert dan lege uitvoer met exitcode 0, en
+  # de assert hieronder zou "het magazijn ging buiten de outway om" melden terwijl het logboek
+  # simpelweg onleesbaar was.
+  gedeelde_txids() {
+    local uit in
+
+    uit="$(txids "fsc_txlog_$(fsc_peer_var "$PUSHER")" out)" || {
+      echo "WAARSCHUWING: txlog van ${PUSHER} niet leesbaar: $(fsc_last_error)" >&2
+      return 1
+    }
+    in="$(txids "fsc_txlog_$(fsc_peer_var "$NOTIFICATIE")" in)" || {
+      echo "WAARSCHUWING: txlog van ${NOTIFICATIE} niet leesbaar: $(fsc_last_error)" >&2
+      return 1
+    }
+
+    comm -12 <(printf '%s\n' "$uit") <(printf '%s\n' "$in")
+  }
+
+  TXLOG_LEESBAAR=1
+else
+  TXLOG_LEESBAAR=0
+fi
+
+VOOR_OK=0
+VOOR=""
+
+if [ "$TXLOG_LEESBAAR" -eq 1 ]; then
+  STABIEL=0
+  POGING=1
+
+  # Uitwachten tot de logboeken stilstaan: in- en outway schrijven hun record out-of-band via de
+  # txlog-API, dus de rij van de probe kan ná de nulmeting landen en dan als "nieuw" meetellen.
+  while [ "$POGING" -le "$PROBE_POGINGEN" ]; do
+    HUIDIG="$(gedeelde_txids)" || break
+
+    if [ "$POGING" -gt 1 ] && [ "$HUIDIG" = "$VORIG" ]; then
+      STABIEL=1
+      break
+    fi
+
+    VORIG="$HUIDIG"
+    sleep "$PROBE_WACHT"
+    POGING=$((POGING + 1))
+  done
+
+  if [ "$STABIEL" -eq 1 ]; then
+    VOOR="$HUIDIG"
+    VOOR_OK=1
+  else
+    echo "WAARSCHUWING: de txlogs kwamen niet tot stilstand binnen ${PROBE_POGINGEN} metingen" >&2
+  fi
+fi
+
+# --- 1. Data-pad --------------------------------------------------------------------------------
+echo "== 1. de CloudEvent van magazijn ${PUSHER} komt bij de stub aan =="
+AANTAL=0
+CODE="$(curl -sS -o /dev/null -w '%{http_code}' --noproxy '*' --max-time 20 \
+          -X POST "${MAGAZIJN_A_DIRECT}/berichten" -H 'Content-Type: application/json' \
+          -d "{\"afzender\":\"${PUSHER_OIN}\",\"ontvanger\":{\"type\":\"BSN\",\"waarde\":\"${BSN}\"},\"onderwerp\":\"${MERK}\",\"inhoud\":\"${MERK}\"}" \
+          2>"$ERRLOG" || true)"
+
+if [ "$CODE" != "201" ] && [ "$CODE" != "200" ]; then
+  fout "aanleveren bij ${PUSHER} gaf HTTP ${CODE:-<geen>}: $(fsc_last_error) — draait de demo-stack?"
+else
+  echo "  bericht '${MERK}' aangeleverd (HTTP ${CODE}); wachten op de outbox-poller..."
+
+  elapsed=0
+
+  while [ "$elapsed" -lt "$PUBLICATIE_TIMEOUT" ]; do
+    AANTAL="$(tel_afleveringen || true)"
+    [ -n "$AANTAL" ] || AANTAL=0
+
+    if [ "$AANTAL" -ge 1 ]; then
+      break
+    fi
+
+    sleep "$PUBLICATIE_INTERVAL"
+    elapsed=$((elapsed + PUBLICATIE_INTERVAL))
+  done
+
+  if [ "$AANTAL" -ge 1 ]; then
+    ok "de stub ontving de CloudEvent van '${MERK}' (na ${elapsed}s)"
+
+    # Zelfde telling, nu mét de header-eis. Blijft hij gelijk, dan gaf de inway het Content-Type
+    # ongewijzigd door en overleeft structured content mode de keten.
+    MET_HEADER="$(tel_afleveringen ',"headers":{"Content-Type":{"contains":"application/cloudevents+json"}}' || true)"
+    [ -n "$MET_HEADER" ] || MET_HEADER=0
+
+    if [ "$MET_HEADER" -eq "$AANTAL" ]; then
+      ok "de inway gaf Content-Type application/cloudevents+json ongewijzigd door"
+    else
+      fout "${MET_HEADER} van ${AANTAL} afleveringen droeg het cloudevents-Content-Type"
+    fi
+  else
+    fout "de stub ontving geen event voor '${MERK}' binnen ${PUBLICATIE_TIMEOUT}s"
+  fi
+fi
+
+# --- 2. Verantwoording ---------------------------------------------------------------------------
+# Zelfde meting als smoke-keten.sh, maar over verkeer dat het MAGAZIJN veroorzaakte en in de
+# tegenovergestelde richting: hier is het magazijn de consumer.
+echo "== 2. verantwoording in beide txlogs =="
+if [ -z "${PROJECT:-}" ]; then
+  fout "projectnaam van de gastheer niet af te leiden — deze assert heeft niets gemeten"
+elif [ "$VOOR_OK" -ne 1 ]; then
+  fout "de nulmeting op de txlogs mislukte — deze assert heeft niets gemeten"
+elif ! NA="$(gedeelde_txids)"; then
+  fout "de txlogs zijn na afloop niet leesbaar — deze assert heeft niets gemeten"
+else
+  NIEUW="$(comm -13 <(printf '%s\n' "$VOOR") <(printf '%s\n' "$NA") | grep -c . || true)"
+
+  if [ "${NIEUW:-0}" -gt 0 ]; then
+    ok "${NIEUW} nieuwe transactie(s) in beide txlogs, uitgaand bij ${PUSHER} en inkomend bij ${NOTIFICATIE}"
+  else
+    fout "geen NIEUWE gedeelde transactie-id — het magazijn ging buiten de outway om"
+  fi
+fi
+
+# --- 3. Fire-and-forget --------------------------------------------------------------------------
+echo "== 3. één aflevering, geen retry-stapeling =="
+if [ "$AANTAL" -eq 0 ]; then
+  fout "geen aflevering gevonden voor '${MERK}' — assert 1 was al rood"
+elif [ "$AANTAL" -eq 1 ]; then
+  ok "het magazijn leverde één keer af en kreeg zijn 202 terug"
+else
+  fout "${AANTAL} afleveringen voor hetzelfde bericht — het antwoord van de stub komt niet terug door de keten"
+fi
+
+echo
+if [ "$FOUTEN" -eq 0 ]; then
+  echo "== NOTIFICATIE-SMOKE GROEN =="
+else
+  echo "== NOTIFICATIE-SMOKE ROOD: ${FOUTEN} bevinding(en) ==" >&2
+  exit 1
+fi

--- a/demo/environment/federatie/smoke-notificatie.sh
+++ b/demo/environment/federatie/smoke-notificatie.sh
@@ -274,6 +274,16 @@ fi
 
 # --- 3. Fire-and-forget --------------------------------------------------------------------------
 echo "== 3. één aflevering, geen retry-stapeling =="
+# Opnieuw tellen, en niet leunen op de stand uit assert 1. Die lus brak af zodra er íets binnen was,
+# dus dat getal is de momentopname van de eerste waarneming — een retry-stapeling landt per definitie
+# daarná en zou onzichtbaar blijven. Eerst een venster laten verstrijken dat ruim genoeg is voor de
+# eerste herhaling (backoff begint op een seconde).
+if [ "$AANTAL" -ge 1 ]; then
+  sleep "$PUBLICATIE_INTERVAL"
+  AANTAL="$(tel_afleveringen || true)"
+  [ -n "$AANTAL" ] || AANTAL=0
+fi
+
 if [ "$AANTAL" -eq 0 ]; then
   fout "geen aflevering gevonden voor '${MERK}' — assert 1 was al rood"
 elif [ "$AANTAL" -eq 1 ]; then

--- a/demo/environment/lib/fsc-contract.sh
+++ b/demo/environment/lib/fsc-contract.sh
@@ -169,22 +169,18 @@ fsc_json_lijst() {
 # fout die hier het signaal is. Een 200 met een ander lijstveld, met `null`, of met een lege body
 # levert dan 0 regels op — niet te onderscheiden van "er zijn geen contracten". Aan consumer-kant
 # betekent dat elke ronde een nieuw contract indienen, en op ZAD draait die ronde elke 15 seconden.
+#
+# Géén controle op `next_cursor`. De cursor is bij OpenFSC v2.5.2 geen afkap-signaal: de manager
+# zet 'm op élke pagina die rijen bevat, ook als die pagina de hele lijst is en de opgevraagde
+# `limit` ruim gehaald wordt; de vólgende pagina komt dan leeg terug met een lege cursor. Erop
+# afbreken betekent dus stuklopen zodra er ook maar één contract bestaat. Het doorlezen gebeurt
+# vóór dit punt, in fsc_contracten_paginas (fsc-harness.sh) — wat hier binnenkomt is de
+# samengevoegde lijst.
 _FSC_CONTRACTEN_JQ='
   def contracten:
     if type != "object" then error("respons is geen JSON-object")
     elif has("contracts") | not then error("respons heeft geen veld \"contracts\"")
     elif (.contracts | type) != "array" then error("veld \"contracts\" is \(.contracts | type), geen array")
-    elif ((.pagination.next_cursor? // .next_cursor? // "") | tostring) != "" then
-      # De lijst is cursor-gepagineerd. Alleen pagina 1 lezen zou betekenen dat de consumer zijn
-      # eigen contract niet meer ziet zodra de manager er genoeg heeft — en dan dient hij elke ronde
-      # een nieuw contract in. Afbreken tot iemand de cursor volgt; stil doorgaan is hier de
-      # gevaarlijke keuze.
-      #
-      # Twee plekken, want het veld staat genest onder `pagination` en niet op topniveau; alleen de
-      # topniveau-vorm toetsen zou een guard opleveren die nooit vuurt, en dat is slechter dan geen
-      # guard. De aanroepers vragen daarnaast expliciet een ruime `limit` op, zodat dit een vangrail
-      # blijft in plaats van een dagelijkse blokkade.
-      error("de contractenlijst is gepagineerd (next_cursor gezet) en dat volgen we nog niet")
     else .contracts end;
 '
 

--- a/demo/environment/lib/fsc-harness.sh
+++ b/demo/environment/lib/fsc-harness.sh
@@ -261,12 +261,64 @@ fsc_alle_peers() { printf '%s %s' "$GASTHEER" "$GASTEN"; }
 fsc_manager_contracts() {
   local envdir="$1" peer="$2" adres="$3" naam="manager.$2.fsc-test.local"
 
-  curl -sS --fail-with-body --noproxy '*' \
-    --resolve "${naam}:9443:${adres}" \
-    --cert "${envdir}/${peer}/pki/internal/${peer}/manager/cert.pem" \
-    --key  "${envdir}/${peer}/pki/internal/${peer}/manager/key.pem" \
-    --cacert "${envdir}/${peer}/pki/internal/${peer}/ca/root.pem" \
-    "https://${naam}:9443/v1/contracts" 2>"$ERRLOG"
+  _fsc_haal() {
+    curl -sS --fail-with-body --noproxy '*' \
+      --resolve "${naam}:9443:${adres}" \
+      --cert "${envdir}/${peer}/pki/internal/${peer}/manager/cert.pem" \
+      --key  "${envdir}/${peer}/pki/internal/${peer}/manager/key.pem" \
+      --cacert "${envdir}/${peer}/pki/internal/${peer}/ca/root.pem" \
+      "$1" 2>"$ERRLOG"
+  }
+
+  fsc_contracten_paginas _fsc_haal "https://${naam}:9443/v1/contracts?limit=1000"
+}
+
+# fsc_contracten_paginas <ophaler> <basis-url>: alle contracten over álle pagina's, als één
+# `{"contracts":[...]}`-object op stdout. <ophaler> is de naam van een functie die één URL ophaalt
+# en de body op stdout zet.
+#
+# WAAROM PAGINEREN. De manager (OpenFSC v2.5.2) zet `pagination.next_cursor` op élke pagina die
+# rijen bevat — óók als die pagina de hele lijst is en de opgevraagde `limit` ruim gehaald wordt.
+# De cursor betekent daar "er kán meer zijn", niet "er ís meer": de volgende pagina komt leeg terug
+# mét een lege cursor. Wie de cursor als afkap-signaal leest, breekt dus af zodra er ook maar één
+# contract bestaat. Vandaar doorlezen tot de cursor leeg is, in plaats van er conclusies aan te
+# verbinden.
+#
+# De uitkomst is bewust weer een `{"contracts":[...]}`-object en geen kale array: alle jq erachter
+# (fsc_contract_beoordeling, fsc_contract_voor_combinatie, fsc_grant_actief) toetst dat veld en de
+# vorm ervan, en die controles horen te blijven gelden.
+fsc_contracten_paginas() {
+  local ophaler="$1" basis="$2" cursor="" url body pagina alle="[]" ronde=0
+
+  while :; do
+    if [ -n "$cursor" ]; then
+      url="${basis}&cursor=$(printf '%s' "$cursor" | jq -sRr @uri)"
+    else
+      url="$basis"
+    fi
+
+    body="$("$ophaler" "$url")" || return 1
+
+    # Geen jq-vangnet met `//`: een respons die geen contractenlijst is, moet hier hard stuk in
+    # plaats van als lege pagina door te glippen. De aanroepers melden dat met hun eigen tekst.
+    pagina="$(printf '%s' "$body" | jq -e '.contracts' 2>"$ERRLOG")" || return 1
+    alle="$(jq -cn --argjson a "$alle" --argjson b "$pagina" '$a + $b')" || return 1
+
+    cursor="$(printf '%s' "$body" | jq -r '.pagination.next_cursor? // .next_cursor? // ""')" || return 1
+    [ -n "$cursor" ] || break
+
+    # Bovengrens tegen een server die eindeloos een cursor blijft zetten: zonder deze rem zou een
+    # bootstrap-lus hier blijven hangen zonder ooit iets te melden. Duizend rijen per pagina maakt
+    # honderd rondes ruim genoeg voor elk realistisch deployment.
+    ronde=$((ronde + 1))
+
+    if [ "$ronde" -ge 100 ]; then
+      echo "de contractenlijst geeft na ${ronde} pagina's nog een cursor — afgebroken" >"$ERRLOG"
+      return 1
+    fi
+  done
+
+  jq -cn --argjson c "$alle" '{contracts: $c}'
 }
 
 # fsc_component_adres <net> <component>: het adres van een component binnen het /24 van een peer,

--- a/demo/environment/lib/fsc-harness.sh
+++ b/demo/environment/lib/fsc-harness.sh
@@ -126,18 +126,31 @@ fsc_grant_hash() {
     | ($g[0] // "unknown")' 2>/dev/null || echo unknown
 }
 
-# fsc_zet_upstream <envdir> <peer> <upstream-url>: publiceer de dienst van die peer (opnieuw) met
-# deze upstream achter de inway. Idempotent — bestaat de dienst al met dezelfde upstream, dan doet
-# publish-service.sh niets.
+# fsc_zet_upstream <envdir> <peer> <upstream-url> [dienst]: publiceer een dienst van die peer
+# (opnieuw) met deze upstream achter de inway. Zonder [dienst] gaat het om de standaarddienst van
+# de peer. Idempotent — bestaat de dienst al met dezelfde upstream, dan doet publish-service.sh
+# niets.
 #
 # Elke smoke die over het data-pad iets beweert, hoort dit zelf te zetten in plaats van het als
 # voorwaarde op te schrijven: smoke-contract.sh toetst de echo van de stub, smoke-keten.sh het
 # échte magazijn, en wie ze na elkaar draait zou anders de ene de andere zien omgooien.
 fsc_zet_upstream() {
-  FSC_CONTROLLER="https://controller.$2.fsc-test.local:9444" \
-  FSC_MANAGER="https://manager.$2.fsc-test.local:9443" \
-  FSC_UPSTREAM_URL="$3" \
-    "$1/$2/deploy/local/publish-service.sh"
+  local envdir="$1" peer="$2" upstream="$3" dienst="${4:-}"
+
+  (
+    export FSC_CONTROLLER="https://controller.${peer}.fsc-test.local:9444"
+    export FSC_MANAGER="https://manager.${peer}.fsc-test.local:9443"
+    export FSC_UPSTREAM_URL="$upstream"
+
+    # Zonder vierde argument publiceert de peer zijn eigen standaarddienst — de default in zijn
+    # publish-service.sh. Niet hier een naam verzinnen: dan zou deze functie moeten weten welke
+    # peer welke dienst draagt.
+    if [ -n "$dienst" ]; then
+      export FSC_SERVICE_NAME="$dienst"
+    fi
+
+    "${envdir}/${peer}/deploy/local/publish-service.sh"
+  )
 }
 
 # fsc_compose_env_waarde <waarde>: waarde zoals hij in een `env_file` van docker compose moet staan.

--- a/demo/environment/lib/test-fsc-contract.sh
+++ b/demo/environment/lib/test-fsc-contract.sh
@@ -383,10 +383,7 @@ echo "== de contractenlijst moet een lijst zijn =="
 
 # Een 200 met een andere vorm mag niet als "geen contracten" doorgaan: aan consumer-kant zou dat
 # elke ronde een nieuw contract opleveren.
-# Een gepagineerde lijst hoort ook af te vallen: alleen pagina 1 lezen zou betekenen dat de consumer
-# zijn eigen contract niet meer ziet zodra de manager er genoeg heeft, en dus elke ronde opnieuw
-# indient.
-for vorm in '' ' ' '{}' '{"contracts":null}' '{"contracts":"x"}' '[]' '<html>502</html>' '{"contracts":[],"next_cursor":"abc"}'; do
+for vorm in '' ' ' '{}' '{"contracts":null}' '{"contracts":"x"}' '[]' '<html>502</html>'; do
   if beoordeel "$vorm" >/dev/null 2>&1; then
     echo "FAIL: respons '${vorm:-<leeg>}' werd stil als lege lijst gelezen" >&2
     fails=$((fails + 1))
@@ -396,6 +393,12 @@ for vorm in '' ' ' '{}' '{"contracts":null}' '{"contracts":"x"}' '[]' '<html>502
 done
 
 assert_beoordeling "een echte lege lijst is wél geldig" '{"contracts":[]}' TEKEN ""
+
+# Een cursor is géén reden om af te wijzen. De manager zet 'm op elke pagina die rijen bevat, ook
+# als die pagina de hele lijst is; erop afbreken zou de bootstrap laten stuklopen zodra er één
+# contract bestaat. Het doorlezen zit in fsc_contracten_paginas, niet in de beoordeling.
+assert_beoordeling "een lijst mét cursor wordt gewoon beoordeeld" \
+  '{"contracts":[],"pagination":{"next_cursor":"abc"}}' TEKEN ""
 
 echo
 echo "== één misvormde rij mag de rest niet meenemen =="

--- a/demo/environment/logius/deploy/local/publish-service.sh
+++ b/demo/environment/logius/deploy/local/publish-service.sh
@@ -22,7 +22,9 @@ fsc_have_jq
 
 # shellcheck disable=SC2034  # gelezen door fsc_tb() uit de caller-scope (lib/fsc-harness.sh).
 COMPOSE=(docker compose -f "$HERE/docker-compose.yaml")
-SERVICE_NAME="profiel-service"
+# Overrulebaar omdat één inway meer dan één dienst kan dragen: logius biedt naast profiel-service
+# ook notificatieservice aan. Dezelfde variabelenaam als smoke-discover.sh gebruikt.
+SERVICE_NAME="${FSC_SERVICE_NAME:-profiel-service}"
 PROVIDER_OIN="00000000000000001000"
 DIR_OIN="00000000000000000010"
 GROUP_ID="moza-fbs-test"

--- a/demo/environment/logius/deploy/zad/verify-zad.md
+++ b/demo/environment/logius/deploy/zad/verify-zad.md
@@ -87,6 +87,25 @@ infrastructuur:
    `berichtenuitvraag`-app zetten (project `mpfb-8wh`).
 5. Een smoke voor het pad `berichtenuitvraag → logius-fscoutway → logius-fscinway → upstream`.
 
+### Inbound data-pad — notificatieservice (lokaal bewezen, ZAD-apply is handmatig vervolgwerk)
+
+Lokaal bewezen met `federatie/smoke-notificatie.sh` (zie
+`docs/plans/2026-08-17-notificatie-via-fsc-plan.md`): `logius` biedt naast `profiel-service` ook
+`notificatieservice` aan op dezelfde inway, met de notificatie-stub als upstream, en het magazijn
+pusht zijn CloudEvents daarheen door zijn eigen outway. Op ZAD moet dit nog worden herhaald tegen
+de échte infrastructuur:
+
+1. `CreateService` via de `logius-fscctl` Administration-API (`SERVICE_NAME=notificatieservice`,
+   `endpoint_url` = de echte notificatiedienst, `inway_address` = `SELF_ADDRESS` van
+   `logius-fscinway`). Eén inway kan meerdere diensten dragen; dit komt náást `profiel-service`.
+2. Het `serviceConnection`-contract met het magazijn opzetten — `bootstrap-consumer.sh` draait aan
+   magazijn-kant, `bootstrap-provider.sh` hier. Zie `federatie/contracts/zad-runbook.md`.
+3. `NOTIFICATIE_URL=https://fsc-magazijna-magazijna-fscoutway:8443/events` en
+   `NOTIFICATIE_GRANT_HASH=<grant-hash uit stap 2>` als env-vars op het gedeployde
+   `berichtenmagazijn` (project `mpfm-w3h`). Beide samen: alleen de hash zetten laat het magazijn
+   FSC-headers naar de oude bestemming sturen, alleen de URL levert `service not found`.
+4. Een smoke voor het pad `berichtenmagazijn → magazijna-fscoutway → logius-fscinway → upstream`.
+
 ## Acceptatiecriteria — afvinklijst
 
 - [ ] Peer (echte OIN) draait op ZAD: manager + controller + outway + inway + txlog + DB

--- a/demo/environment/magazijn-a/deploy/local/docker-compose.podman-hostnet.yaml
+++ b/demo/environment/magazijn-a/deploy/local/docker-compose.podman-hostnet.yaml
@@ -57,6 +57,7 @@ x-hosts: &hosts
   - "controller.magazijn-a.fsc-test.local:127.0.0.1"
   - "txlog.magazijn-a.fsc-test.local:127.0.0.1"
   - "inway.magazijn-a.fsc-test.local:127.0.0.1"
+  - "outway.magazijn-a.fsc-test.local:127.0.0.1"
   - "stub-upstream:127.0.0.1"
   - "postgres:127.0.0.1"
 
@@ -116,6 +117,18 @@ services:
     # dual-stack wildcard-bind: die verschijnt in `ss` als `*:8080`, niet als `0.0.0.0:8080`, en
     # ontsnapt dus aan een controle die alleen op `0.0.0.0` zoekt.
     command: ["-listen=127.0.0.1:8080", "-text=hello from magazijn-a stub-upstream"]
+
+  outway-magazijn-a:
+    network_mode: host
+    networks: !reset null
+    extra_hosts: *hosts
+    restart: on-failure:600
+    environment:
+      # MANAGER_INTERNAL_ADDRESS blijft naar 9443 wijzen — die poort verhuist niet.
+      LISTEN_ADDRESS: 127.0.0.1:58443
+      MONITORING_ADDRESS: 127.0.0.1:58081
+      CONTROLLER_REGISTRATION_API_ADDRESS: https://controller.magazijn-a.fsc-test.local:39443
+      TX_LOG_API_ADDRESS: https://txlog.magazijn-a.fsc-test.local:49443
 
   inway-magazijn-a:
     network_mode: host

--- a/demo/environment/magazijn-a/deploy/local/docker-compose.podman.yaml
+++ b/demo/environment/magazijn-a/deploy/local/docker-compose.podman.yaml
@@ -19,6 +19,9 @@ services:
   manager-magazijn-a:
     userns_mode: "keep-id"
 
+  outway-magazijn-a:
+    userns_mode: "keep-id"
+
   inway-magazijn-a:
     userns_mode: "keep-id"
 

--- a/demo/environment/magazijn-a/deploy/local/docker-compose.yaml
+++ b/demo/environment/magazijn-a/deploy/local/docker-compose.yaml
@@ -187,6 +187,49 @@ services:
     image: docker.io/hashicorp/http-echo:1.0
     command: ["-listen=:8080", "-text=hello from magazijn-a stub-upstream"]
 
+  outway-magazijn-a:
+    image: docker.io/federatedserviceconnectivity/outway:${IMAGE_TAG:-v2.5.2}
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"   # host-UID -> leest 0600-keys
+    restart: on-failure                            # boot-race met de eigen manager
+    command:
+      - /usr/local/bin/outway
+      - serve
+    environment:
+      LOG_TYPE: local
+      LOG_LEVEL: debug
+      GROUP_ID: moza-fbs-test
+      NAME: magazijn-a-outway
+      SELF_ADDRESS: https://outway.magazijn-a.fsc-test.local:443
+      LISTEN_ADDRESS: 0.0.0.0:8443
+      MONITORING_ADDRESS: 0.0.0.0:8081
+      DISABLE_CRL_CHECKS: "true"
+      # De outway registreert zich bij de controller en praat met de manager op de authenticated
+      # interne poort (:9443). fsc-outway serve eist beide.
+      MANAGER_INTERNAL_ADDRESS: https://manager.magazijn-a.fsc-test.local:9443
+      CONTROLLER_REGISTRATION_API_ADDRESS: https://controller.magazijn-a.fsc-test.local:9443
+      # Echte txlog-api (INTERNAL-PKI mTLS): bij egress logt de outway de transactie (direction: out).
+      TX_LOG_API_ADDRESS: https://txlog.magazijn-a.fsc-test.local:9443
+      TLS_ROOT_CERT: /pki/internal/magazijn-a/ca/root.pem
+      TLS_CERT: /pki/internal/magazijn-a/outway/cert.pem
+      TLS_KEY: /pki/internal/magazijn-a/outway/key.pem
+      TLS_GROUP_ROOT_CERT: /pki/ca/root.pem
+      TLS_GROUP_CERT: /pki/out/magazijn-a/outway/cert.pem
+      TLS_GROUP_KEY: /pki/out/magazijn-a/outway/key.pem
+    volumes:
+      - "${PKI_DIR:?zet PKI_DIR in .env}:/pki:ro"
+    networks:
+      default:
+        # Alias = de internal-cert-hostnaam; géén :443-router-route (de outway is client, geen ingress).
+        aliases:
+          - outway.magazijn-a.fsc-test.local
+    depends_on:
+      manager-magazijn-a:
+        condition: service_started
+      controller-magazijn-a:
+        condition: service_started
+      txlog-magazijn-a:
+        condition: service_started
+
   inway-magazijn-a:
     image: docker.io/federatedserviceconnectivity/inway:${IMAGE_TAG:-v2.5.2}
     user: "${HOST_UID:-1000}:${HOST_GID:-1000}"   # host-UID -> leest 0600-keys

--- a/demo/environment/magazijn-a/deploy/local/publish-service.sh
+++ b/demo/environment/magazijn-a/deploy/local/publish-service.sh
@@ -22,7 +22,8 @@ fsc_have_jq
 
 # shellcheck disable=SC2034  # gelezen door fsc_tb() uit de caller-scope (lib/fsc-harness.sh).
 COMPOSE=(docker compose -f "$HERE/docker-compose.yaml")
-SERVICE_NAME="berichtenmagazijn"
+# Overrulebaar, symmetrisch met de andere peers: één inway kan meer dan één dienst dragen.
+SERVICE_NAME="${FSC_SERVICE_NAME:-berichtenmagazijn}"
 PROVIDER_OIN="00000000000000100000"
 DIR_OIN="00000000000000000010"
 GROUP_ID="moza-fbs-test"                 # = GROUP_ID env-var op de manager; als de manager een directory-adres verwacht, gebruik DIRECTORY_MANAGER_ADDRESS

--- a/demo/environment/magazijn-a/deploy/zad/verify-zad.md
+++ b/demo/environment/magazijn-a/deploy/zad/verify-zad.md
@@ -59,11 +59,24 @@ Analoog aan `deploy/local/smoke-discover.sh`, tegen de ZAD-directory-DB of
 via de directory-UI: `berichtenmagazijn` moet als dienst van OIN `00000000000000100000` in de
 catalogus staan.
 
+## (d) Outway — uitgaand verkeer van het magazijn
+
+Sinds de notificatie-push heeft deze peer ook een outway (`magazijna-fscoutway`): het magazijn is
+niet alleen aanbieder van `berichtenmagazijn` maar ook afnemer van `notificatieservice`, en dat
+verkeer gaat uit door zijn eigen outway. Het component is nieuw op ZAD en moet daar nog aangemaakt
+worden: opnemen in de projectspec, certificaten uit `pki/peers/magazijn-a/outway/` uitgeven en de
+bijlagen koppelen zoals `cert-manifest.md` dat voor de andere componenten beschrijft. De outway is
+egress-only en heeft geen ingress-route nodig.
+
+Het component kan vooruitlopend worden uitgerold zonder gedrag te veranderen: zolang
+`NOTIFICATIE_GRANT_HASH` op het magazijn leeg is, blijft de aflevering rechtstreeks lopen.
+
 ## Acceptatiecriteria — afvinklijst
 
 - [ ] Peer (echte OIN) draait op ZAD: manager + controller + inway + txlog + DB (project-isolatie)
 - [ ] Peer heeft een geldige group-cert (getekend onder fsc-testnet's group-CA)
 - [ ] Peer meldt zich aan bij de directory (announce)
 - [ ] `berichtenmagazijn` gepubliceerd + vindbaar in de directory
+- [ ] `magazijna-fscoutway` draait en registreert zich bij `magazijna-fscctl` (zie (d))
 
 Elk vinkje vereist een operator met ZAD-toegang, gegenereerde certs en een draaiende peer.

--- a/demo/environment/magazijn-a/pki/gen-csr.sh
+++ b/demo/environment/magazijn-a/pki/gen-csr.sh
@@ -34,7 +34,7 @@ PEER="magazijn-a"
 OIN="00000000000000100000"                                # = subject.serialNumber = Peer ID
 # endpoint:component-korte-naam (de ZAD-component + Service heet `<deployment>-<short>`). Volgorde
 # bepaalt de uitvoer-volgorde; spiegelt de MGZ*_SVC-namen in upsert-peer.sh.
-ENDPOINTS=( "manager:magazijna-fscmgr" "controller:magazijna-fscctl" "inway:magazijna-fscinway" "txlog:magazijna-fsctxlog" "bootstrap:magazijna-fscbootstrap" )
+ENDPOINTS=( "manager:magazijna-fscmgr" "controller:magazijna-fscctl" "inway:magazijna-fscinway" "outway:magazijna-fscoutway" "txlog:magazijna-fsctxlog" "bootstrap:magazijna-fscbootstrap" )
 
 # Genereer per endpoint de csr.json. SAN-volgorde: peer-identiteit (alleen manager) ->
 # <endpoint>.<peer>.fsc-test.local -> externe mesh-host -> Service-kortnaam -> Service-FQDN.

--- a/demo/environment/magazijn-a/pki/peers/magazijn-a/outway/csr.json
+++ b/demo/environment/magazijn-a/pki/peers/magazijn-a/outway/csr.json
@@ -1,0 +1,20 @@
+{
+  "CN": "outway.magazijn-a.fsc-test.local",
+  "key": {
+    "algo": "rsa",
+    "size": 4096
+  },
+  "hosts": [
+    "outway.magazijn-a.fsc-test.local",
+    "magazijna-fscoutway-fsc-magazijna-mpfm-w3h.rig.prd1.gn2.quattro.rijksapps.nl",
+    "fsc-magazijna-magazijna-fscoutway",
+    "fsc-magazijna-magazijna-fscoutway.rig-prd-mpfm-w3h.svc.cluster.local"
+  ],
+  "serialnumber": "00000000000000100000",
+  "names": [
+    {
+      "O": "magazijn-a",
+      "C": "NL"
+    }
+  ]
+}

--- a/docs/plans/2026-08-17-notificatie-via-fsc-design.md
+++ b/docs/plans/2026-08-17-notificatie-via-fsc-design.md
@@ -1,0 +1,180 @@
+**Status:** Concept
+
+# Notificatie-events via FSC — ontwerp
+
+Issue: MinBZK/MijnOverheidZakelijk#784. Zusterissue #730 (profiel-bevraging via FSC) is
+uitgevoerd als dienstpublicatie op de `logius`-peer.
+
+## Context
+
+Het berichtenmagazijn publiceert bericht-events als CloudEvents-webhook: `POST /events` met
+`Content-Type: application/cloudevents+json`, antwoord `202`. Dat loopt nu rechtstreeks naar een
+WireMock-stub (`compose.yaml`, host `:8084`), via `DownstreamClient` op een kale
+`java.net.http.HttpClient`. Het doelmodel schrijft iets anders voor: `workspace.dsl:191` zegt
+"CloudEvents webhook via FSC". Dit ontwerp haalt de implementatie naar dat model toe.
+
+Waar #730 een **pull**-bevraging door de mesh bracht, bewijst dit een **push**: het magazijn is
+hier de afnemer die uitgaand verkeer door zijn eigen outway stuurt.
+
+## Rolverdeling
+
+| Rol | Peer | Component |
+|-----|------|-----------|
+| Consumer (pusher) | `magazijn-a` (OIN `00000000000000100000`) | outway — **nieuw** |
+| Provider (ontvanger) | `logius` (OIN `00000000000000001000`) | bestaande inway, tweede dienst |
+
+De notificatiedienst komt op de bestaande `logius`-inway te staan, naast `profiel-service`. Dat is
+een bewuste afwijking van het acceptatiecriterium "eigen OIN, cert uit test-CA": een derde
+peer-stack kost een volledige compose-, PKI- en adresruimte-duplicatie, terwijl de eigenschap die
+dit issue moet bewijzen — een magazijn dat uitgaand door FSC pusht — daar niet van afhangt. De
+dienst is later naar een eigen peer te verhuizen; dat is dan een publicatie- en contractwijziging,
+geen wijziging aan het magazijn.
+
+Gevolg is dat het verkeer tussen deze twee peers voortaan **beide kanten op** loopt:
+
+- `logius → magazijn-a` — `berichtenmagazijn` ophalen (bestond al, #782);
+- `magazijn-a → logius` — `notificatieservice` pushen (nieuw).
+
+Daarmee toont de harness meteen dat een peer niet in één rol vastzit: `magazijn-a` is provider én
+consumer, `logius` andersom.
+
+## Wat er niet klopte aan de issue-analyse
+
+Het issue noemt de FBS-kant "config-only, #726-patroon". Dat gaat hier niet op.
+
+De outway kiest de doel-inway op de header `Fsc-Grant-Hash`, en `fsc-outway serve` eist daarnaast
+een `Fsc-Transaction-Id` in UUID-v7-vorm; zonder die headers antwoordt hij met "service not found"
+respectievelijk "invalid uuid version, must be v7". In deze codebase worden die headers gezet door
+`FscOutwayHeadersFilter` / `ProfielFscOutwayHeadersFilter`, en dat zijn **JAX-RS-clientfilters**.
+`DownstreamClient` is bewust géén JAX-RS-client — aantal en URL's van downstreams komen uit config,
+dus een `@RegisterRestClient` per stuk zou minder flexibel zijn. Alleen de URL naar de outway
+ombuigen levert dus een `service not found`.
+
+Er is daarom een codewijziging in `berichtenmagazijn` nodig. Klein, maar wel echt.
+
+## Ontwerp — applicatiekant
+
+### Grant-hash per downstream
+
+`PublicatieConfig.Downstream` krijgt een optionele `grant-hash`
+(`magazijn.publicatie.downstreams.<key>.grant-hash`). Leeg of afwezig = het huidige gedrag: geen
+FSC-headers, rechtstreeks verkeer. Dat is niet alleen een migratiepad maar de blijvende situatie
+voor downstreams die buiten de mesh liggen.
+
+### Headercontract op één plek
+
+`FscOutwayHeaders` levert het headerpaar voortaan als data (grant-hash + verse UUID-v7
+transaction-id). De bestaande `zet(ClientRequestContext, ...)` gaat daarop leunen, zodat er één
+bron van waarheid blijft en JAX-RS-callers ongemoeid blijven. `DownstreamClient` zet dezelfde
+headers op zijn `HttpRequest.Builder`.
+
+Het alternatief — `DownstreamClient` omzetten naar een JAX-RS-client zodat het bestaande filter
+past — is verworpen: dat draait de bewuste keuze voor config-gedreven downstreams terug en raakt
+de retry-, timeout- en foutafhandeling die daaromheen is gebouwd.
+
+### SSRF-blocklist en de outway
+
+`DownstreamClient.valideerUrl` hanteert een exacte loopback-whitelist (`localhost`, `127.0.0.1`,
+`[::1]`), een TLS-eis buiten loopback (BIO 13.2.1) en een SSRF-blocklist op alles wat naar een
+intern adres resolveert. Die drie zijn geschreven voor downstreams die over publiek internet naar
+een federatieve dienstverlener gaan. Voor de outway kloppen ze niet:
+
+- **lokaal** draait de demo-stack met `QUARKUS_PROFILE=dev`, waar de hele validatie al uitstaat —
+  het federatiebewijs loopt dus sowieso;
+- **op ZAD** wordt de outway aangesproken als `https://fsc-…-fscoutway:8443` (zie
+  `logius/deploy/zad/verify-zad.md`). De TLS-eis is dan voldaan, maar die ClusterIP resolveert naar
+  een RFC1918-adres en loopt op de blocklist stuk.
+
+Besluit: **een downstream met een grant-hash slaat de SSRF-blocklist over**. De TLS-eis blijft
+onverkort staan. De rechtvaardiging is dat de bestemming van zo'n call niet meer door onze URL
+wordt bepaald maar door het FSC-contract: de outway routeert op de grant-hash, en een URL die naar
+een ander intern adres wijst levert geen verkeer maar een fout. Dat is een strakkere garantie dan
+de blocklist geeft, niet een zwakkere.
+
+Wat er wél mee verdwijnt: een operator met config-toegang kan het magazijn met een verzonnen
+grant-hash op een intern adres richten. Die bypass moet daarom zichtbaar zijn — bij boot logt het
+magazijn één regel met een alert-token die opsomt welke downstreams door een outway lopen, in
+dezelfde vorm als het bestaande `DOWNSTREAM_URL_VALIDATIE_UIT`.
+
+De overwogen alternatieven: een aparte `via-outway`-vlag (een tweede knop die altijd samen met de
+grant-hash gezet moet worden — twee dingen die uiteen kunnen lopen), en de validatie ongemoeid
+laten (kleinste diff, maar dan beschrijft het ZAD-runbook een pad dat bij de eerste poging faalt).
+
+## Ontwerp — harness
+
+### Outway bij `magazijn-a`
+
+De peer heeft er nog geen. Het adresschema in `federatie/README.md` reserveert `.5` al voor elke
+peer, dus de outway komt op `127.20.2.5:8443`, gespiegeld aan `outway-logius`. Dat raakt: de
+PKI-definitie (`pki/peers/magazijn-a/outway/csr.json`, met de ZAD-hostnamen erin zoals de andere
+componenten die dragen), de drie compose-bestanden van de peer, en de federatie-overlay.
+
+### Twee diensten op één inway
+
+`logius/deploy/local/publish-service.sh` heeft de dienstnaam hardcoded. Die wordt overrulebaar via
+`FSC_SERVICE_NAME` — dezelfde variabelenaam die `smoke-discover.sh` al gebruikt — met de huidige
+waarde als default, zodat bestaande aanroepen niet wijzigen. `fsc_zet_upstream()` krijgt de dienst
+als extra argument.
+
+De upstream van `notificatieservice` is de bestaande WireMock notificatie-stub op host `:8084`, net
+zoals `smoke-keten.sh` de inway van `magazijn-a` naar het échte magazijn op `:8090` laat wijzen.
+
+### Rollen en contract
+
+`peers.env` krijgt de notificatierollen: welke peer de dienst draagt, welke peers pushen, en de
+dienstnaam. `contracts/fbs-contracten.sh` krijgt een tweede lus die per pusher een contract opzet
+en het grant-hash naar hetzelfde `demo/generated/fsc-grants.env` schrijft. Dat bestand houdt
+bewust één schrijver, inclusief het opruimen ervan bij een mislukte run — een grant-hash uit een
+vorige federatie die blijft staan, levert stil `400 UNKNOWN_GRANT_HASH_IN_HEADER` op.
+
+De contract-bootstrap zelf is generiek en hoeft niet te wijzigen: `bootstrap.sh` krijgt alle peers,
+adressen en certificaten uit env.
+
+### Demo-stack
+
+`compose.podman-hostnet.yaml` geeft `berichtenmagazijn` dezelfde `env_file`-koppeling naar
+`demo/generated/fsc-grants.env` die de uitvraag al heeft, plus een overrulebare `NOTIFICATIE_URL`.
+Ontbreekt dat bestand — geen federatie op deze machine — dan start de stack zonder grant-hash en
+valt het magazijn terug op rechtstreeks verkeer.
+
+## Verificatie
+
+`federatie/smoke-notificatie.sh`, naar het model van `smoke-keten.sh`:
+
+1. **Data-pad** — een uniek gemerkt bericht aanleveren bij `magazijn-a`; na de outbox-poller staat
+   de CloudEvent in de request-journal van de stub (`__admin/requests`), mét
+   `Content-Type: application/cloudevents+json`. Het merk is uniek per run: zonder dat houdt een
+   event uit een eerdere run de assert groen terwijl de keten stuk is.
+2. **Verantwoording** — een nieuwe gedeelde transactie-id in beide txlogs: uitgaand bij
+   `magazijn-a`, inkomend bij `logius`, op `service_name = notificatieservice`. Ging de push
+   rechtstreeks, dan groeit geen van beide. Met nulmeting vooraf, om dezelfde reden als in
+   `smoke-keten.sh`: een eerdere run laat rijen achter.
+3. **Fire-and-forget intact** — de stub blijft `202` geven en de claim komt op afgeleverd te staan
+   in plaats van in de retry-lus te blijven hangen.
+
+De outbox-poller draait op 60s. De smoke wacht daarop met een bovengrens, en verlaagt de interval
+niet: anders bewijst hij een configuratie die niemand draait.
+
+Applicatiekant, op de bestaande `DownstreamHttpServer`-opzet: geparametriseerd over afwezig, leeg,
+whitespace en gevuld grant-hash — headers exact doorgegeven, transaction-id parseert als UUID v7,
+en bij een lege waarde géén van beide headers. Plus de SSRF-uitzondering: intern adres mét
+grant-hash gaat door, intern adres zónder wordt geweigerd.
+
+## Buiten scope
+
+- **De aanmeld-downstream.** Technisch identiek en in het C4-model óók via FSC, maar `aanmeld`
+  wijst niet naar een stub maar naar de échte uitvraag-webhook. Dat pad verdient een eigen
+  dienstpublicatie en een eigen issue. De codewijziging hier maakt het daarna klein: één contract
+  en één configregel.
+- **Een eigen `notificatie`-peer.** Zie de afweging onder Rolverdeling.
+- **Live ZAD-uitrol.** De runbooks worden bijgewerkt (outway-component bij `magazijn-a`,
+  `CreateService notificatieservice`, env-vars op het gedeployde magazijn), maar het toepassen
+  ervan vereist echte ZAD-toegang en blijft — net als bij elk eerder peer-plan — handmatig
+  vervolgwerk.
+- **`workspace.dsl`.** Regel 191 beschrijft dit pad al correct.
+
+## Openstaand
+
+De dienst heet `notificatieservice`, letterlijk zoals in de acceptatiecriteria. Dat wijkt af van
+`profiel-service` en sluit aan bij `berichtenmagazijn`; de bestaande namen zijn onderling al niet
+consistent, dus dit ontwerp volgt het issue in plaats van een derde schrijfwijze te introduceren.

--- a/docs/plans/2026-08-17-notificatie-via-fsc-design.md
+++ b/docs/plans/2026-08-17-notificatie-via-fsc-design.md
@@ -1,4 +1,4 @@
-**Status:** Concept
+**Status:** Uitgevoerd
 
 # Notificatie-events via FSC — ontwerp
 
@@ -172,6 +172,32 @@ grant-hash gaat door, intern adres zónder wordt geweigerd.
   ervan vereist echte ZAD-toegang en blijft — net als bij elk eerder peer-plan — handmatig
   vervolgwerk.
 - **`workspace.dsl`.** Regel 191 beschrijft dit pad al correct.
+
+## Wat de uitvoering opleverde
+
+Drie dingen kwamen pas boven water toen de keten écht draaide. Ze staan hier omdat ze het ontwerp
+raken, niet alleen de uitvoering.
+
+**De outway wil HTTP/1.1.** De JDK-`HttpClient` onderhandelt op een plain-http-doel eerst een
+upgrade naar h2c. De outway proxyt die hop-by-hop-headers ongewijzigd door naar de inway, waar het
+Go-http2-transport ze weigert; de outway antwoordt dan 502 en het magazijn blijft herproberen. Dat
+past bij het contract: elke dienstpublicatie draagt `PROTOCOL_TCP_HTTP_1.1`. De request naar een
+outway-downstream wordt daarom expliciet op HTTP/1.1 gepind — alleen dáár, zodat rechtstreekse
+downstreams h2 mogen blijven doen.
+
+**De contract-bootstrap was stuk op paginatie.** `fsc-contract.sh` brak af zodra de manager een
+`next_cursor` meestuurde, in de aanname dat een cursor betekent dat de lijst is afgekapt. OpenFSC
+v2.5.2 zet die cursor op élke pagina die rijen bevat; de volgende pagina komt leeg terug met een
+lege cursor. De bootstrap werkte daardoor alleen op een volstrekt lege manager en faalde elke run
+daarna — terwijl hij op ZAD juist in een lus draait. Opgelost door door te lezen tot de cursor leeg
+is. Dit is een defect van vóór dit werk (#782) dat hier alleen aan het licht kwam.
+
+**Grant-hash en URL horen samen.** Staat de hash wél en wijst de URL niet naar de outway, dan
+stuurt het magazijn FSC-headers naar een bestemming die er niets mee doet, en vervalt bovendien de
+SSRF-controle op die URL. De boot-waarschuwing maakt dat zichtbaar, maar hij verschijnt pas bij de
+eerste aflevering: `DownstreamClient` is `@ApplicationScoped` en dus lui geconstrueerd. Dat geldt
+net zo goed voor het al bestaande `DOWNSTREAM_URL_VALIDATIE_UIT`. Wie op deze tokens alert, moet
+dus weten dat ze aan verkeer hangen en niet aan de start van de pod.
 
 ## Openstaand
 

--- a/docs/plans/2026-08-17-notificatie-via-fsc-plan.md
+++ b/docs/plans/2026-08-17-notificatie-via-fsc-plan.md
@@ -422,7 +422,7 @@ En ná `%prod.magazijn.publicatie.downstreams.notificatie.url=${NOTIFICATIE_URL}
 
 - [ ] **Stap 2: Demo-stack koppelen**
 
-Voeg in `compose.podman-hostnet.yaml` bij de service `berichtenmagazijn` (vóór `environment:`) hetzelfde `env_file`-blok toe dat `berichtenuitvraag` al heeft:
+Voeg in `compose.podman-hostnet.yaml` bij de service `berichtenmagazijn-a` (vóór `environment:`) hetzelfde `env_file`-blok toe dat `berichtenuitvraag` al heeft:
 
 ```yaml
     # Het grant-hash komt uit de contract-bootstrap van de federatie
@@ -443,15 +443,30 @@ En vervang in datzelfde `environment:`-blok de regel `NOTIFICATIE_URL: http://12
       NOTIFICATIE_URL: ${NOTIFICATIE_URL:-http://127.0.0.1:18084/events}
 ```
 
-Laat `berichtenmagazijn-b` ongewijzigd: die peer doet niet mee aan de federatie en moet rechtstreeks blijven werken.
+Laat `berichtenmagazijn-b` ongewijzigd: dat magazijn doet niet mee aan de federatie en moet rechtstreeks blijven werken.
 
 - [ ] **Stap 3: Verifieer de compose-syntax**
 
+Niet met `python3 -c "import yaml..."`: compose' eigen tags (`!reset`, `!override`) laat de
+YAML-parser struikelen, ook op een ongewijzigd bestand. Laat compose zelf renderen — dat toetst
+meteen de interpolatie:
+
 ```bash
-python3 -c "import yaml; yaml.safe_load(open('compose.podman-hostnet.yaml'))" && echo "YAML OK"
+docker compose --profile demo -f compose.yaml -f compose.podman.yaml -f compose.podman-hostnet.yaml \
+  config --quiet && echo "COMPOSE OK"
 ```
 
-Expected: `YAML OK`.
+Expected: `COMPOSE OK`. Controleer daarna dat de default én de override kloppen:
+
+```bash
+docker compose --profile demo -f compose.yaml -f compose.podman.yaml -f compose.podman-hostnet.yaml config \
+  | grep -A2 'NOTIFICATIE_URL'
+NOTIFICATIE_URL=http://127.20.2.5:8443/events docker compose --profile demo \
+  -f compose.yaml -f compose.podman.yaml -f compose.podman-hostnet.yaml config | grep 'NOTIFICATIE_URL'
+```
+
+Expected: zonder override de toxiproxy-URL (`http://127.0.0.1:18084/events`), mét override het
+outway-adres.
 
 - [ ] **Stap 4: Commit**
 
@@ -593,13 +608,16 @@ Voeg in het `*hosts`-anker bovenaan datzelfde bestand de regel toe:
 
 - [ ] **Stap 6: Verifieer de compose-syntax van alle drie**
 
+De drie bestanden stapelen en compose laten renderen; een losse YAML-parser struikelt over
+`!reset`/`!override`. Draai vanuit de peer-map, want `${PKI_DIR}` komt uit de `.env` daar:
+
 ```bash
-for f in demo/environment/magazijn-a/deploy/local/docker-compose*.yaml; do
-  python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" "$f" && echo "OK $f"
-done
+(cd demo/environment/magazijn-a/deploy/local && \
+ docker compose -f docker-compose.yaml -f docker-compose.podman.yaml \
+                -f docker-compose.podman-hostnet.yaml config --quiet) && echo "COMPOSE OK"
 ```
 
-Expected: drie `OK`-regels.
+Expected: `COMPOSE OK`.
 
 - [ ] **Stap 7: Commit**
 
@@ -667,13 +685,17 @@ Op dit moment doen `logius` en `magazijn-a` mee. Beide dragen twee rollen: `logi
 
 - [ ] **Stap 3: Verifieer de compose-syntax**
 
+De federatie-overlay is geen zelfstandig bestand — hij hoort bovenop de drie peer-bestanden.
+Laat compose de hele stapel renderen:
+
 ```bash
-for f in demo/environment/federatie/compose/*.yaml; do
-  python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" "$f" && echo "OK $f"
-done
+(cd demo/environment/magazijn-a/deploy/local && \
+ docker compose -f docker-compose.yaml -f docker-compose.podman.yaml \
+                -f docker-compose.podman-hostnet.yaml \
+                -f ../../../federatie/compose/magazijn-a.yaml config --quiet) && echo "COMPOSE OK"
 ```
 
-Expected: twee `OK`-regels.
+Expected: `COMPOSE OK`.
 
 - [ ] **Stap 4: Commit**
 

--- a/docs/plans/2026-08-17-notificatie-via-fsc-plan.md
+++ b/docs/plans/2026-08-17-notificatie-via-fsc-plan.md
@@ -1,0 +1,1520 @@
+**Status:** Concept
+
+# Notificatie-events via FSC — implementatieplan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Het berichtenmagazijn levert zijn CloudEvents af door zijn eigen FSC-outway bij de inway van `logius`, in plaats van rechtstreeks bij de notificatie-stub.
+
+**Architecture:** `magazijn-a` wordt consumer/outway (nieuw component), `logius` biedt naast `profiel-service` ook `notificatieservice` aan op zijn bestaande inway met de WireMock notificatie-stub als upstream. Applicatiekant: `DownstreamClient` krijgt een optionele grant-hash per downstream en zet daarmee de twee FSC-outway-headers; een downstream mét grant-hash slaat de SSRF-blocklist over (de bestemming volgt dan uit het contract, niet uit onze URL).
+
+**Tech Stack:** Kotlin/Quarkus 3.x (Java 21), JUnit 5 + MockK, Bash + curl/jq/openssl, Docker Compose (OpenFSC v2.5.2), podman, WireMock, cfssl.
+
+**Spec:** `docs/plans/2026-08-17-notificatie-via-fsc-design.md`
+
+## Global Constraints
+
+- Issue: MinBZK/MijnOverheidZakelijk#784. Géén auto-close-keyword in de PR-body; het issue blijft open bij merge.
+- Nederlands in commits, comments en documentatie. Vaste technische idiomen blijven Engels: outway, inway, grant-hash, thumbprint, upstream, probe, backoff, retry, timeout.
+- Peers en OIN's: `logius` = `00000000000000001000` (provider), `magazijn-a` = `00000000000000100000` (consumer/pusher), directory = `00000000000000000010`, `GROUP_ID` = `moza-fbs-test`.
+- Dienstnaam letterlijk: `notificatieservice`.
+- Adresschema federatie: `magazijn-a` = `127.20.2.0/24`, octet `.5` = outway. De outway van `magazijn-a` wordt dus `127.20.2.5:8443` (monitoring `:8081`).
+- Kotlin-stijl: lege regel vóór én ná elk multi-line blok en elk zelfstandig control-statement (`if`, `when`, `for`, `try`). Zie CLAUDE.md voor de precieze regel.
+- `detekt` draait met `maxIssues: 0` zonder baseline. Bewuste uitzonderingen krijgen een inline `@Suppress` mét motivatie.
+- Comments leggen het *waarom* vast, nooit het *wat*. Geen verwijzingen naar review-labels, naar CLAUDE.md, of naar "PoC"/"voorlopig".
+- Altijd `clean` vóór `test`/`verify`: `./mvnw clean test -pl services/berichtenmagazijn -am`.
+- Nooit rechtstreeks naar `main` pushen. Branch: `feature/784-notificatie-via-fsc`.
+- Geen reviewer toevoegen aan de PR.
+
+---
+
+### Taak 1: Headerpaar als data in `FscOutwayHeaders`
+
+Het FSC-outway-headercontract zit nu vast aan JAX-RS (`ClientRequestContext`). `DownstreamClient` gebruikt `java.net.http.HttpClient` en kan er niet bij. Deze taak maakt het headerpaar transport-onafhankelijk, zonder het contract te dupliceren.
+
+**Files:**
+- Modify: `libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeaders.kt`
+- Test: `libraries/fbs-common/src/test/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeadersTest.kt`
+
+**Interfaces:**
+- Produces: `FscOutwayHeaders.headers(grantHash: String): Map<String, String>` — de twee headers voor één outway-call, met een verse UUID-v7 transaction-id. Taak 2 gebruikt dit.
+- `FscOutwayHeaders.zet(requestContext, grantHash)` behoudt exact zijn huidige signatuur en gedrag.
+
+- [ ] **Stap 1: Schrijf de falende test**
+
+Voeg toe aan `libraries/fbs-common/src/test/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeadersTest.kt` (bestaat al; voeg deze tests toe binnen de bestaande klasse):
+
+```kotlin
+    @Test
+    fun `headers levert de grant-hash ongewijzigd en een verse transaction-id`() {
+        val headers = FscOutwayHeaders.headers("\$1\$4\$k4rwlWTsCM_j89Fc3nrbnQa9-KB43")
+
+        assertEquals("\$1\$4\$k4rwlWTsCM_j89Fc3nrbnQa9-KB43", headers[FscOutwayHeaders.GRANT_HASH_HEADER])
+
+        val transactionId = UUID.fromString(headers.getValue(FscOutwayHeaders.TRANSACTION_ID_HEADER))
+
+        assertEquals(7, transactionId.version(), "de outway weigert een transaction-id die geen UUID v7 is")
+    }
+
+    @Test
+    fun `headers levert bij elke aanroep een andere transaction-id`() {
+        val eerste = FscOutwayHeaders.headers("hash")
+        val tweede = FscOutwayHeaders.headers("hash")
+
+        assertNotEquals(
+            eerste[FscOutwayHeaders.TRANSACTION_ID_HEADER],
+            tweede[FscOutwayHeaders.TRANSACTION_ID_HEADER],
+        )
+    }
+```
+
+Vul de imports aan met `org.junit.jupiter.api.Assertions.assertNotEquals` en `java.util.UUID` als die er nog niet staan.
+
+- [ ] **Stap 2: Draai de test en bevestig dat hij faalt**
+
+```bash
+./mvnw clean test -pl libraries/fbs-common -Dtest=FscOutwayHeadersTest
+```
+
+Expected: FAIL — `Unresolved reference: headers`.
+
+- [ ] **Stap 3: Implementeer**
+
+Vervang in `FscOutwayHeaders.kt` de functie `zet(...)` door onderstaande twee functies. Laat de constants en `log` ongewijzigd:
+
+```kotlin
+    /**
+     * Het headerpaar voor één outway-call. Losgetrokken van het transport omdat niet elke
+     * caller een JAX-RS-client is: de downstream-aflevering van CloudEvents gebruikt
+     * `java.net.http.HttpClient`, en zou het contract anders moeten dupliceren.
+     */
+    fun headers(grantHash: String): Map<String, String> = mapOf(
+        GRANT_HASH_HEADER to grantHash,
+        TRANSACTION_ID_HEADER to UuidV7.generate().toString(),
+    )
+
+    fun zet(requestContext: ClientRequestContext, grantHash: String) {
+        val paar = headers(grantHash)
+
+        paar.forEach { (naam, waarde) -> requestContext.headers.putSingle(naam, waarde) }
+
+        // Zonder deze transaction-id in de app-log is een call niet terug te vinden in de
+        // outway-/inway-logs, die 'm ongewijzigd doorgeven. Log alleen de host, nooit het
+        // volledige URI: sommige callers (Profiel-service) dragen een BSN in het pad, en
+        // deze regel logt bij DEBUG — dus een pad of query hier zou dat BSN naar de
+        // applicatielog schrijven. De host identificeert de outway afdoende.
+        log.debugf(
+            "FSC-outway-call naar %s: Fsc-Transaction-Id=%s",
+            requestContext.uri.host,
+            paar[TRANSACTION_ID_HEADER],
+        )
+    }
+```
+
+- [ ] **Stap 4: Draai de tests en bevestig dat ze slagen**
+
+```bash
+./mvnw clean test -pl libraries/fbs-common
+```
+
+Expected: `BUILD SUCCESS`, geen falende tests. Let op: bestaande `FscOutwayHeadersTest`-tests moeten óók nog groen zijn — `zet(...)` mag niet van gedrag veranderd zijn.
+
+- [ ] **Stap 5: detekt**
+
+```bash
+./mvnw detekt:check -pl libraries/fbs-common
+```
+
+Expected: `BUILD SUCCESS`.
+
+- [ ] **Stap 6: Commit**
+
+```bash
+git add libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeaders.kt \
+        libraries/fbs-common/src/test/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeadersTest.kt
+git commit -m "refactor(common): maak het FSC-outway-headerpaar transport-onafhankelijk"
+```
+
+---
+
+### Taak 2: Grant-hash per downstream in `DownstreamClient`
+
+**Files:**
+- Modify: `services/berichtenmagazijn/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/PublicatieConfig.kt`
+- Modify: `services/berichtenmagazijn/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/DownstreamClient.kt`
+- Test: `services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/DownstreamClientTest.kt`
+
+**Interfaces:**
+- Consumes: `FscOutwayHeaders.headers(grantHash)` uit Taak 1.
+- Produces: configsleutel `magazijn.publicatie.downstreams.<key>.grant-hash` (`Optional<String>`); constante `DownstreamClient.OUTWAY_SSRF_ALERT_TOKEN = "DOWNSTREAM_VIA_OUTWAY"`. Taak 3 zet de property, Taak 8 leunt op het gedrag.
+
+- [ ] **Stap 1: Breid de config-interface uit**
+
+Voeg in `PublicatieConfig.kt` binnen `interface Downstream`, ná `url()` en vóór `maxPogingen()`, toe:
+
+```kotlin
+        /**
+         * FSC-grant-hash voor een downstream die door de eigen outway loopt. Aanwezig ⇒ de call
+         * krijgt `Fsc-Grant-Hash` en `Fsc-Transaction-Id` mee, en de SSRF-blocklist geldt er niet:
+         * de outway kiest de bestemming op het contract achter deze hash, niet op onze URL.
+         * Afwezig of leeg ⇒ rechtstreeks verkeer, met alle URL-controles onverkort.
+         */
+        fun grantHash(): Optional<String>
+```
+
+Voeg bovenaan het bestand de import `java.util.Optional` toe.
+
+- [ ] **Stap 2: Schrijf de falende tests**
+
+`DownstreamStub` in `DownstreamClientTest.kt` implementeert `PublicatieConfig.Downstream` en moet de nieuwe methode dragen. Vervang de bestaande `DownstreamStub`-klasse door:
+
+```kotlin
+    private class DownstreamStub(
+        private val u: String,
+        private val hash: String? = null,
+    ) : PublicatieConfig.Downstream {
+        override fun url(): String = u
+        override fun grantHash(): java.util.Optional<String> = java.util.Optional.ofNullable(hash)
+        override fun maxPogingen(): Int = 5
+        override fun backoff(): PublicatieConfig.Backoff = object : PublicatieConfig.Backoff {
+            override fun basis(): java.time.Duration = java.time.Duration.ofSeconds(1)
+            override fun plafond(): java.time.Duration = java.time.Duration.ofHours(1)
+        }
+    }
+```
+
+Voeg daarna deze tests toe aan de klasse:
+
+```kotlin
+    @ParameterizedTest(name = "grant-hash \"{0}\" levert geen FSC-headers")
+    @NullSource
+    @ValueSource(strings = ["", "   "])
+    fun `zonder bruikbare grant-hash gaan er geen FSC-headers mee`(hash: String?) {
+        every { config.downstreams() } returns mapOf("aanmeld" to DownstreamStub(server.baseUrl, hash))
+
+        val resultaat = client.lever(Publicatiedoel("aanmeld"), event)
+
+        assertEquals(DownstreamResultaat.Geslaagd, resultaat)
+
+        val ontvangen = server.headers.single()
+
+        assertFalse(ontvangen.keys.any { it.equals(FscOutwayHeaders.GRANT_HASH_HEADER, ignoreCase = true) })
+        assertFalse(ontvangen.keys.any { it.equals(FscOutwayHeaders.TRANSACTION_ID_HEADER, ignoreCase = true) })
+    }
+
+    @Test
+    fun `met grant-hash gaan beide FSC-outway-headers mee`() {
+        val hash = "\$1\$4\$k4rwlWTsCM_j89Fc3nrbnQa9-KB43"
+
+        every { config.downstreams() } returns mapOf("aanmeld" to DownstreamStub(server.baseUrl, hash))
+
+        val resultaat = client.lever(Publicatiedoel("aanmeld"), event)
+
+        assertEquals(DownstreamResultaat.Geslaagd, resultaat)
+
+        // HttpExchange normaliseert headernamen naar Capitalized-Case; zoek daarom
+        // hoofdletter-ongevoelig op in plaats van op de exacte sleutel.
+        val ontvangen = server.headers.single().mapKeys { (naam, _) -> naam.lowercase() }
+
+        assertEquals(hash, ontvangen.getValue(FscOutwayHeaders.GRANT_HASH_HEADER.lowercase()).single())
+
+        val transactionId = UUID.fromString(
+            ontvangen.getValue(FscOutwayHeaders.TRANSACTION_ID_HEADER.lowercase()).single(),
+        )
+
+        assertEquals(7, transactionId.version())
+    }
+
+    @Test
+    fun `grant-hash met omringende whitespace gaat getrimd de header in`() {
+        every { config.downstreams() } returns mapOf("aanmeld" to DownstreamStub(server.baseUrl, "  hash-met-ruimte  "))
+
+        client.lever(Publicatiedoel("aanmeld"), event)
+
+        val ontvangen = server.headers.single().mapKeys { (naam, _) -> naam.lowercase() }
+
+        assertEquals("hash-met-ruimte", ontvangen.getValue(FscOutwayHeaders.GRANT_HASH_HEADER.lowercase()).single())
+    }
+
+    @Test
+    fun `een intern adres wordt geweigerd zonder grant-hash`() {
+        every { config.downstreams() } returns mapOf("aanmeld" to DownstreamStub("http://10.0.0.1:8443/events"))
+
+        val resultaat = client.lever(Publicatiedoel("aanmeld"), event)
+
+        assertTrue(
+            resultaat is DownstreamResultaat.ConfiguratieFout,
+            "een RFC1918-adres zonder grant-hash hoort op de TLS-eis of de SSRF-blocklist te stranden",
+        )
+    }
+
+    @Test
+    fun `een intern https-adres mag wel met grant-hash - de outway bepaalt de bestemming`() {
+        // De outway van de federatie luistert op een adres dat naar RFC1918 resolveert; de
+        // SSRF-blocklist zou dat pad blokkeren terwijl het contract de bestemming al vastlegt.
+        // Geen echte call: de host bestaat niet, dus een NetwerkFout bewíjst dat de
+        // URL-validatie 'm heeft doorgelaten. Een ConfiguratieFout zou betekenen dat hij is
+        // afgekeurd vóór het netwerk.
+        every { config.downstreams() } returns
+            mapOf("aanmeld" to DownstreamStub("https://10.255.255.1:8443/events", "hash"))
+
+        val resultaat = client.lever(Publicatiedoel("aanmeld"), event)
+
+        assertFalse(
+            resultaat is DownstreamResultaat.ConfiguratieFout,
+            "met een grant-hash hoort de SSRF-blocklist niet te gelden; kreeg: $resultaat",
+        )
+    }
+```
+
+Vul de imports aan: `nl.rijksoverheid.moz.fbs.common.fsc.FscOutwayHeaders`, `org.junit.jupiter.params.ParameterizedTest`, `org.junit.jupiter.params.provider.NullSource`, `org.junit.jupiter.params.provider.ValueSource`.
+
+Let op de test-timeout van de laatste test: `10.255.255.1` is niet-routeerbaar, dus de connect-timeout van 5s uit `start()` bepaalt de duur.
+
+- [ ] **Stap 3: Draai de tests en bevestig dat ze falen**
+
+```bash
+./mvnw clean test -pl services/berichtenmagazijn -am -Dtest=DownstreamClientTest
+```
+
+Expected: FAIL — de headers ontbreken en de laatste test krijgt een `ConfiguratieFout`.
+
+- [ ] **Stap 4: Implementeer in `DownstreamClient`**
+
+Vervang in `lever(...)` het blok vanaf `val url = downstream.url()` tot en met de `requestBuilder`-opbouw door:
+
+```kotlin
+        val url = downstream.url()
+        val grantHash = bruikbareGrantHash(downstream)
+        val urlValidatie = valideerUrl(url, viaOutway = grantHash != null)
+        if (urlValidatie != null) return urlValidatie
+
+        val payload = try {
+            objectMapper.writeValueAsBytes(event)
+        } catch (ex: JsonProcessingException) {
+            log.errorf(ex, "Serialisatie van CloudEvent mislukt: doel=%s eventType=%s", doel, event.type)
+            return DownstreamResultaat.SerialisatieFout(
+                "Serialisatie mislukt voor doel=$doel: ${ex.javaClass.simpleName}",
+            )
+        }
+
+        val requestBuilder = HttpRequest.newBuilder()
+            .uri(URI.create(url))
+            .timeout(config.client().requestTimeout())
+            .header("Content-Type", "application/cloudevents+json")
+            .POST(BodyPublishers.ofByteArray(payload))
+
+        if (grantHash != null) {
+            FscOutwayHeaders.headers(grantHash).forEach { (naam, waarde) -> requestBuilder.header(naam, waarde) }
+        }
+```
+
+Voeg de private helper toe, direct ná `lever(...)`:
+
+```kotlin
+    /**
+     * De grant-hash van een downstream, of `null` als er geen bruikbare staat. Trimmen omdat een
+     * hash die via een env-var uit een gegenereerd bestand komt makkelijk een spatie of newline
+     * meekrijgt, en de outway daar `400 UNKNOWN_GRANT_HASH_IN_HEADER` op geeft.
+     */
+    private fun bruikbareGrantHash(downstream: PublicatieConfig.Downstream): String? =
+        downstream.grantHash().orElse(null)?.trim()?.takeIf { it.isNotEmpty() }
+```
+
+Pas de signatuur van `valideerUrl` aan naar `private fun valideerUrl(url: String, viaOutway: Boolean): DownstreamResultaat.ConfiguratieFout?` en vervang het SSRF-blok aan het einde door:
+
+```kotlin
+        // SSRF-blocklist ([blokkeerIntern]): zonder dit kan een operator met config-toegang de
+        // magazijn-pod als proxy naar interne services gebruiken. Loopback is hierboven al
+        // toegestaan voor dev-stubs (WireMock/embedded HTTP). Een downstream met een grant-hash
+        // valt erbuiten: die gaat door de eigen, co-located outway, en dáár bepaalt het
+        // FSC-contract achter de hash de bestemming — een URL naar een ander intern adres levert
+        // dan geen verkeer maar een fout. De bypass is bij boot zichtbaar gemaakt.
+        if (!isLoopback && !viaOutway) {
+            val ssrfFout = blokkeerIntern(host)
+            if (ssrfFout != null) return ssrfFout
+        }
+        return null
+```
+
+Voeg in het `init`-blok, ná de bestaande `PROFIELEN_ZONDER_TLS_EIS`-waarschuwing, toe:
+
+```kotlin
+        val viaOutway = config.downstreams()
+            .filterValues { bruikbareGrantHash(it) != null }
+            .keys
+
+        if (viaOutway.isNotEmpty()) {
+            // Een SSRF-uitzondering hoort niet stil te zijn: zonder deze regel is aan een
+            // draaiende pod niet te zien welke downstreams buiten de blocklist vallen.
+            log.warnf(
+                "%s: downstream(s) %s lopen door de eigen FSC-outway; de SSRF-blocklist geldt daar niet.",
+                OUTWAY_SSRF_ALERT_TOKEN,
+                viaOutway.joinToString(", "),
+            )
+        }
+```
+
+Voeg in het `companion object` toe, naast `VALIDATIE_UIT_ALERT_TOKEN`:
+
+```kotlin
+        /** Alert-token voor de SSRF-uitzondering op outway-downstreams; routeerbaar in log-alerting. */
+        const val OUTWAY_SSRF_ALERT_TOKEN = "DOWNSTREAM_VIA_OUTWAY"
+```
+
+Voeg de import `nl.rijksoverheid.moz.fbs.common.fsc.FscOutwayHeaders` toe.
+
+- [ ] **Stap 5: Draai de tests en bevestig dat ze slagen**
+
+```bash
+./mvnw clean test -pl services/berichtenmagazijn -am -Dtest='DownstreamClientTest,PublicatieConfigValidationTest,PublicatieStreamE2ETest'
+```
+
+Expected: `BUILD SUCCESS`. Faalt `PublicatieConfigValidationTest` op een ontbrekende `grantHash`-implementatie in een andere stub, voeg daar dezelfde `override fun grantHash(): Optional<String> = Optional.empty()` toe.
+
+- [ ] **Stap 6: Volledige suite + detekt**
+
+```bash
+./mvnw clean verify -pl services/berichtenmagazijn -am
+./mvnw detekt:check -pl services/berichtenmagazijn
+```
+
+Expected: `BUILD SUCCESS`, JaCoCo-gate ≥90% gehaald, geen nieuwe waarschuwingen in de output behalve de drie bekend-geaccepteerde (jansi, guava/Unsafe, LogManager).
+
+- [ ] **Stap 7: Commit**
+
+```bash
+git add services/berichtenmagazijn/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/PublicatieConfig.kt \
+        services/berichtenmagazijn/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/DownstreamClient.kt \
+        services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/
+git commit -m "feat(magazijn): lever CloudEvents af door de eigen FSC-outway"
+```
+
+---
+
+### Taak 3: Configuratie en demo-stack
+
+**Files:**
+- Modify: `services/berichtenmagazijn/src/main/resources/application.properties:198-205`
+- Modify: `compose.podman-hostnet.yaml`
+
+**Interfaces:**
+- Consumes: de configsleutel uit Taak 2.
+- Produces: env-var `NOTIFICATIE_GRANT_HASH` (gevuld door Taak 7) en een overrulebare `NOTIFICATIE_URL` op het magazijn.
+
+- [ ] **Stap 1: Property toevoegen**
+
+Voeg in `application.properties` direct ná de regel `%dev.magazijn.publicatie.downstreams.notificatie.url=...` toe:
+
+```properties
+# Grant-hash voor de notificatie-downstream. Gevuld ⇒ de aflevering loopt door de eigen
+# FSC-outway (headers + SSRF-uitzondering, zie DownstreamClient); leeg ⇒ rechtstreeks. Lokaal
+# komt de waarde uit demo/generated/fsc-grants.env, dat de contract-bootstrap van de federatie
+# schrijft; ontbreekt dat bestand, dan blijft de waarde leeg en verandert er niets.
+%dev.magazijn.publicatie.downstreams.notificatie.grant-hash=${NOTIFICATIE_GRANT_HASH:}
+```
+
+En ná `%prod.magazijn.publicatie.downstreams.notificatie.url=${NOTIFICATIE_URL}`:
+
+```properties
+%prod.magazijn.publicatie.downstreams.notificatie.grant-hash=${NOTIFICATIE_GRANT_HASH:}
+```
+
+- [ ] **Stap 2: Demo-stack koppelen**
+
+Voeg in `compose.podman-hostnet.yaml` bij de service `berichtenmagazijn` (vóór `environment:`) hetzelfde `env_file`-blok toe dat `berichtenuitvraag` al heeft:
+
+```yaml
+    # Het grant-hash komt uit de contract-bootstrap van de federatie
+    # (demo/environment/federatie/contracts/fbs-contracten.sh). Ontbreekt het bestand — geen
+    # federatie op deze machine — dan start de stack gewoon zonder, en levert het magazijn zijn
+    # events rechtstreeks af.
+    env_file:
+      - path: demo/generated/fsc-grants.env
+        required: false
+```
+
+En vervang in datzelfde `environment:`-blok de regel `NOTIFICATIE_URL: http://127.0.0.1:18084/events` door:
+
+```yaml
+      # Default: rechtstreeks via toxiproxy, zodat de storing-knop van de demo werkt. Zet
+      # NOTIFICATIE_URL op de outway van magazijn-a (http://127.20.2.5:8443/events) om deze push
+      # via de FSC-keten te laten lopen; het grant-hash komt dan uit env_file hierboven.
+      NOTIFICATIE_URL: ${NOTIFICATIE_URL:-http://127.0.0.1:18084/events}
+```
+
+Laat `berichtenmagazijn-b` ongewijzigd: die peer doet niet mee aan de federatie en moet rechtstreeks blijven werken.
+
+- [ ] **Stap 3: Verifieer de compose-syntax**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('compose.podman-hostnet.yaml'))" && echo "YAML OK"
+```
+
+Expected: `YAML OK`.
+
+- [ ] **Stap 4: Commit**
+
+```bash
+git add services/berichtenmagazijn/src/main/resources/application.properties compose.podman-hostnet.yaml
+git commit -m "feat(magazijn): maak de notificatie-downstream via de outway configureerbaar"
+```
+
+---
+
+### Taak 4: Outway-component bij `magazijn-a`
+
+**Files:**
+- Create: `demo/environment/magazijn-a/pki/peers/magazijn-a/outway/csr.json`
+- Modify: `demo/environment/magazijn-a/deploy/local/docker-compose.yaml`
+- Modify: `demo/environment/magazijn-a/deploy/local/docker-compose.podman.yaml`
+- Modify: `demo/environment/magazijn-a/deploy/local/docker-compose.podman-hostnet.yaml`
+
+**Interfaces:**
+- Produces: de container `outway-magazijn-a` en het group-cert `pki/out/magazijn-a/outway/cert.pem` — Taak 5 (federatie-adres) en Taak 7 (thumbprint voor het contract) leunen hierop.
+
+- [ ] **Stap 1: PKI-definitie**
+
+Maak `demo/environment/magazijn-a/pki/peers/magazijn-a/outway/csr.json`:
+
+```json
+{
+  "CN": "outway.magazijn-a.fsc-test.local",
+  "key": {
+    "algo": "rsa",
+    "size": 4096
+  },
+  "hosts": [
+    "outway.magazijn-a.fsc-test.local",
+    "magazijna-fscoutway-fsc-magazijna-mpfm-w3h.rig.prd1.gn2.quattro.rijksapps.nl",
+    "fsc-magazijna-magazijna-fscoutway",
+    "fsc-magazijna-magazijna-fscoutway.rig-prd-mpfm-w3h.svc.cluster.local"
+  ],
+  "serialnumber": "00000000000000100000",
+  "names": [
+    {
+      "O": "magazijn-a",
+      "C": "NL"
+    }
+  ]
+}
+```
+
+- [ ] **Stap 2: Certificaten uitgeven en controleren**
+
+```bash
+(cd demo/environment/magazijn-a/pki && ./issue.sh && ./verify.sh)
+ls demo/environment/magazijn-a/pki/out/magazijn-a/outway/ demo/environment/magazijn-a/pki/internal/magazijn-a/outway/
+```
+
+Expected: beide mappen bevatten `cert.pem` en `key.pem`. `verify.sh` eindigt zonder fout.
+
+- [ ] **Stap 3: Outway-service in de basis-compose**
+
+Voeg in `demo/environment/magazijn-a/deploy/local/docker-compose.yaml` direct vóór `inway-magazijn-a:` (regel 190) toe:
+
+```yaml
+  outway-magazijn-a:
+    image: docker.io/federatedserviceconnectivity/outway:${IMAGE_TAG:-v2.5.2}
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"   # host-UID -> leest 0600-keys
+    restart: on-failure                            # boot-race met de eigen manager
+    command:
+      - /usr/local/bin/outway
+      - serve
+    environment:
+      LOG_TYPE: local
+      LOG_LEVEL: debug
+      GROUP_ID: moza-fbs-test
+      NAME: magazijn-a-outway
+      SELF_ADDRESS: https://outway.magazijn-a.fsc-test.local:443
+      LISTEN_ADDRESS: 0.0.0.0:8443
+      MONITORING_ADDRESS: 0.0.0.0:8081
+      DISABLE_CRL_CHECKS: "true"
+      # De outway registreert zich bij de controller en praat met de manager op de authenticated
+      # interne poort (:9443). fsc-outway serve eist beide.
+      MANAGER_INTERNAL_ADDRESS: https://manager.magazijn-a.fsc-test.local:9443
+      CONTROLLER_REGISTRATION_API_ADDRESS: https://controller.magazijn-a.fsc-test.local:9443
+      # Echte txlog-api (INTERNAL-PKI mTLS): bij egress logt de outway de transactie (direction: out).
+      TX_LOG_API_ADDRESS: https://txlog.magazijn-a.fsc-test.local:9443
+      TLS_ROOT_CERT: /pki/internal/magazijn-a/ca/root.pem
+      TLS_CERT: /pki/internal/magazijn-a/outway/cert.pem
+      TLS_KEY: /pki/internal/magazijn-a/outway/key.pem
+      TLS_GROUP_ROOT_CERT: /pki/ca/root.pem
+      TLS_GROUP_CERT: /pki/out/magazijn-a/outway/cert.pem
+      TLS_GROUP_KEY: /pki/out/magazijn-a/outway/key.pem
+    volumes:
+      - "${PKI_DIR:?zet PKI_DIR in .env}:/pki:ro"
+    networks:
+      default:
+        # Alias = de internal-cert-hostnaam; géén :443-router-route (de outway is client, geen ingress).
+        aliases:
+          - outway.magazijn-a.fsc-test.local
+    depends_on:
+      manager-magazijn-a:
+        condition: service_started
+      controller-magazijn-a:
+        condition: service_started
+      txlog-magazijn-a:
+        condition: service_started
+```
+
+- [ ] **Stap 4: Podman-overlay**
+
+Voeg in `demo/environment/magazijn-a/deploy/local/docker-compose.podman.yaml` vóór `inway-magazijn-a:` toe:
+
+```yaml
+  outway-magazijn-a:
+    userns_mode: "keep-id"
+```
+
+- [ ] **Stap 5: Hostnet-overlay**
+
+Voeg in `demo/environment/magazijn-a/deploy/local/docker-compose.podman-hostnet.yaml` vóór `inway-magazijn-a:` (regel 120) toe:
+
+```yaml
+  outway-magazijn-a:
+    network_mode: host
+    networks: !reset null
+    extra_hosts: *hosts
+    restart: on-failure:600
+    environment:
+      # MANAGER_INTERNAL_ADDRESS blijft naar 9443 wijzen — die poort verhuist niet.
+      LISTEN_ADDRESS: 127.0.0.1:58443
+      MONITORING_ADDRESS: 127.0.0.1:58081
+      CONTROLLER_REGISTRATION_API_ADDRESS: https://controller.magazijn-a.fsc-test.local:39443
+      TX_LOG_API_ADDRESS: https://txlog.magazijn-a.fsc-test.local:49443
+```
+
+Voeg in het `*hosts`-anker bovenaan datzelfde bestand de regel toe:
+
+```yaml
+  - "outway.magazijn-a.fsc-test.local:127.0.0.1"
+```
+
+- [ ] **Stap 6: Verifieer de compose-syntax van alle drie**
+
+```bash
+for f in demo/environment/magazijn-a/deploy/local/docker-compose*.yaml; do
+  python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" "$f" && echo "OK $f"
+done
+```
+
+Expected: drie `OK`-regels.
+
+- [ ] **Stap 7: Commit**
+
+```bash
+git add demo/environment/magazijn-a/pki/peers/magazijn-a/outway/csr.json \
+        demo/environment/magazijn-a/deploy/local/docker-compose.yaml \
+        demo/environment/magazijn-a/deploy/local/docker-compose.podman.yaml \
+        demo/environment/magazijn-a/deploy/local/docker-compose.podman-hostnet.yaml
+git commit -m "feat(demo): geef magazijn-a een outway, zodat het uitgaand door FSC kan"
+```
+
+Let op: `pki/out/` en `pki/internal/` staan in `.gitignore` (sleutelmateriaal). Controleer met `git status --short demo/environment/magazijn-a/pki/` dat er géén `.pem`-bestanden gestaged staan; alleen de `csr.json` hoort erin.
+
+---
+
+### Taak 5: Outway in de federatie-overlay
+
+**Files:**
+- Modify: `demo/environment/federatie/compose/magazijn-a.yaml`
+- Modify: `demo/environment/federatie/compose/logius.yaml`
+- Modify: `demo/environment/federatie/README.md`
+
+**Interfaces:**
+- Consumes: `outway-magazijn-a` uit Taak 4.
+- Produces: de outway op `127.20.2.5:8443`, bereikbaar voor het magazijn uit de demo-stack.
+
+- [ ] **Stap 1: Adres in de federatie-overlay**
+
+Voeg in `demo/environment/federatie/compose/magazijn-a.yaml` in het `x-hosts-federatie`-anker de regel toe, ná `"txlog.magazijn-a.fsc-test.local:127.20.2.3"`:
+
+```yaml
+  - "outway.magazijn-a.fsc-test.local:127.20.2.5"
+```
+
+Voeg dezelfde regel toe in het `x-hosts-federatie`-anker van `demo/environment/federatie/compose/logius.yaml` — beide stacks delen één netns en moeten dezelfde namen kennen.
+
+Voeg in `magazijn-a.yaml` ná het `inway-magazijn-a`-blok toe:
+
+```yaml
+  outway-magazijn-a:
+    extra_hosts: *hosts-federatie
+    environment:
+      LISTEN_ADDRESS: 127.20.2.5:8443
+      MONITORING_ADDRESS: 127.20.2.5:8081
+      CONTROLLER_REGISTRATION_API_ADDRESS: https://controller.magazijn-a.fsc-test.local:9443
+      MANAGER_INTERNAL_ADDRESS: https://manager.magazijn-a.fsc-test.local:9443
+      TX_LOG_API_ADDRESS: https://txlog.magazijn-a.fsc-test.local:9443
+```
+
+- [ ] **Stap 2: README bijwerken**
+
+In `demo/environment/federatie/README.md` staat onder "Adresschema" al een rij `.5 | outway`. Voeg onder de peer-tabel géén nieuwe rij toe (die klopt al), maar vervang in de inleiding de zin:
+
+```
+Op dit moment doen `logius` (uitvraag-consumer) en `magazijn-a` (provider) mee.
+```
+
+door:
+
+```
+Op dit moment doen `logius` en `magazijn-a` mee. Beide dragen twee rollen: `logius` biedt
+`profiel-service` en `notificatieservice` aan en neemt `berichtenmagazijn` af, `magazijn-a` biedt
+`berichtenmagazijn` aan en pusht notificatie-events door zijn eigen outway.
+```
+
+- [ ] **Stap 3: Verifieer de compose-syntax**
+
+```bash
+for f in demo/environment/federatie/compose/*.yaml; do
+  python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" "$f" && echo "OK $f"
+done
+```
+
+Expected: twee `OK`-regels.
+
+- [ ] **Stap 4: Commit**
+
+```bash
+git add demo/environment/federatie/compose/magazijn-a.yaml \
+        demo/environment/federatie/compose/logius.yaml \
+        demo/environment/federatie/README.md
+git commit -m "feat(demo): geef de outway van magazijn-a zijn eigen federatie-adres"
+```
+
+---
+
+### Taak 6: Meerdere diensten op één inway
+
+**Files:**
+- Modify: `demo/environment/logius/deploy/local/publish-service.sh`
+- Modify: `demo/environment/magazijn-a/deploy/local/publish-service.sh`
+- Modify: `demo/environment/lib/fsc-harness.sh:136-141`
+
+**Interfaces:**
+- Produces: `FSC_SERVICE_NAME` als override op beide `publish-service.sh`-scripts, en `fsc_zet_upstream <envdir> <peer> <upstream> [dienst]`. Taak 8 gebruikt het vierde argument.
+
+- [ ] **Stap 1: Dienstnaam overrulebaar maken**
+
+Vervang in `demo/environment/logius/deploy/local/publish-service.sh` de regel `SERVICE_NAME="profiel-service"` door:
+
+```bash
+# Overrulebaar omdat één inway meer dan één dienst kan dragen: logius biedt naast profiel-service
+# ook notificatieservice aan. Dezelfde variabelenaam als smoke-discover.sh gebruikt.
+SERVICE_NAME="${FSC_SERVICE_NAME:-profiel-service}"
+```
+
+Vervang in `demo/environment/magazijn-a/deploy/local/publish-service.sh` de regel `SERVICE_NAME="berichtenmagazijn"` door:
+
+```bash
+# Overrulebaar, symmetrisch met de andere peers: één inway kan meer dan één dienst dragen.
+SERVICE_NAME="${FSC_SERVICE_NAME:-berichtenmagazijn}"
+```
+
+- [ ] **Stap 2: `fsc_zet_upstream` een dienst-argument geven**
+
+Vervang in `demo/environment/lib/fsc-harness.sh` de functie `fsc_zet_upstream` door:
+
+```bash
+# fsc_zet_upstream <envdir> <peer> <upstream-url> [dienst]
+#
+# Publiceert (idempotent) een dienst van <peer> met <upstream-url> als endpoint. Zonder <dienst>
+# publiceert de peer zijn eigen standaarddienst — de default in zijn publish-service.sh.
+fsc_zet_upstream() {
+  local envdir="$1" peer="$2" upstream="$3" dienst="${4:-}"
+
+  (
+    export FSC_CONTROLLER="https://controller.${peer}.fsc-test.local:9444"
+    export FSC_MANAGER="https://manager.${peer}.fsc-test.local:9443"
+    export FSC_UPSTREAM_URL="$upstream"
+
+    if [ -n "$dienst" ]; then
+      export FSC_SERVICE_NAME="$dienst"
+    fi
+
+    "${envdir}/${peer}/deploy/local/publish-service.sh"
+  )
+}
+```
+
+- [ ] **Stap 3: Shellcheck**
+
+```bash
+shellcheck demo/environment/lib/fsc-harness.sh \
+           demo/environment/logius/deploy/local/publish-service.sh \
+           demo/environment/magazijn-a/deploy/local/publish-service.sh
+```
+
+Expected: geen output (geen bevindingen). Is `shellcheck` niet geïnstalleerd, sla deze stap over en noteer dat in de PR-body.
+
+- [ ] **Stap 4: Bewijs dat de bestaande aanroepen niet wijzigen**
+
+```bash
+grep -rn "fsc_zet_upstream" demo/environment/
+```
+
+Expected: de aanroepen in `smoke-keten.sh` en `smoke-contract.sh` geven drie argumenten en blijven dus op de peer-default staan. Verander ze niet.
+
+- [ ] **Stap 5: Commit**
+
+```bash
+git add demo/environment/lib/fsc-harness.sh \
+        demo/environment/logius/deploy/local/publish-service.sh \
+        demo/environment/magazijn-a/deploy/local/publish-service.sh
+git commit -m "feat(demo): laat één inway meerdere diensten publiceren"
+```
+
+---
+
+### Taak 7: Contract `magazijn-a → logius` voor `notificatieservice`
+
+**Files:**
+- Modify: `demo/environment/federatie/peers.env`
+- Modify: `demo/environment/federatie/contracts/fbs-contracten.sh`
+
+**Interfaces:**
+- Consumes: de outway-thumbprint uit Taak 4, `bootstrap.sh` (ongewijzigd).
+- Produces: een regel `NOTIFICATIE_GRANT_HASH=<hash>` in `demo/generated/fsc-grants.env`, gelezen door Taak 3.
+
+- [ ] **Stap 1: Rollen in `peers.env`**
+
+Voeg onderaan `demo/environment/federatie/peers.env`, ná het blok met `UITVRAAG`/`MAGAZIJNEN`/`MAGAZIJN_DIENST`, toe:
+
+```bash
+# Wie de notificatiedienst aanbiedt en wie erop pusht. Andersom dan de magazijn-rollen hierboven:
+# het magazijn is hier de áfnemer — het duwt CloudEvents door zijn eigen outway naar de inway van
+# de aanbieder. Een tweede pusher toevoegen is één naam erbij.
+NOTIFICATIE=logius
+PUSHERS="magazijn-a"
+NOTIFICATIE_DIENST=notificatieservice
+```
+
+- [ ] **Stap 2: Het contract-per-combinatie-blok uitfactoren**
+
+Vervang in `demo/environment/federatie/contracts/fbs-contracten.sh` alles vanaf `CONS_NET="$(fsc_peer_waarde NET "$UITVRAAG")"` tot en met de afsluitende `done` van de magazijn-lus, door:
+
+```bash
+FOUTEN=0
+GEDAAN=0
+
+# De demo-stack moet het grant-hash kennen om `Fsc-Grant-Hash` te kunnen zetten, en compose kan dat
+# niet uit een draaiende manager halen. Vandaar een gegenereerd env-bestand dat de apps inlezen.
+# Naar `.tmp` en pas aan het eind verplaatsen: een half geschreven bestand zou een app met een
+# grant-hash voor de ene bestemming en niets voor de andere laten starten.
+GRANTS="$(cd "${ENVDIR}/.." && pwd)/generated/fsc-grants.env"
+mkdir -p "$(dirname "$GRANTS")"
+: > "$GRANTS.tmp"
+# Eén trap voor beide tijdelijke bestanden: fsc_errlog_init zette er al een op $ERRLOG, en een
+# tweede `trap ... EXIT` vervangt die in plaats van hem aan te vullen.
+trap 'rm -f "$GRANTS.tmp" "$ERRLOG"' EXIT
+
+# grant_regel_voor <consumer-peer> <consumer-oin> <thumbprint> <provider-oin> <dienst> <env-naam>:
+# één `<ENV-NAAM>=<hash>`-regel op stdout.
+#
+# Het grant-hash is NIET het contract-hash: de outway routeert op de grant uit `content.grants[]`,
+# en wie het contract-hash op de header zet krijgt structureel 400 UNKNOWN_GRANT_HASH_IN_HEADER.
+#
+# De contracten komen van de manager van de CONSUMER: dat is de kant waar de outway zijn grant
+# vandaan haalt. Bij de provider staat hetzelfde contract, maar de consumer praat daar niet mee.
+grant_regel_voor() {
+  local consumer="$1" cons_oin="$2" thumb="$3" prov_oin="$4" dienst="$5" envnaam="$6"
+  local json contract grant cons_net
+
+  cons_net="$(fsc_peer_waarde NET "$consumer")"
+  json="$(fsc_manager_contracts "$ENVDIR" "$consumer" "$(fsc_component_adres "$cons_net" manager)")" || return 1
+  contract="$(fsc_grant_actief "$json" "$dienst" "$prov_oin" "$cons_oin" "$thumb" | sort | head -n1)"
+  [ -n "$contract" ] || return 1
+
+  grant="$(fsc_grant_hash "$json" "$contract" "$dienst" "$thumb")"
+  fsc_grant_bruikbaar "$grant" || return 1
+
+  # Escapen voor compose: een kale `$` in dit bestand wordt als variabele-verwijzing gelezen en
+  # vreet de rest van het hash op. Zie fsc_compose_env_waarde.
+  printf '%s=%s\n' "$envnaam" "$(fsc_compose_env_waarde "$grant")"
+}
+
+# contract_op <consumer-peer> <provider-peer> <dienst> <env-naam>: zet het contract op en schrijft
+# het grant-hash weg. Werkt in beide richtingen — welke peer consumer is, staat in peers.env.
+contract_op() {
+  local consumer="$1" provider="$2" dienst="$3" envnaam="$4"
+  local cons_net cons_oin prov_net prov_oin cons_thumb
+
+  cons_net="$(fsc_peer_waarde NET "$consumer")"
+  cons_oin="$(fsc_peer_waarde OIN "$consumer")"
+  prov_net="$(fsc_peer_waarde NET "$provider")"
+  prov_oin="$(fsc_peer_waarde OIN "$provider")"
+
+  if [ -z "$cons_net" ] || [ -z "$cons_oin" ] || [ -z "$prov_net" ] || [ -z "$prov_oin" ]; then
+    echo "FAIL: NET_/OIN_ ontbreekt voor '${consumer}' of '${provider}' in peers.env." >&2
+    return 1
+  fi
+
+  if [ "$prov_oin" = "$cons_oin" ]; then
+    # Een zelfreferentieel contract is geldig FSC, maar hier zou het betekenen dat aanbieder en
+    # afnemer dezelfde identiteit dragen — dan klopt peers.env niet.
+    echo "FAIL: '${consumer}' en '${provider}' hebben dezelfde OIN (${prov_oin})." >&2
+    return 1
+  fi
+
+  cons_thumb="$(fsc_outway_thumbprint "${ENVDIR}/${consumer}/pki/out/${consumer}/outway/cert.pem")" || {
+    echo "FAIL: kon de outway-thumbprint van '${consumer}' niet berekenen: $(fsc_last_error)" >&2
+    return 1
+  }
+
+  echo "== contract ${consumer} -> ${provider} (${dienst}) =="
+
+  # De interne manager-API zit op het manager-adres van de peer, op de standaardpoort 9443. De
+  # octet-toewijzing staat in federatie/README.md en geldt voor elke peer gelijk.
+  FSC_CONSUMER_OIN="$cons_oin" \
+  FSC_PROVIDER_OIN="$prov_oin" \
+  FSC_SERVICE_NAME="$dienst" \
+  FSC_OUTWAY_CERT="${ENVDIR}/${consumer}/pki/out/${consumer}/outway/cert.pem" \
+  FSC_CONSUMER_MANAGER="https://manager.${consumer}.fsc-test.local:9443" \
+  FSC_CONSUMER_ADRES="$(fsc_component_adres "$cons_net" manager)" \
+  FSC_CONSUMER_CERT="${ENVDIR}/${consumer}/pki/internal/${consumer}/manager/cert.pem" \
+  FSC_CONSUMER_KEY="${ENVDIR}/${consumer}/pki/internal/${consumer}/manager/key.pem" \
+  FSC_CONSUMER_CA="${ENVDIR}/${consumer}/pki/internal/${consumer}/ca/root.pem" \
+  FSC_PROVIDER_MANAGER="https://manager.${provider}.fsc-test.local:9443" \
+  FSC_PROVIDER_ADRES="$(fsc_component_adres "$prov_net" manager)" \
+  FSC_PROVIDER_CERT="${ENVDIR}/${provider}/pki/internal/${provider}/manager/cert.pem" \
+  FSC_PROVIDER_KEY="${ENVDIR}/${provider}/pki/internal/${provider}/manager/key.pem" \
+  FSC_PROVIDER_CA="${ENVDIR}/${provider}/pki/internal/${provider}/ca/root.pem" \
+    "${HERE}/bootstrap.sh" || {
+      echo "FAIL: contract ${consumer} -> ${provider} niet opgezet." >&2
+      return 1
+    }
+
+  grant_regel_voor "$consumer" "$cons_oin" "$cons_thumb" "$prov_oin" "$dienst" "$envnaam" >> "$GRANTS.tmp" || {
+    echo "FAIL: contract staat, maar het grant-hash van ${provider} (${dienst}) is niet af te leiden." >&2
+    return 1
+  }
+}
+
+# Ophalen: de uitvraag-outway mag `berichtenmagazijn` afnemen bij elk magazijn.
+#
+# De env-naam is de peernaam in hoofdletters: `magazijn-a` -> `MAGAZIJN_A_GRANT_HASH`. Dat is
+# precies de naam die application.properties van de uitvraag leest voor het magazijn met die OIN.
+# Hernoem je een peer in peers.env, dan moet die property mee.
+for magazijn in $MAGAZIJNEN; do
+  ENVNAAM="$(printf '%s' "$magazijn" | tr '[:lower:]-' '[:upper:]_')_GRANT_HASH"
+
+  if contract_op "$UITVRAAG" "$magazijn" "$MAGAZIJN_DIENST" "$ENVNAAM"; then
+    GEDAAN=$((GEDAAN + 1))
+  else
+    FOUTEN=$((FOUTEN + 1))
+  fi
+
+  echo
+done
+
+# Pushen: elk magazijn mag zijn CloudEvents kwijt bij de notificatiedienst. Andere richting,
+# zelfde machinerie — het magazijn is hier de consumer.
+for pusher in $PUSHERS; do
+  if contract_op "$pusher" "$NOTIFICATIE" "$NOTIFICATIE_DIENST" NOTIFICATIE_GRANT_HASH; then
+    GEDAAN=$((GEDAAN + 1))
+  else
+    FOUTEN=$((FOUTEN + 1))
+  fi
+
+  echo
+done
+```
+
+Pas ook de `:` -controles bovenaan het script aan naar:
+
+```bash
+: "${UITVRAAG:?geen UITVRAAG in peers.env}"
+: "${MAGAZIJNEN:?geen MAGAZIJNEN in peers.env}"
+: "${MAGAZIJN_DIENST:?geen MAGAZIJN_DIENST in peers.env}"
+: "${NOTIFICATIE:?geen NOTIFICATIE in peers.env}"
+: "${PUSHERS:?geen PUSHERS in peers.env}"
+: "${NOTIFICATIE_DIENST:?geen NOTIFICATIE_DIENST in peers.env}"
+```
+
+En de slot-melding, zodat die niet meer over "magazijnen" alleen praat:
+
+```bash
+  echo "FBS-CONTRACTEN OK (${GEDAAN} contract(en))."
+```
+
+Laat de "nul contracten"-uitgang, de `mv`, en het opruimen van `$GRANTS` bij fouten ongewijzigd; die logica klopt nog steeds.
+
+Let op: bij meer dan één pusher schrijft de lus meerdere regels `NOTIFICATIE_GRANT_HASH=` naar hetzelfde bestand, en dan wint de laatste. Dat is nu correct (één pusher) maar niet houdbaar. Voeg daarom bovenaan de pusher-lus toe:
+
+```bash
+# Eén env-naam voor alle pushers werkt zolang er één is; een tweede zou de eerste overschrijven.
+# Dit is een bewuste grens, geen omissie: een tweede pusher betekent een tweede magazijn-deployment
+# met een eigen env, niet twee hashes in één bestand.
+if [ "$(printf '%s\n' $PUSHERS | grep -c .)" -gt 1 ]; then
+  echo "FAIL: PUSHERS bevat meer dan één peer; NOTIFICATIE_GRANT_HASH kan er maar één dragen." >&2
+  exit 2
+fi
+```
+
+- [ ] **Stap 3: Shellcheck**
+
+```bash
+shellcheck demo/environment/federatie/contracts/fbs-contracten.sh
+```
+
+Expected: geen bevindingen. (`$PUSHERS` zonder quotes in de `printf` is opzettelijk — woordsplitsing is hier de bedoeling; voeg `# shellcheck disable=SC2086` toe met die motivatie als shellcheck erover valt.)
+
+- [ ] **Stap 4: Commit**
+
+```bash
+git add demo/environment/federatie/peers.env demo/environment/federatie/contracts/fbs-contracten.sh
+git commit -m "feat(demo): contract magazijn->notificatie naast het ophaalcontract"
+```
+
+---
+
+### Taak 8: Smoke — de push door de keten
+
+**Files:**
+- Create: `demo/environment/federatie/smoke-notificatie.sh`
+
+**Interfaces:**
+- Consumes: Taak 3 t/m 7 én een draaiende demo-stack.
+- Produces: het bewijs voor de acceptatiecriteria van het issue.
+
+- [ ] **Stap 1: Schrijf het script**
+
+```bash
+#!/usr/bin/env bash
+# Smoke: bewijst dat het magazijn zijn CloudEvents door FSC pusht — berichtenmagazijn-a levert af
+# via zijn eigen outway -> router -> inway van de notificatie-aanbieder -> WireMock-stub, in plaats
+# van rechtstreeks.
+#
+#   1. data-pad — een bericht dat uniek is voor deze run komt als CloudEvent in de request-journal
+#      van de stub terecht, met Content-Type application/cloudevents+json. Een aanwezige event op
+#      zichzelf zegt niets: zonder uniek merk houdt een event uit een eerdere run dit groen;
+#   2. verantwoording — dezelfde transactie staat in beide txlogs, uitgaand bij het magazijn en
+#      inkomend bij de aanbieder. Ging de push rechtstreeks, dan groeit geen van beide;
+#   3. fire-and-forget intact — de stub antwoordde 202 en het magazijn leverde precies één keer af;
+#      een retry-stapeling zou betekenen dat de keten het antwoord niet terugkrijgt.
+#
+# Voorwaarden:
+#   - de federatie draait en de contracten staan -> ./federatie.sh up && contracts/fbs-contracten.sh
+#   - de demo-stack draait met het magazijn door de outway:
+#       MODUS=hostnet NOTIFICATIE_URL=http://127.20.2.5:8443/events demo/podman-up.sh
+#
+# Linux + podman: gebruikt `podman` en `curl`.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ENVDIR="$(cd "${HERE}/.." && pwd)"
+
+# shellcheck source=../lib/fsc-harness.sh
+. "${ENVDIR}/lib/fsc-harness.sh"
+# shellcheck source=peers.env
+. "${HERE}/peers.env"
+
+fsc_errlog_init
+
+MAGAZIJN_A_DIRECT="${MAGAZIJN_A_DIRECT:-http://127.0.0.1:8090/api/v1}"
+NOTIFICATIE_STUB="${NOTIFICATIE_STUB:-http://127.0.0.1:8084}"
+# De inway moet de stub als upstream krijgen. Host-adres, want de stub draait in de demo-stack en
+# niet in de peer-stack; in hostnet-modus delen ze de netns.
+NOTIFICATIE_UPSTREAM="${NOTIFICATIE_UPSTREAM:-http://127.0.0.1:8084}"
+# De outbox-poller draait op 60s. Bewust niet verlaagd: dan bewijst deze smoke een configuratie die
+# niemand draait. Vandaar een bovengrens in plaats van een vaste wachttijd.
+PUBLICATIE_TIMEOUT="${PUBLICATIE_TIMEOUT:-120}"
+PUBLICATIE_INTERVAL="${PUBLICATIE_INTERVAL:-5}"
+PROBE_POGINGEN="${PROBE_POGINGEN:-5}"
+PROBE_WACHT="${PROBE_WACHT:-3}"
+
+PUSHER="$(printf '%s' "$PUSHERS" | awk '{print $1}')"
+PUSHER_OIN="$(fsc_peer_waarde OIN "$PUSHER")"
+
+FOUTEN=0
+fout() { echo "FAIL: $*" >&2; FOUTEN=$((FOUTEN + 1)); }
+ok()   { echo "OK: $*"; }
+
+command -v curl >/dev/null 2>&1 || { echo "FAIL: 'curl' is vereist." >&2; exit 1; }
+
+# Elke run een VERSE ontvanger-BSN: het merk zit in onderwerp en inhoud, maar een vaste BSN zou de
+# stub-journal met events van eerdere runs vullen en assert 3 (precies één aflevering) breken. De
+# BSN moet door de elfproef komen, anders weigert het magazijn hem en leest dat als een ketenfout.
+nieuwe_bsn() {
+  local cijfers som i c laatste
+
+  while :; do
+    cijfers=""; som=0
+
+    for i in 9 8 7 6 5 4 3 2; do
+      # Eerste cijfer nooit 0: een BSN met een voorloopnul is negen tekens lang maar wordt door
+      # sommige parsers als achtcijferig gelezen.
+      if [ "$i" -eq 9 ]; then c=$((RANDOM % 9 + 1)); else c=$((RANDOM % 10)); fi
+      cijfers="${cijfers}${c}"
+      som=$((som + c * i))
+    done
+
+    for laatste in 0 1 2 3 4 5 6 7 8 9; do
+      if [ $(( (som - laatste) % 11 )) -eq 0 ]; then
+        printf '%s%s' "$cijfers" "$laatste"
+        return 0
+      fi
+    done
+  done
+}
+
+BSN="$(nieuwe_bsn)"
+MERK="notifsmoke-$$-$(od -An -N4 -tu4 < /dev/urandom | tr -d ' ')"
+
+# --- 0. De inway van de aanbieder wijst naar de notificatie-stub --------------------------------
+# Hier afdwingen en niet als voorwaarde aan de gebruiker laten: de publicatie is idempotent, en wie
+# eerst een andere smoke draait zet de upstream ongemerkt terug.
+echo "== 0. ${NOTIFICATIE} biedt ${NOTIFICATIE_DIENST} aan met de stub als upstream =="
+if fsc_zet_upstream "$ENVDIR" "$NOTIFICATIE" "$NOTIFICATIE_UPSTREAM" "$NOTIFICATIE_DIENST" \
+     >/dev/null 2>"$ERRLOG"; then
+  ok "dienst ${NOTIFICATIE_DIENST} gepubliceerd op de inway van ${NOTIFICATIE}"
+else
+  fout "kon ${NOTIFICATIE_DIENST} niet publiceren: $(fsc_last_error)"
+fi
+
+# Probe door de outway: bewijst dat het contract leeft en dat de dienstwijziging is doorgedrongen,
+# vóór we het van de applicatie afhankelijk maken. De dienstwijziging propageert asynchroon, dus de
+# eerste pogingen kunnen nog bij de vorige upstream uitkomen.
+GRANT="$(fsc_compose_env_lees "$(cd "${ENVDIR}/.." && pwd)/generated/fsc-grants.env" NOTIFICATIE_GRANT_HASH || true)"
+OUTWAY="http://$(fsc_component_adres "$(fsc_peer_waarde NET "$PUSHER")" outway):8443"
+
+if ! fsc_grant_bruikbaar "$GRANT"; then
+  fout "geen bruikbaar NOTIFICATIE_GRANT_HASH in demo/generated/fsc-grants.env — draai contracts/fbs-contracten.sh"
+else
+  POGING=1
+  DOOR=0
+
+  while [ "$POGING" -le "$PROBE_POGINGEN" ]; do
+    CODE="$(curl -sS -o /dev/null -w '%{http_code}' --noproxy '*' --max-time 10 \
+              -X POST "${OUTWAY}/events" \
+              -H "Fsc-Grant-Hash: ${GRANT}" \
+              -H 'Content-Type: application/cloudevents+json' \
+              -d '{"specversion":"1.0","id":"probe","source":"urn:probe","type":"probe"}' \
+              2>"$ERRLOG" || true)"
+
+    if [ "$CODE" = "202" ]; then
+      DOOR=1
+      break
+    fi
+
+    [ "$POGING" -lt "$PROBE_POGINGEN" ] && sleep "$PROBE_WACHT"
+    POGING=$((POGING + 1))
+  done
+
+  if [ "$DOOR" -eq 1 ]; then
+    ok "de outway van ${PUSHER} bereikt de stub door de inway heen (202, na ${POGING} poging(en))"
+  else
+    fout "de probe door de outway gaf HTTP ${CODE:-<geen>}: $(fsc_last_error)"
+  fi
+fi
+
+# --- Nulmeting op de txlogs ---------------------------------------------------------------------
+# NA de probe, niet ervoor: die gaat zelf door outway en inway en schrijft dus in beide logboeken.
+# Stond de nulmeting ervóór, dan telde die rij als "nieuw" en kon assert 2 nooit rood worden.
+if PROJECT="$(fsc_compose_project "${ENVDIR}/${GASTHEER}/deploy/local/docker-compose.yaml")"; then
+  txids() {  # <db> <richting>
+    podman exec "${PROJECT}-postgres-1" psql -U postgres -d "$1" -tA \
+      -c "SELECT transaction_id FROM transactionlog.records
+          WHERE direction = '$2' AND service_name = '${NOTIFICATIE_DIENST}' AND grant_hash IS NOT NULL" \
+      2>"$ERRLOG" | sort -u
+  }
+
+  # Eerst opvangen in variabelen, dan pas vergelijken: in een process substitution is de exitstatus
+  # onzichtbaar, en een gestopte postgres zou dan als "geen transacties" lezen.
+  gedeelde_txids() {
+    local uit in
+
+    uit="$(txids "fsc_txlog_$(fsc_peer_var "$PUSHER")" out)" || {
+      echo "WAARSCHUWING: txlog van ${PUSHER} niet leesbaar: $(fsc_last_error)" >&2
+      return 1
+    }
+    in="$(txids "fsc_txlog_$(fsc_peer_var "$NOTIFICATIE")" in)" || {
+      echo "WAARSCHUWING: txlog van ${NOTIFICATIE} niet leesbaar: $(fsc_last_error)" >&2
+      return 1
+    }
+
+    comm -12 <(printf '%s\n' "$uit") <(printf '%s\n' "$in")
+  }
+
+  TXLOG_LEESBAAR=1
+else
+  TXLOG_LEESBAAR=0
+fi
+
+VOOR_OK=0
+VOOR=""
+
+if [ "$TXLOG_LEESBAAR" -eq 1 ]; then
+  STABIEL=0
+  POGING=1
+
+  # Uitwachten tot de logboeken stilstaan: de in-/outway schrijven hun record out-of-band, dus de
+  # rij van de probe kan ná de nulmeting landen en dan als "nieuw" meetellen.
+  while [ "$POGING" -le "$PROBE_POGINGEN" ]; do
+    HUIDIG="$(gedeelde_txids)" || break
+
+    if [ "$POGING" -gt 1 ] && [ "$HUIDIG" = "$VORIG" ]; then
+      STABIEL=1
+      break
+    fi
+
+    VORIG="$HUIDIG"
+    sleep "$PROBE_WACHT"
+    POGING=$((POGING + 1))
+  done
+
+  if [ "$STABIEL" -eq 1 ]; then
+    VOOR="$HUIDIG"
+    VOOR_OK=1
+  else
+    echo "WAARSCHUWING: de txlogs kwamen niet tot stilstand binnen ${PROBE_POGINGEN} metingen" >&2
+  fi
+fi
+
+# --- 1. Data-pad --------------------------------------------------------------------------------
+echo "== 1. de CloudEvent van magazijn ${PUSHER} komt bij de stub aan =="
+CODE="$(curl -sS -o /dev/null -w '%{http_code}' --noproxy '*' --max-time 20 \
+          -X POST "${MAGAZIJN_A_DIRECT}/berichten" -H 'Content-Type: application/json' \
+          -d "{\"afzender\":\"${PUSHER_OIN}\",\"ontvanger\":{\"type\":\"BSN\",\"waarde\":\"${BSN}\"},\"onderwerp\":\"${MERK}\",\"inhoud\":\"${MERK}\"}" \
+          2>"$ERRLOG" || true)"
+
+if [ "$CODE" != "201" ] && [ "$CODE" != "200" ]; then
+  fout "aanleveren bij ${PUSHER} gaf HTTP ${CODE:-<geen>}: $(fsc_last_error) — draait de demo-stack?"
+else
+  echo "  bericht '${MERK}' aangeleverd (HTTP ${CODE}); wachten op de outbox-poller..."
+
+  # WireMock's count-API in plaats van de journal uitkammen: dan telt de matcher en niet een grep
+  # over een JSON-blob waarin het merk toevallig meer dan één keer voorkomt (het staat in zowel
+  # onderwerp als inhoud). tel_afleveringen <extra-matchers-json> geeft het aantal terug.
+  tel_afleveringen() {
+    curl -sS --noproxy '*' --max-time 10 -X POST "${NOTIFICATIE_STUB}/__admin/requests/count" \
+      -H 'Content-Type: application/json' \
+      -d "{\"method\":\"POST\",\"url\":\"/events\",\"bodyPatterns\":[{\"contains\":\"${MERK}\"}]$1}" \
+      2>"$ERRLOG" \
+      | sed -n 's/.*"count"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p'
+  }
+
+  AANTAL=0
+  elapsed=0
+
+  while [ "$elapsed" -lt "$PUBLICATIE_TIMEOUT" ]; do
+    AANTAL="$(tel_afleveringen "" || true)"
+
+    if [ "${AANTAL:-0}" -ge 1 ] 2>/dev/null; then
+      break
+    fi
+
+    sleep "$PUBLICATIE_INTERVAL"
+    elapsed=$((elapsed + PUBLICATIE_INTERVAL))
+  done
+
+  if [ "${AANTAL:-0}" -ge 1 ] 2>/dev/null; then
+    ok "de stub ontving de CloudEvent van '${MERK}' (na ${elapsed}s)"
+
+    # Zelfde telling, nu mét de header-eis. Blijft hij gelijk, dan heeft de inway het Content-Type
+    # ongewijzigd doorgegeven — structured content mode overleeft de keten.
+    MET_HEADER="$(tel_afleveringen ',"headers":{"Content-Type":{"contains":"application/cloudevents+json"}}' || true)"
+
+    if [ "${MET_HEADER:-0}" = "$AANTAL" ]; then
+      ok "de inway gaf Content-Type application/cloudevents+json ongewijzigd door"
+    else
+      fout "${MET_HEADER:-0} van ${AANTAL} afleveringen droeg het cloudevents-Content-Type — structured mode gesneuveld in de keten?"
+    fi
+  else
+    fout "de stub ontving geen event voor '${MERK}' binnen ${PUBLICATIE_TIMEOUT}s"
+  fi
+fi
+
+# --- 2. Verantwoording ---------------------------------------------------------------------------
+echo "== 2. verantwoording in beide txlogs =="
+if [ -z "${PROJECT:-}" ]; then
+  fout "projectnaam van de gastheer niet af te leiden — deze assert heeft niets gemeten"
+elif [ "$VOOR_OK" -ne 1 ]; then
+  fout "de nulmeting op de txlogs mislukte — deze assert heeft niets gemeten"
+elif ! NA="$(gedeelde_txids)"; then
+  fout "de txlogs zijn na afloop niet leesbaar — deze assert heeft niets gemeten"
+else
+  NIEUW="$(comm -13 <(printf '%s\n' "$VOOR") <(printf '%s\n' "$NA") | grep -c . || true)"
+
+  if [ "${NIEUW:-0}" -gt 0 ]; then
+    ok "${NIEUW} nieuwe transactie(s) in beide txlogs, uitgaand bij ${PUSHER} en inkomend bij ${NOTIFICATIE}"
+  else
+    fout "geen NIEUWE gedeelde transactie-id — het magazijn ging buiten de outway om"
+  fi
+fi
+
+# --- 3. Fire-and-forget --------------------------------------------------------------------------
+# Precies één aflevering voor dit merk. Meer betekent dat het magazijn het 202 niet terugkreeg en in
+# de retry-lus zat; dat zou de fire-and-forget-eigenschap stilzwijgend hebben opgegeven.
+echo "== 3. één aflevering, geen retry-stapeling =="
+if [ "${AANTAL:-0}" -eq 0 ] 2>/dev/null; then
+  fout "geen aflevering gevonden voor '${MERK}' — assert 1 was al rood"
+elif [ "$AANTAL" -eq 1 ]; then
+  ok "het magazijn leverde één keer af en kreeg zijn 202 terug"
+else
+  fout "${AANTAL} afleveringen voor hetzelfde bericht — het antwoord van de stub komt niet terug door de keten"
+fi
+
+echo
+if [ "$FOUTEN" -eq 0 ]; then
+  echo "== NOTIFICATIE-SMOKE GROEN =="
+else
+  echo "== NOTIFICATIE-SMOKE ROOD: ${FOUTEN} bevinding(en) ==" >&2
+  exit 1
+fi
+```
+
+- [ ] **Stap 2: Uitvoerbaar maken en shellcheck**
+
+```bash
+chmod +x demo/environment/federatie/smoke-notificatie.sh
+shellcheck demo/environment/federatie/smoke-notificatie.sh
+```
+
+Expected: geen bevindingen.
+
+- [ ] **Stap 3: Commit**
+
+```bash
+git add demo/environment/federatie/smoke-notificatie.sh
+git commit -m "test(demo): smoke voor de notificatie-push door de FSC-keten"
+```
+
+---
+
+### Taak 9: End-to-end draaien
+
+Geen bestandswijzigingen tenzij een assert rood is — dan repareren in de taak waar de fout hoort en dáár committen.
+
+**Files:**
+- Geen (verificatie).
+
+**Interfaces:**
+- Consumes: Taak 1 t/m 8.
+
+- [ ] **Stap 1: Group-CA opnieuw delen**
+
+De outway van `magazijn-a` heeft een vers group-cert dat nog niet onder de gedeelde CA hangt.
+
+```bash
+cd demo/environment
+./federatie/deel-groep-ca.sh --check
+./federatie/deel-groep-ca.sh
+```
+
+Expected: `--check` toont wat er gebeurt; de tweede run voert het uit zonder fout.
+
+- [ ] **Stap 2: Federatie opzetten**
+
+```bash
+cd demo/environment
+./federatie/federatie.sh down || true
+./federatie/federatie.sh up
+./federatie/smoke-federatie.sh
+```
+
+Expected: `FEDERATIE-SMOKE GROEN.` Draait de outway van magazijn-a mee? Controleer met
+`./federatie/federatie.sh status`; er hoort een listener op `127.20.2.5:8443` te staan.
+
+- [ ] **Stap 3: Contracten**
+
+```bash
+cd demo/environment
+./federatie/contracts/fbs-contracten.sh
+grep -c GRANT_HASH ../generated/fsc-grants.env
+```
+
+Expected: `FBS-CONTRACTEN OK (2 contract(en)).` en `2` regels — `MAGAZIJN_A_GRANT_HASH` en `NOTIFICATIE_GRANT_HASH`.
+
+- [ ] **Stap 4: Demo-stack met de push door de outway**
+
+```bash
+MODUS=hostnet NOTIFICATIE_URL=http://127.20.2.5:8443/events ./demo/podman-up.sh
+```
+
+Expected: de stack komt op. Controleer daarna in de log van het magazijn dat de bypass-regel er staat:
+
+```bash
+podman logs $(podman ps --format '{{.Names}}' | grep -m1 berichtenmagazijn) 2>&1 | grep DOWNSTREAM_VIA_OUTWAY
+```
+
+Expected: één regel die `notificatie` noemt. Ontbreekt hij, dan is `NOTIFICATIE_GRANT_HASH` niet
+doorgekomen — compose leest `env_file` bij het **aanmaken** van een container, dus een al draaiende
+stack houdt de oude waarde tot je hem hercreëert.
+
+- [ ] **Stap 5: De smoke**
+
+```bash
+./demo/environment/federatie/smoke-notificatie.sh
+```
+
+Expected: `== NOTIFICATIE-SMOKE GROEN ==`.
+
+- [ ] **Stap 6: Bewijs dat het bestaande pad niet gesneuveld is**
+
+```bash
+./demo/environment/federatie/smoke-contract.sh
+MODUS=hostnet MAGAZIJN_A_URL=http://127.20.1.5:8443 ./demo/environment/federatie/smoke-keten.sh
+```
+
+Expected: beide groen. `smoke-keten.sh` bewijst dat het ophaal-pad nog werkt nu de inway van
+`logius` twee diensten draagt en `fsc_zet_upstream` een argument erbij heeft.
+
+- [ ] **Stap 7: Opruimen**
+
+Er is geen `podman-down.sh`; breek de stack af met dezelfde drie compose-bestanden die
+`podman-up.sh` in hostnet-modus stapelt (zie `demo/podman-up.sh:201-204`):
+
+```bash
+docker compose -f compose.yaml -f compose.podman.yaml -f compose.podman-hostnet.yaml down -v
+cd demo/environment && ./federatie/federatie.sh down
+```
+
+- [ ] **Stap 8: Noteer de uitkomst**
+
+Leg de uitkomst van elke smoke vast (groen/rood + eventuele afwijking) voor de PR-body. Rapporteer
+een rode assert als zodanig; niet wegpoetsen door een timeout op te hogen zonder reden.
+
+---
+
+### Taak 10: Documentatie en ZAD-runbooks
+
+**Files:**
+- Modify: `demo/environment/federatie/README.md`
+- Modify: `demo/environment/logius/deploy/zad/verify-zad.md`
+- Modify: `demo/environment/magazijn-a/deploy/zad/verify-zad.md`
+- Modify: `docs/plans/2026-08-17-notificatie-via-fsc-design.md`
+- Modify: `docs/plans/2026-08-17-notificatie-via-fsc-plan.md`
+
+**Interfaces:**
+- Consumes: de bewezen stand uit Taak 9.
+
+- [ ] **Stap 1: Federatie-README — contracten en smokes**
+
+Voeg in `demo/environment/federatie/README.md` onder "Contracten", ná het codeblok met
+`fbs-contracten.sh`, toe:
+
+```markdown
+`fbs-contracten.sh` zet twee soorten contract op: één per magazijn zodat de uitvraag-outway
+`berichtenmagazijn` mag ophalen, en één per pusher zodat het magazijn zijn CloudEvents kwijt kan bij
+`notificatieservice`. Die tweede loopt de andere kant op — het magazijn is daar de afnemer.
+
+```bash
+./federatie/smoke-notificatie.sh   # bewijst de push: outway magazijn -> inway aanbieder -> stub
+```
+
+Voor de push moet de demo-stack het magazijn door de outway laten leveren:
+
+```bash
+MODUS=hostnet NOTIFICATIE_URL=http://127.20.2.5:8443/events demo/podman-up.sh
+```
+```
+
+- [ ] **Stap 2: ZAD-runbook van de aanbieder**
+
+Voeg onderaan `demo/environment/logius/deploy/zad/verify-zad.md` toe:
+
+```markdown
+### Inbound data-pad — notificatieservice (lokaal bewezen, ZAD-apply is handmatig vervolgwerk)
+
+Lokaal bewezen in `federatie/` (`smoke-notificatie.sh`, zie
+`docs/plans/2026-08-17-notificatie-via-fsc-plan.md`): `logius` biedt naast `profiel-service` ook
+`notificatieservice` aan op dezelfde inway, met de notificatie-stub als upstream. Op ZAD moet dit
+nog worden herhaald tegen de échte infrastructuur:
+
+1. `CreateService` via de `logius-fscctl` Administration-API (`SERVICE_NAME=notificatieservice`,
+   `endpoint_url` = de echte notificatiedienst, `inway_address` = `SELF_ADDRESS` van
+   `logius-fscinway`).
+2. Het `serviceConnection`-contract met het magazijn opzetten (`bootstrap-consumer.sh` aan
+   magazijn-kant, `bootstrap-provider.sh` hier — zie `federatie/contracts/zad-runbook.md`).
+3. `NOTIFICATIE_URL=https://fsc-magazijna-magazijna-fscoutway:8443/events` en
+   `NOTIFICATIE_GRANT_HASH=<grant-hash uit stap 2>` als env-vars op het gedeployde
+   `berichtenmagazijn` (project `mpfm-w3h`).
+4. Een smoke voor het pad `berichtenmagazijn → magazijna-fscoutway → logius-fscinway → upstream`.
+```
+
+- [ ] **Stap 3: ZAD-runbook van de pusher**
+
+Voeg onderaan `demo/environment/magazijn-a/deploy/zad/verify-zad.md` toe:
+
+```markdown
+### Outway — uitgaand verkeer van het magazijn
+
+`magazijn-a` heeft sinds de notificatie-push een outway (`magazijna-fscoutway`). Die is nieuw op
+ZAD en moet daar nog aangemaakt worden: component toevoegen aan de projectspec, certificaten uit
+`pki/peers/magazijn-a/outway/` uitgeven en bijlagen koppelen zoals `cert-manifest.md` dat voor de
+andere componenten beschrijft. De outway is egress-only en heeft geen ingress-route nodig.
+
+Zonder `NOTIFICATIE_GRANT_HASH` op het magazijn blijft de aflevering rechtstreeks lopen; het
+component kan dus vooruitlopend worden uitgerold zonder gedrag te veranderen.
+```
+
+- [ ] **Stap 4: Status van design en plan bijwerken**
+
+Zet in beide documenten de kopregel om:
+
+```markdown
+**Status:** Uitgevoerd
+```
+
+- [ ] **Stap 5: Commit**
+
+```bash
+git add demo/environment/federatie/README.md \
+        demo/environment/logius/deploy/zad/verify-zad.md \
+        demo/environment/magazijn-a/deploy/zad/verify-zad.md \
+        docs/plans/2026-08-17-notificatie-via-fsc-design.md \
+        docs/plans/2026-08-17-notificatie-via-fsc-plan.md
+git commit -m "docs(demo): leg de notificatie-push via FSC vast in runbooks en README"
+```
+
+- [ ] **Stap 6: Reviewronde vóór de PR**
+
+Draai `/code-review` op het volledige diff van de branch en verwerk de bevindingen; commit de
+reparaties in de taak waar ze horen. Doe dit ná Taak 9, niet ervoor: een rode smoke verandert de
+code die je anders al hebt laten reviewen.
+
+- [ ] **Stap 7: PR openen**
+
+Schrijf de PR-body naar een bestand en gebruik dat — `gh pr create --body` met meerregelige tekst
+is foutgevoelig, en `gh pr edit` faalt in deze repo op Projects-classic:
+
+```bash
+cat > /tmp/pr-784.md <<'EOF'
+Sluit het notificatie-pad aan op de FSC-mesh: het magazijn levert zijn CloudEvents af door zijn
+eigen outway bij de inway van de aanbieder, in plaats van rechtstreeks op de stub.
+
+Twee afwijkingen van het issue, beide bewust:
+
+- **Niet config-only.** De outway kiest de doel-inway op `Fsc-Grant-Hash` en eist een
+  `Fsc-Transaction-Id` in UUID-v7. Die headers worden gezet door JAX-RS-clientfilters, en
+  `DownstreamClient` is bewust géén JAX-RS-client. Alleen de URL ombuigen levert `service not
+  found`. Vandaar een grant-hash per downstream plus het headerpaar op de uitgaande request.
+- **Geen eigen `notificatie`-peer.** De dienst staat op de bestaande `logius`-inway, naast
+  `profiel-service`. Een derde peer-stack kost een volledige compose-, PKI- en
+  adresruimte-duplicatie zonder iets extra's te bewijzen over de eigenschap die dit issue
+  aantoont: een magazijn dat uitgaand door FSC pusht. Verhuizen is later een publicatie- en
+  contractwijziging, geen wijziging aan het magazijn.
+
+Daarnaast: een downstream mét grant-hash slaat de SSRF-blocklist over. De bestemming volgt daar uit
+het FSC-contract in plaats van uit onze URL, en op ZAD resolveert de outway naar een RFC1918-adres
+waar de blocklist anders op afketst. De uitzondering logt bij boot een regel met
+`DOWNSTREAM_VIA_OUTWAY`. De TLS-eis blijft onverkort staan.
+
+Ontwerp: `docs/plans/2026-08-17-notificatie-via-fsc-design.md`
+Plan: `docs/plans/2026-08-17-notificatie-via-fsc-plan.md`
+
+Lokaal bewezen met `demo/environment/federatie/smoke-notificatie.sh`; `smoke-contract.sh` en
+`smoke-keten.sh` blijven groen.
+
+Werkt aan #784.
+EOF
+
+git push -u origin feature/784-notificatie-via-fsc
+gh pr create --title "Notificatie-events door de FSC-keten (#784)" --body-file /tmp/pr-784.md
+```
+
+Geen reviewer toevoegen. Let op de laatste regel van de body: "Werkt aan #784" en niet `Closes`/
+`Fixes` — het issue moet openblijven bij merge.

--- a/docs/plans/2026-08-17-notificatie-via-fsc-plan.md
+++ b/docs/plans/2026-08-17-notificatie-via-fsc-plan.md
@@ -1,4 +1,4 @@
-**Status:** Concept
+**Status:** Uitgevoerd
 
 # Notificatie-events via FSC — implementatieplan
 

--- a/libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeaders.kt
+++ b/libraries/fbs-common/src/main/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeaders.kt
@@ -20,11 +20,20 @@ object FscOutwayHeaders {
 
     private val log = Logger.getLogger(FscOutwayHeaders::class.java)
 
-    fun zet(requestContext: ClientRequestContext, grantHash: String) {
-        val transactionId = UuidV7.generate()
+    /**
+     * Het headerpaar voor één outway-call. Losgetrokken van het transport omdat niet elke caller
+     * een JAX-RS-client is: de downstream-aflevering van CloudEvents gebruikt
+     * `java.net.http.HttpClient` en zou het contract anders moeten dupliceren.
+     */
+    fun headers(grantHash: String): Map<String, String> = mapOf(
+        GRANT_HASH_HEADER to grantHash,
+        TRANSACTION_ID_HEADER to UuidV7.generate().toString(),
+    )
 
-        requestContext.headers.putSingle(GRANT_HASH_HEADER, grantHash)
-        requestContext.headers.putSingle(TRANSACTION_ID_HEADER, transactionId.toString())
+    fun zet(requestContext: ClientRequestContext, grantHash: String) {
+        val paar = headers(grantHash)
+
+        paar.forEach { (naam, waarde) -> requestContext.headers.putSingle(naam, waarde) }
 
         // Zonder deze transaction-id in de app-log is een call niet terug te vinden in de
         // outway-/inway-logs, die 'm ongewijzigd doorgeven. Log alleen de host, nooit het
@@ -34,7 +43,7 @@ object FscOutwayHeaders {
         log.debugf(
             "FSC-outway-call naar %s: Fsc-Transaction-Id=%s",
             requestContext.uri.host,
-            transactionId,
+            paar[TRANSACTION_ID_HEADER],
         )
     }
 }

--- a/libraries/fbs-common/src/test/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeadersTest.kt
+++ b/libraries/fbs-common/src/test/kotlin/nl/rijksoverheid/moz/fbs/common/fsc/FscOutwayHeadersTest.kt
@@ -71,6 +71,28 @@ class FscOutwayHeadersTest {
     }
 
     @Test
+    fun `headers levert de grant-hash ongewijzigd en een verse transaction-id`() {
+        val headers = FscOutwayHeaders.headers("\$1\$4\$k4rwlWTsCM_j89Fc3nrbnQa9-KB43")
+
+        assertEquals("\$1\$4\$k4rwlWTsCM_j89Fc3nrbnQa9-KB43", headers[FscOutwayHeaders.GRANT_HASH_HEADER])
+
+        val transactionId = UUID.fromString(headers.getValue(FscOutwayHeaders.TRANSACTION_ID_HEADER))
+
+        assertEquals(7, transactionId.version(), "de outway weigert een transaction-id die geen UUID v7 is")
+    }
+
+    @Test
+    fun `headers levert bij elke aanroep een andere transaction-id`() {
+        val eerste = FscOutwayHeaders.headers("abc123")
+        val tweede = FscOutwayHeaders.headers("abc123")
+
+        assertNotEquals(
+            eerste[FscOutwayHeaders.TRANSACTION_ID_HEADER],
+            tweede[FscOutwayHeaders.TRANSACTION_ID_HEADER],
+        )
+    }
+
+    @Test
     fun `twee invocaties leveren twee verschillende transaction-ids`() {
         val eerste = zetHeaders("abc123")
         val tweede = zetHeaders("abc123")

--- a/services/berichtenmagazijn/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/DownstreamClient.kt
+++ b/services/berichtenmagazijn/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/DownstreamClient.kt
@@ -122,7 +122,19 @@ class DownstreamClient(
             .POST(BodyPublishers.ofByteArray(payload))
 
         if (grantHash != null) {
-            FscOutwayHeaders.headers(grantHash).forEach { (naam, waarde) -> requestBuilder.header(naam, waarde) }
+            val fscHeaders = FscOutwayHeaders.headers(grantHash)
+
+            fscHeaders.forEach { (naam, waarde) -> requestBuilder.header(naam, waarde) }
+
+            // Zonder deze transaction-id in de app-log is een mislukte aflevering niet te
+            // correleren met de rij in de outway-/inway-txlogs, die 'm ongewijzigd doorgeven —
+            // en juist dáár staat waaróm de outway 502 gaf. Alleen het doel loggen, nooit de
+            // URL: die kan een pad met persoonsgegevens dragen.
+            log.debugf(
+                "FSC-outway-aflevering naar %s: Fsc-Transaction-Id=%s",
+                doel.key,
+                fscHeaders[FscOutwayHeaders.TRANSACTION_ID_HEADER],
+            )
 
             // De FSC-data-plane is HTTP/1.1 — dat staat zo in het publicatiecontract van elke
             // dienst (`PROTOCOL_TCP_HTTP_1.1`). Zonder deze pin onderhandelt de JDK-client op een
@@ -212,7 +224,14 @@ class DownstreamClient(
     private fun bruikbareGrantHash(downstream: PublicatieConfig.Downstream): String? =
         downstream.grantHash().orElse(null)?.trim()?.takeIf { it.isNotEmpty() }
 
-    private fun valideerUrl(url: String, viaOutway: Boolean): DownstreamResultaat.ConfiguratieFout? {
+    /**
+     * Keurt een downstream-URL goed of af. `internal` zodat de scheme-, loopback- en SSRF-regels
+     * te toetsen zijn zonder een echte call te doen — een test die op een niet-routeerbaar adres
+     * moet aflopen kost een connect-timeout, en levert een ándere uitkomst op een machine die
+     * dat adres wél kan bereiken. Spiegelt [mapDeliveryException], dat om dezelfde reden
+     * rechtstreeks getest wordt.
+     */
+    internal fun valideerUrl(url: String, viaOutway: Boolean): DownstreamResultaat.ConfiguratieFout? {
         val parsed = try {
             URI.create(url)
         } catch (_: IllegalArgumentException) {

--- a/services/berichtenmagazijn/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/DownstreamClient.kt
+++ b/services/berichtenmagazijn/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/DownstreamClient.kt
@@ -123,6 +123,14 @@ class DownstreamClient(
 
         if (grantHash != null) {
             FscOutwayHeaders.headers(grantHash).forEach { (naam, waarde) -> requestBuilder.header(naam, waarde) }
+
+            // De FSC-data-plane is HTTP/1.1 — dat staat zo in het publicatiecontract van elke
+            // dienst (`PROTOCOL_TCP_HTTP_1.1`). Zonder deze pin onderhandelt de JDK-client op een
+            // plain-http-doel eerst een upgrade naar h2c, en die hop-by-hop-headers proxyt de
+            // outway ongewijzigd door naar de inway; het Go-http2-transport daarachter weigert ze
+            // met "invalid Upgrade request header" en de outway antwoordt 502. Alleen op dit pad
+            // pinnen: downstreams die rechtstreeks worden aangesproken mogen wel h2 doen.
+            requestBuilder.version(HttpClient.Version.HTTP_1_1)
         }
 
         // W3C Trace Context propagatie: injecteer `traceparent` (en `tracestate`)

--- a/services/berichtenmagazijn/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/DownstreamClient.kt
+++ b/services/berichtenmagazijn/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/DownstreamClient.kt
@@ -9,6 +9,7 @@ import jakarta.annotation.PreDestroy
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.enterprise.inject.Instance
 import nl.rijksoverheid.moz.fbs.common.FoutBeschrijving
+import nl.rijksoverheid.moz.fbs.common.fsc.FscOutwayHeaders
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
 import java.io.IOException
@@ -60,6 +61,20 @@ class DownstreamClient(
                 profiel,
             )
         }
+
+        val viaOutway = config.downstreams()
+            .filterValues { bruikbareGrantHash(it) != null }
+            .keys
+
+        if (viaOutway.isNotEmpty()) {
+            // Een SSRF-uitzondering hoort niet stil te zijn: zonder deze regel is aan een draaiende
+            // pod niet te zien welke downstreams buiten de blocklist vallen.
+            log.warnf(
+                "%s: downstream(s) %s lopen door de eigen FSC-outway; de SSRF-blocklist geldt daar niet.",
+                OUTWAY_SSRF_ALERT_TOKEN,
+                viaOutway.joinToString(", "),
+            )
+        }
     }
 
     private val http: HttpClient = HttpClient.newBuilder()
@@ -87,7 +102,8 @@ class DownstreamClient(
             )
 
         val url = downstream.url()
-        val urlValidatie = valideerUrl(url)
+        val grantHash = bruikbareGrantHash(downstream)
+        val urlValidatie = valideerUrl(url, viaOutway = grantHash != null)
         if (urlValidatie != null) return urlValidatie
 
         val payload = try {
@@ -104,6 +120,10 @@ class DownstreamClient(
             .timeout(config.client().requestTimeout())
             .header("Content-Type", "application/cloudevents+json")
             .POST(BodyPublishers.ofByteArray(payload))
+
+        if (grantHash != null) {
+            FscOutwayHeaders.headers(grantHash).forEach { (naam, waarde) -> requestBuilder.header(naam, waarde) }
+        }
 
         // W3C Trace Context propagatie: injecteer `traceparent` (en `tracestate`)
         // uit de huidige OpenTelemetry-context, zodat de keten cross-organisatie
@@ -176,7 +196,15 @@ class DownstreamClient(
         }
     }
 
-    private fun valideerUrl(url: String): DownstreamResultaat.ConfiguratieFout? {
+    /**
+     * De grant-hash van [downstream], of `null` als er geen bruikbare staat. Trimmen omdat een
+     * hash die via een env-var uit een gegenereerd bestand komt makkelijk een spatie of newline
+     * meekrijgt, en de outway daarop `400 UNKNOWN_GRANT_HASH_IN_HEADER` antwoordt.
+     */
+    private fun bruikbareGrantHash(downstream: PublicatieConfig.Downstream): String? =
+        downstream.grantHash().orElse(null)?.trim()?.takeIf { it.isNotEmpty() }
+
+    private fun valideerUrl(url: String, viaOutway: Boolean): DownstreamResultaat.ConfiguratieFout? {
         val parsed = try {
             URI.create(url)
         } catch (_: IllegalArgumentException) {
@@ -214,7 +242,13 @@ class DownstreamClient(
         // SSRF-blocklist ([blokkeerIntern]): zonder dit kan een operator met
         // config-toegang de magazijn-pod als proxy naar interne services gebruiken.
         // Loopback is hierboven al toegestaan voor dev-stubs (WireMock/embedded HTTP).
-        if (!isLoopback) {
+        //
+        // Een downstream met een grant-hash valt erbuiten: die gaat door de eigen, co-located
+        // outway, en dáár bepaalt het FSC-contract achter de hash de bestemming — een URL naar een
+        // ander intern adres levert dan geen verkeer maar een fout. Zonder deze uitzondering is het
+        // pad onbruikbaar: een outway-ClusterIP resolveert naar RFC1918. De TLS-eis hierboven
+        // blijft wél gelden, en een actieve uitzondering logt bij boot [OUTWAY_SSRF_ALERT_TOKEN].
+        if (!isLoopback && !viaOutway) {
             val ssrfFout = blokkeerIntern(host)
             if (ssrfFout != null) return ssrfFout
         }
@@ -306,6 +340,13 @@ class DownstreamClient(
          * mag niet wijzigen zonder die alert mee te verhuizen.
          */
         const val VALIDATIE_UIT_ALERT_TOKEN = "DOWNSTREAM_URL_VALIDATIE_UIT"
+
+        /**
+         * Greppable marker voor downstreams die door de eigen outway lopen en daarmee buiten de
+         * SSRF-blocklist vallen. Zelfde afspraak als [VALIDATIE_UIT_ALERT_TOKEN]: ops hangt hier
+         * een alert-regel aan, dus de waarde wijzigt niet zonder die alert mee te verhuizen.
+         */
+        const val OUTWAY_SSRF_ALERT_TOKEN = "DOWNSTREAM_VIA_OUTWAY"
 
         /**
          * Laat alleen W3C `traceparent` door; `tracestate` (vendor-routing/sampling)

--- a/services/berichtenmagazijn/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/PublicatieConfig.kt
+++ b/services/berichtenmagazijn/src/main/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/PublicatieConfig.kt
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.Pattern
 import nl.rijksoverheid.moz.fbs.common.identificatie.Oin
 import org.hibernate.validator.constraints.URL
 import java.time.Duration
+import java.util.Optional
 
 /**
  * Type-safe configuratie voor de Publicatie Stream.
@@ -134,6 +135,14 @@ interface PublicatieConfig {
         @NotBlank
         @URL(regexp = "^https?://.*")
         fun url(): String
+
+        /**
+         * FSC-grant-hash voor een downstream die door de eigen outway loopt. Aanwezig ⇒ de call
+         * krijgt `Fsc-Grant-Hash` en `Fsc-Transaction-Id` mee, en de SSRF-blocklist geldt er niet:
+         * de outway kiest de bestemming op het contract achter deze hash, niet op onze URL.
+         * Afwezig of leeg ⇒ rechtstreeks verkeer, met alle URL-controles onverkort.
+         */
+        fun grantHash(): Optional<String>
 
         /** Max afleverpogingen voordat de delivery terminal MISLUKT wordt. Per downstream,
          *  zodat een trage/onbetrouwbare doel meer pogingen kan krijgen dan een snelle. */

--- a/services/berichtenmagazijn/src/main/resources/application.properties
+++ b/services/berichtenmagazijn/src/main/resources/application.properties
@@ -197,12 +197,18 @@ magazijn.publicatie.verwerkingsregister-aanleveren=https://register.example.com/
 # demo-stack leidt beide via Toxiproxy en zet AANMELD_URL op de echte uitvraag-webhook.
 %dev.magazijn.publicatie.downstreams.aanmeld.url=${AANMELD_URL:http://localhost:8083/events}
 %dev.magazijn.publicatie.downstreams.notificatie.url=${NOTIFICATIE_URL:http://localhost:8084/events}
+# Grant-hash voor de notificatie-downstream. Gevuld ⇒ de aflevering loopt door de eigen
+# FSC-outway (FSC-headers + SSRF-uitzondering); leeg ⇒ rechtstreeks, ongewijzigd gedrag.
+# Lokaal komt de waarde uit demo/generated/fsc-grants.env, dat de contract-bootstrap van de
+# federatie schrijft; zonder dat bestand blijft hij leeg.
+%dev.magazijn.publicatie.downstreams.notificatie.grant-hash=${NOTIFICATIE_GRANT_HASH:}
 # In %prod komen de downstream-URL's uit env-vars; de keys staan hier omdat SmallRye
 # map-keys niet uit losse env-vars ontdekt. aanmeld = de echte uitvraag-webhook
 # (POST /api/v1/aanmeldingen), notificatie = WireMock-stub. De ZAD-deploymentnaam
 # zit al in de env-waarde verwerkt (URL-templating op $DEPLOYMENT_NAME in OM).
 %prod.magazijn.publicatie.downstreams.aanmeld.url=${AANMELD_URL}
 %prod.magazijn.publicatie.downstreams.notificatie.url=${NOTIFICATIE_URL}
+%prod.magazijn.publicatie.downstreams.notificatie.grant-hash=${NOTIFICATIE_GRANT_HASH:}
 # Timeouts op de gedeelde DownstreamClient-HttpClient. Anders dan de lokale
 # Redis-awaits zijn dit remote, cross-organisatie calls over publiek internet naar een
 # federatieve dienstverlener: connect (TCP+TLS-opbouw) 5s, request (volledige

--- a/services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/ApplicationPropertiesTest.kt
+++ b/services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/ApplicationPropertiesTest.kt
@@ -46,6 +46,7 @@ class ApplicationPropertiesTest {
         "%dev.magazijn.publicatie.organisatie.oin, MAGAZIJN_OIN",
         "%dev.magazijn.publicatie.downstreams.aanmeld.url, AANMELD_URL",
         "%dev.magazijn.publicatie.downstreams.notificatie.url, NOTIFICATIE_URL",
+        "%dev.magazijn.publicatie.downstreams.notificatie.grant-hash, NOTIFICATIE_GRANT_HASH",
         "%dev.quarkus.rest-client.profiel-service.url, PROFIEL_SERVICE_URL",
     )
     fun `dev-regels van de demo houden hun env-var-expansie`(sleutel: String, envVar: String) {

--- a/services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/DownstreamClientTest.kt
+++ b/services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/DownstreamClientTest.kt
@@ -491,6 +491,22 @@ class DownstreamClientTest {
     }
 
     @Test
+    fun `een outway-call biedt geen h2c-upgrade aan`() {
+        // De outway proxyt hop-by-hop-headers ongewijzigd door naar de inway, en het
+        // Go-http2-transport daarachter weigert een `Upgrade: h2c` met 502. De JDK-client stuurt
+        // die upgrade standaard mee op een plain-http-doel, dus het uitblijven ervan is precies
+        // wat deze call bruikbaar maakt.
+        every { config.downstreams() } returns mapOf("aanmeld" to DownstreamStub(server.baseUrl, "hash"))
+
+        client.lever(Publicatiedoel("aanmeld"), event)
+
+        val headers = ontvangenHeaders()
+
+        assertFalse(headers.containsKey("upgrade"), "h2c-upgrade aangeboden: $headers")
+        assertFalse(headers.containsKey("http2-settings"), "h2c-upgrade aangeboden: $headers")
+    }
+
+    @Test
     fun `grant-hash met omringende whitespace gaat getrimd de header in`() {
         // Een hash komt via een env-var uit een gegenereerd bestand en krijgt makkelijk een
         // newline mee; de outway antwoordt daarop met 400 UNKNOWN_GRANT_HASH_IN_HEADER.

--- a/services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/DownstreamClientTest.kt
+++ b/services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/DownstreamClientTest.kt
@@ -10,6 +10,7 @@ import nl.rijksoverheid.moz.fbs.common.fsc.FscOutwayHeaders
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -525,46 +526,33 @@ class DownstreamClientTest {
 
     @Test
     fun `een intern adres zonder grant-hash blijft geweigerd`() {
-        every { config.downstreams() } returns mapOf("aanmeld" to DownstreamStub("https://10.0.0.1:8443/events"))
-
-        val resultaat = client.lever(Publicatiedoel("aanmeld"), event)
+        val resultaat = client.valideerUrl("https://10.0.0.1:8443/events", viaOutway = false)
 
         assertTrue(
-            resultaat is DownstreamResultaat.ConfiguratieFout,
+            resultaat != null && resultaat.reden.contains("SSRF"),
             "een RFC1918-adres zonder grant-hash hoort op de SSRF-blocklist te stranden, kreeg: $resultaat",
         )
-        assertTrue((resultaat as DownstreamResultaat.ConfiguratieFout).reden.contains("SSRF"))
     }
 
     @Test
     fun `een intern adres mag wel met grant-hash - het contract bepaalt de bestemming`() {
         // De outway luistert op een adres dat naar RFC1918 resolveert; de blocklist zou dat pad
-        // blokkeren terwijl het FSC-contract achter de hash de bestemming al vastlegt. Geen echte
-        // call: het adres is niet-routeerbaar, dus een netwerk-/timeoutfout bewíjst dat de
-        // validatie 'm heeft doorgelaten. Een ConfiguratieFout zou betekenen dat hij vóór het
-        // netwerk is afgekeurd.
-        every { config.downstreams() } returns
-            mapOf("aanmeld" to DownstreamStub("https://10.255.255.1:8443/events", "hash"))
+        // blokkeren terwijl het FSC-contract achter de hash de bestemming al vastlegt.
+        val resultaat = client.valideerUrl("https://10.255.255.1:8443/events", viaOutway = true)
 
-        val resultaat = client.lever(Publicatiedoel("aanmeld"), event)
-
-        assertFalse(
-            resultaat is DownstreamResultaat.ConfiguratieFout,
-            "met een grant-hash hoort de SSRF-blocklist niet te gelden, kreeg: $resultaat",
-        )
+        assertNull(resultaat, "met een grant-hash hoort de SSRF-blocklist niet te gelden")
     }
 
     @Test
     fun `de TLS-eis blijft gelden voor een outway-downstream`() {
-        // De SSRF-uitzondering is er één, niet twee: buiten loopback blijft TLS verplicht, ook met
-        // een grant-hash. Anders zou een grant-hash in de config stilzwijgend plaintext-verkeer
-        // naar een externe host toestaan.
-        every { config.downstreams() } returns
-            mapOf("aanmeld" to DownstreamStub("http://prod.example.com/events", "hash"))
+        // De uitzondering is er één, niet twee: buiten loopback blijft TLS verplicht, ook met een
+        // grant-hash. Anders zou een grant-hash in de config stilzwijgend plaintext-verkeer naar
+        // een externe host toestaan.
+        val resultaat = client.valideerUrl("http://prod.example.com/events", viaOutway = true)
 
-        val resultaat = client.lever(Publicatiedoel("aanmeld"), event)
-
-        assertTrue(resultaat is DownstreamResultaat.ConfiguratieFout)
-        assertTrue((resultaat as DownstreamResultaat.ConfiguratieFout).reden.contains("TLS"))
+        assertTrue(
+            resultaat != null && resultaat.reden.contains("TLS"),
+            "plain http buiten loopback hoort ook met grant-hash af te vallen, kreeg: $resultaat",
+        )
     }
 }

--- a/services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/DownstreamClientTest.kt
+++ b/services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/DownstreamClientTest.kt
@@ -6,13 +6,18 @@ import io.mockk.every
 import io.mockk.mockk
 import io.opentelemetry.api.OpenTelemetry
 import jakarta.enterprise.inject.Instance
+import nl.rijksoverheid.moz.fbs.common.fsc.FscOutwayHeaders
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.NullSource
+import org.junit.jupiter.params.provider.ValueSource
 import java.time.Instant
+import java.util.Optional
 import java.util.UUID
 
 /**
@@ -26,8 +31,12 @@ import java.util.UUID
  */
 class DownstreamClientTest {
 
-    private class DownstreamStub(private val u: String) : PublicatieConfig.Downstream {
+    private class DownstreamStub(
+        private val u: String,
+        private val hash: String? = null,
+    ) : PublicatieConfig.Downstream {
         override fun url(): String = u
+        override fun grantHash(): Optional<String> = Optional.ofNullable(hash)
         override fun maxPogingen(): Int = 5
         override fun backoff(): PublicatieConfig.Backoff = object : PublicatieConfig.Backoff {
             override fun basis(): java.time.Duration = java.time.Duration.ofSeconds(1)
@@ -430,5 +439,116 @@ class DownstreamClientTest {
         // Doel-assertie: tracestate is niet aanwezig (case-insensitive header-keys).
         val tracestateAanwezig = headers.keys.any { it.equals("tracestate", ignoreCase = true) }
         assertFalse(tracestateAanwezig, "tracestate header lekt naar downstream: $headers")
+    }
+
+    /**
+     * Headers van de embedded server, met kleine-letter-sleutels. `HttpExchange` normaliseert
+     * headernamen naar `Capitalized-Case`, dus zoeken op de exacte constante zou missen.
+     */
+    private fun ontvangenHeaders(): Map<String, List<String>> {
+        org.awaitility.Awaitility.await()
+            .atMost(2, java.util.concurrent.TimeUnit.SECONDS)
+            .until { server.aantalAanroepen >= 1 }
+
+        return server.headers.single().mapKeys { (naam, _) -> naam.lowercase() }
+    }
+
+    @ParameterizedTest(name = "grant-hash [{0}] levert geen FSC-headers")
+    @NullSource
+    @ValueSource(strings = ["", "   "])
+    fun `zonder bruikbare grant-hash gaan er geen FSC-headers mee`(hash: String?) {
+        every { config.downstreams() } returns mapOf("aanmeld" to DownstreamStub(server.baseUrl, hash))
+
+        val resultaat = client.lever(Publicatiedoel("aanmeld"), event)
+
+        assertEquals(DownstreamResultaat.Geslaagd, resultaat)
+
+        val headers = ontvangenHeaders()
+
+        assertFalse(headers.containsKey(FscOutwayHeaders.GRANT_HASH_HEADER.lowercase()))
+        assertFalse(headers.containsKey(FscOutwayHeaders.TRANSACTION_ID_HEADER.lowercase()))
+    }
+
+    @Test
+    fun `met grant-hash gaan beide FSC-outway-headers mee`() {
+        val hash = "\$1\$4\$k4rwlWTsCM_j89Fc3nrbnQa9-KB43"
+
+        every { config.downstreams() } returns mapOf("aanmeld" to DownstreamStub(server.baseUrl, hash))
+
+        val resultaat = client.lever(Publicatiedoel("aanmeld"), event)
+
+        assertEquals(DownstreamResultaat.Geslaagd, resultaat)
+
+        val headers = ontvangenHeaders()
+
+        assertEquals(hash, headers.getValue(FscOutwayHeaders.GRANT_HASH_HEADER.lowercase()).single())
+
+        val transactionId = UUID.fromString(
+            headers.getValue(FscOutwayHeaders.TRANSACTION_ID_HEADER.lowercase()).single(),
+        )
+
+        assertEquals(7, transactionId.version(), "de outway weigert een transaction-id die geen UUID v7 is")
+    }
+
+    @Test
+    fun `grant-hash met omringende whitespace gaat getrimd de header in`() {
+        // Een hash komt via een env-var uit een gegenereerd bestand en krijgt makkelijk een
+        // newline mee; de outway antwoordt daarop met 400 UNKNOWN_GRANT_HASH_IN_HEADER.
+        every { config.downstreams() } returns
+            mapOf("aanmeld" to DownstreamStub(server.baseUrl, "  hash-met-ruimte  "))
+
+        client.lever(Publicatiedoel("aanmeld"), event)
+
+        val headers = ontvangenHeaders()
+
+        assertEquals(
+            "hash-met-ruimte",
+            headers.getValue(FscOutwayHeaders.GRANT_HASH_HEADER.lowercase()).single(),
+        )
+    }
+
+    @Test
+    fun `een intern adres zonder grant-hash blijft geweigerd`() {
+        every { config.downstreams() } returns mapOf("aanmeld" to DownstreamStub("https://10.0.0.1:8443/events"))
+
+        val resultaat = client.lever(Publicatiedoel("aanmeld"), event)
+
+        assertTrue(
+            resultaat is DownstreamResultaat.ConfiguratieFout,
+            "een RFC1918-adres zonder grant-hash hoort op de SSRF-blocklist te stranden, kreeg: $resultaat",
+        )
+        assertTrue((resultaat as DownstreamResultaat.ConfiguratieFout).reden.contains("SSRF"))
+    }
+
+    @Test
+    fun `een intern adres mag wel met grant-hash - het contract bepaalt de bestemming`() {
+        // De outway luistert op een adres dat naar RFC1918 resolveert; de blocklist zou dat pad
+        // blokkeren terwijl het FSC-contract achter de hash de bestemming al vastlegt. Geen echte
+        // call: het adres is niet-routeerbaar, dus een netwerk-/timeoutfout bewíjst dat de
+        // validatie 'm heeft doorgelaten. Een ConfiguratieFout zou betekenen dat hij vóór het
+        // netwerk is afgekeurd.
+        every { config.downstreams() } returns
+            mapOf("aanmeld" to DownstreamStub("https://10.255.255.1:8443/events", "hash"))
+
+        val resultaat = client.lever(Publicatiedoel("aanmeld"), event)
+
+        assertFalse(
+            resultaat is DownstreamResultaat.ConfiguratieFout,
+            "met een grant-hash hoort de SSRF-blocklist niet te gelden, kreeg: $resultaat",
+        )
+    }
+
+    @Test
+    fun `de TLS-eis blijft gelden voor een outway-downstream`() {
+        // De SSRF-uitzondering is er één, niet twee: buiten loopback blijft TLS verplicht, ook met
+        // een grant-hash. Anders zou een grant-hash in de config stilzwijgend plaintext-verkeer
+        // naar een externe host toestaan.
+        every { config.downstreams() } returns
+            mapOf("aanmeld" to DownstreamStub("http://prod.example.com/events", "hash"))
+
+        val resultaat = client.lever(Publicatiedoel("aanmeld"), event)
+
+        assertTrue(resultaat is DownstreamResultaat.ConfiguratieFout)
+        assertTrue((resultaat as DownstreamResultaat.ConfiguratieFout).reden.contains("TLS"))
     }
 }

--- a/services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/PublicatieClaimVerwerkerEdgeCaseTest.kt
+++ b/services/berichtenmagazijn/src/test/kotlin/nl/rijksoverheid/moz/fbs/berichtenmagazijn/publicatie/PublicatieClaimVerwerkerEdgeCaseTest.kt
@@ -40,6 +40,7 @@ class PublicatieClaimVerwerkerEdgeCaseTest {
 
     private class DownstreamStub(private val u: String, private val max: Int = 3) : PublicatieConfig.Downstream {
         override fun url(): String = u
+        override fun grantHash(): java.util.Optional<String> = java.util.Optional.empty()
         override fun maxPogingen(): Int = max
         override fun backoff(): PublicatieConfig.Backoff = object : PublicatieConfig.Backoff {
             override fun basis(): Duration = Duration.ofSeconds(1)


### PR DESCRIPTION
Sluit het notificatie-pad aan op de FSC-mesh: het berichtenmagazijn levert zijn CloudEvents af
door zijn eigen outway bij de inway van de aanbieder, in plaats van rechtstreeks op de stub.
Daarmee loopt het verkeer tussen `logius` en `magazijn-a` voortaan beide kanten op — ophalen de
ene kant, pushen de andere — en draagt elke peer twee rollen.

## Twee afwijkingen van het issue, beide bewust

**Niet config-only.** De outway kiest de doel-inway op `Fsc-Grant-Hash` en eist een
`Fsc-Transaction-Id` in UUID-v7. Die headers worden gezet door JAX-RS-clientfilters, en
`DownstreamClient` is bewust géén JAX-RS-client — aantal en URL's van downstreams komen uit config.
Alleen de URL ombuigen levert `service not found`. Vandaar een optionele grant-hash per downstream
plus het headerpaar op de uitgaande request; leeg of afwezig betekent onveranderd rechtstreeks
verkeer.

**Geen eigen `notificatie`-peer.** De dienst staat op de bestaande `logius`-inway, naast
`profiel-service`. Een derde peer-stack kost een volledige compose-, PKI- en
adresruimte-duplicatie zonder iets extra's te bewijzen over de eigenschap die dit issue aantoont:
een magazijn dat uitgaand door FSC pusht. Verhuizen is later een publicatie- en contractwijziging,
geen wijziging aan het magazijn.

## SSRF-uitzondering

Een downstream mét grant-hash slaat de SSRF-blocklist over. De bestemming volgt daar uit het
FSC-contract achter die hash in plaats van uit onze URL, en op ZAD resolveert de outway naar een
RFC1918-adres waar de blocklist anders op afketst. De TLS-eis blijft onverkort staan (apart
getest). Een actieve uitzondering logt `DOWNSTREAM_VIA_OUTWAY` met de betrokken downstreams — bij
de eerste aflevering, niet bij boot: `DownstreamClient` is `@ApplicationScoped` en dus lui
geconstrueerd, net als bij het al bestaande `DOWNSTREAM_URL_VALIDATIE_UIT`.

## Twee fixes die buiten de scope van #784 vielen

**Paginatie in de contract-bootstrap** (`97260f45`). De bootstrap brak af zodra de manager een
`next_cursor` meestuurde, in de aanname dat een cursor betekent dat de lijst is afgekapt. OpenFSC
v2.5.2 zet die cursor op élke pagina die rijen bevat; de volgende pagina komt leeg terug met een
lege cursor. De bootstrap werkte daardoor alleen op een volstrekt lege manager en faalde elke run
daarna — terwijl beide helften op ZAD juist in een lus draaien. Dit is een defect van vóór dit
werk dat hier aan het licht kwam; apart vastgelegd in #964.

**HTTP/1.1 richting de outway** (`ed249cdd`). De JDK-client onderhandelt op een plain-http-doel
eerst een upgrade naar h2c. De outway proxyt die hop-by-hop-headers ongewijzigd door naar de inway,
waar het Go-http2-transport ze weigert; de outway antwoordt 502 en het magazijn blijft
herproberen. De FSC-data-plane is HTTP/1.1 — dat staat zo in het publicatiecontract van elke
dienst. Alleen het outway-pad wordt gepind; rechtstreekse downstreams mogen h2 blijven doen.

## Verificatie

- `./mvnw clean verify -pl services/berichtenmagazijn -am`: 412 tests groen, detekt 0 bevindingen,
  JaCoCo-gate gehaald.
- Lokaal end-to-end, met beide richtingen tegelijk door de mesh:
  `federatie/smoke-notificatie.sh` (nieuw), `smoke-keten.sh` en `smoke-contract.sh` alle groen.
  De notificatie-smoke bewijst het data-pad met een uniek merk per run, een nieuwe gedeelde
  transactie in beide txlogs, het ongewijzigd doorgegeven `application/cloudevents+json`, en
  precies één aflevering.
- Reviewronde gedraaid en verwerkt (`6f07ae71`), waarna de smokes opnieuw zijn gedraaid omdat een
  van de bevindingen de assert-logica raakte.

De ZAD-uitrol blijft handmatig vervolgwerk; de runbooks van beide peers zijn bijgewerkt met de
stappen en met het nieuwe outway-component bij `magazijn-a`.

Ontwerp: `docs/plans/2026-08-17-notificatie-via-fsc-design.md`
Plan: `docs/plans/2026-08-17-notificatie-via-fsc-plan.md`

Werkt aan #784.
