### PR TITLE
docs: actualiseer README naar de huidige repo en modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Grens tussen NL en EN — geldt voor identifiers én comments/KDoc:
 - **GroupId:** `nl.rijksoverheid.moz`
 - **Packages:** `nl.rijksoverheid.moz.fbs.<module-naam>.*` — `fbs` reserveert een productnamespace onder de MOZ-organisatie-groupId, zowel voor services als voor gedeelde libraries.
 - **Monorepo structuur:** `services/<service-naam>/` als Maven module
-- **Actieve modules:** `services/berichtenmagazijn`, `services/berichtenuitvraag`. Gedeelde libraries: `libraries/fbs-common` (JAX-RS filters, exception mappers, identificatienummers), `libraries/fbs-magazijnregister` (1:1-koppeling afzender-OIN ↔ magazijn achter de `Magazijnregister`-facade) en `libraries/fbs-berichtensessiecache` (in-process sessiecache achter de `Sessiecache`-facade; alles daarbinnen is `internal`). `services/berichtenlijst/` bestaat als directory maar is niet actief.
+- **Actieve modules:** `services/berichtenmagazijn`, `services/berichtenuitvraag` en `services/demo-console` (bedieningspaneel voor demo's). Gedeelde libraries: `libraries/fbs-common` (JAX-RS filters, exception mappers, identificatienummers), `libraries/fbs-magazijnregister` (1:1-koppeling afzender-OIN ↔ magazijn achter de `Magazijnregister`-facade) en `libraries/fbs-berichtensessiecache` (in-process sessiecache achter de `Sessiecache`-facade; alles daarbinnen is `internal`).
 - **Magazijnregister:** één magazijn per deelnemende organisatie; het `magazijnId` dat door DTO's/SSE stroomt ís de afzender-OIN (publiek, geen PII). Config-conventie: `magazijnen."<OIN>".{url,naam}` — de map-key is de OIN, dus dubbele OIN's zijn structureel onmogelijk. `ConfigMagazijnregister` valideert keys/URLs fail-fast bij boot (https-eis buiten dev/test). Consumers (sessiecache-aggregatie, `MagazijnRouter`-routering) lezen uitsluitend de `Magazijnregister`-facade; database-opslag + beheer-interface volgen later.
 - **Gegenereerde code:** `target/generated-sources/openapi/` — nooit handmatig aanpassen
 - **Bestandsnamen:** geen spaties in bestands- of mapnamen; gebruik `kebab-case` of `snake_case` (documentatie/markdown/configuratie) of `PascalCase`/`camelCase` (Kotlin/Java sources) — zodat shellscripts, build-tools en CI-pipelines zonder quoting werken.
@@ -240,13 +240,12 @@ géén uitgeschakeld component**).
 | `libraries/fbs-berichtensessiecache/`  | In-process sessiecache-library (`Sessiecache`-facade, Redis)    |
 | `services/berichtenuitvraag/src/main/resources/openapi/berichtenuitvraag-api.yaml` | OpenAPI spec frontend-API |
 | `libraries/fbs-common/`                | Gedeelde JAX-RS filters en exception mappers                    |
-| `services/berichtenmagazijn/pom.xml`   | Module POM (OpenAPI generator, H2, JPA, Fault Tolerance)        |
+| `services/berichtenmagazijn/pom.xml`   | Module POM (OpenAPI generator, PostgreSQL + Flyway, JPA, Fault Tolerance) |
 | `services/berichtenmagazijn/src/main/resources/openapi/berichtenmagazijn-api.yaml` | OpenAPI spec Aanlever API |
 | `docs/architecture/`                   | C4 model (Structurizr DSL)                                      |
 | `bruno/<service-naam>/`                | Bruno-collectie per service (handmatige / exploratieve API-requests tegen de lokale dev-mode) |
 | `compose.yaml`                         | Lokale dev-omgeving (Redis, WireMock, PostgreSQL)               |
-| `.github/workflows/`                   | CI: CodeQL security scanning, Scorecard, Architecture validatie |
-| `.github/CODEOWNERS`                   | Code ownership (`@MinBZK/mijnoverheid-zakelijk`)                |
+| `.github/workflows/`                   | CI: test + coverage, detekt, CodeQL, Scorecard, ClusterFuzzLite, architectuursite, ZAD-deploy en preview-cleanup |
 
 ## Omgevingsvariabelen
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,7 @@ docker compose up -d                                             # Start Redis, 
 ./mvnw clean test -pl services/berichtenmagazijn -am             # Tests berichtenmagazijn
 ./mvnw clean verify -pl services/berichtenmagazijn -am           # Volledige suite + JaCoCo (Docker vereist)
 ./mvnw quarkus:dev -pl services/berichtenmagazijn                # Dev mode (poort 8090)
+./mvnw clean test -pl services/demo-console -am                  # Tests demo-console (pure JVM)
 ```
 
 ### Build- en test-warnings nalopen
@@ -244,8 +245,9 @@ géén uitgeschakeld component**).
 | `services/berichtenmagazijn/src/main/resources/openapi/berichtenmagazijn-api.yaml` | OpenAPI spec Aanlever API |
 | `docs/architecture/`                   | C4 model (Structurizr DSL)                                      |
 | `bruno/<service-naam>/`                | Bruno-collectie per service (handmatige / exploratieve API-requests tegen de lokale dev-mode) |
+| `services/demo-console/`               | Demo-bedieningspaneel (pure-JVM-tests, geen JaCoCo-gate)        |
 | `compose.yaml`                         | Lokale dev-omgeving (Redis, WireMock, PostgreSQL)               |
-| `.github/workflows/`                   | CI: test + coverage, detekt, CodeQL, Scorecard, ClusterFuzzLite, architectuursite, ZAD-deploy en preview-cleanup |
+| `.github/workflows/`                   | CI: tests + coverage, detekt, CodeQL, Scorecard, ClusterFuzzLite, pin-consistentie, architectuursite, FSC-harness en ZAD-deploy — zie de directory voor de volledige lijst |
 
 ## Omgevingsvariabelen
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,6 +244,7 @@ géén uitgeschakeld component**).
 | `services/berichtenmagazijn/pom.xml`   | Module POM (OpenAPI generator, PostgreSQL + Flyway, JPA, Fault Tolerance) |
 | `services/berichtenmagazijn/src/main/resources/openapi/berichtenmagazijn-api.yaml` | OpenAPI spec Aanlever API |
 | `docs/architecture/`                   | C4 model (Structurizr DSL)                                      |
+| `docs/ontwikkelen.md`                  | Lokale ontwikkelgids: tests, kwaliteitsgates, linting, tweede magazijn, configuratie |
 | `bruno/<service-naam>/`                | Bruno-collectie per service (handmatige / exploratieve API-requests tegen de lokale dev-mode) |
 | `services/demo-console/`               | Demo-bedieningspaneel (pure-JVM-tests, geen JaCoCo-gate)        |
 | `compose.yaml`                         | Lokale dev-omgeving (Redis, WireMock, PostgreSQL)               |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Proof of Concept Berichtenbox voor MijnOverheid Zakelijk (MOZa) binnen het Feder
 ## Inleiding
 
 Dit project is een Proof of Concept voor de Berichtenbox binnen het Federatief Berichtenstelsel,
-beschreven op https://www.logius.nl/onze-dienstverlening/interactie/federatief-berichten-stelsel.
+beschreven op
+<https://www.logius.nl/onze-dienstverlening/interactie/federatief-berichten-stelsel>.
 
 ## Doel
 
@@ -23,29 +24,34 @@ voor het portaal.
 - **Berichtenmagazijn** — decentrale opslag per organisatie; ontvangt aangeleverde berichten
   (Aanlever-API) en levert ze uit aan de uitvraag.
 - **Berichtenuitvraag** — frontend-API voor het portaal: bevraagt alle magazijnen van de ontvanger,
-  streamt voortgang via SSE en bedient lijst, zoeken, detail en bijlagen.
+  streamt voortgang via SSE, bedient lijst, zoeken, detail en bijlagen, en neemt aanmeldingen
+  van magazijnen aan.
 - **Demo-console** — bedieningspaneel voor demonstraties (magazijnen legen, dataset laden,
-  berichten opvoeren).
+  berichten opvoeren). Draait alleen mee in de demo-stack.
 
 De uitvraag heeft geen losse berichtensessiecache-service meer: die is opgegaan in
 `berichtenuitvraag` als in-process library, met Redis als gedeelde backing store.
-Het berichtnotificatieprofiel en de notificatiedienst zitten niet in deze repository — lokaal en op
-de testomgeving draaien die als stubs.
+De notificatievoorkeuren en toestemming van de ontvanger komen van een externe Profiel-service:
+die wordt hier wel bevraagd (`libraries/fbs-common`, package `profiel`), maar niet gebouwd —
+lokaal en op de testomgeving draait die, net als de notificatiedienst, als stub.
 
 ## Repostructuur
 
-| Pad                                | Wat                                                                        |
-|------------------------------------|----------------------------------------------------------------------------|
-| `services/berichtenmagazijn/`      | Magazijn-service (PostgreSQL + Flyway, Aanlever-API)                        |
-| `services/berichtenuitvraag/`      | Uitvraag-service (frontend-API, aggregatie, SSE)                            |
-| `services/demo-console/`           | Demo-bedieningspaneel                                                       |
-| `libraries/fbs-common/`            | Gedeelde JAX-RS filters, exception mappers, identificatienummers (BSN/RSIN/OIN) |
-| `libraries/fbs-magazijnregister/`  | Koppeling afzender-OIN ↔ magazijn (`Magazijnregister`-facade)               |
-| `libraries/fbs-berichtensessiecache/` | In-process sessiecache op Redis (`Sessiecache`-facade)                   |
-| `bruno/`                           | Bruno-collecties met voorbeeldrequests per service                          |
-| `demo/`                            | Demo-stack: stubgenerator, smoke-test, omgevingen                           |
-| `docs/`                            | Architectuur (C4/Structurizr), runbooks, plannen, verantwoording            |
-| `wiremock/`, `toxiproxy/`          | Stubs en fault-injectie voor de lokale keten                                |
+De belangrijkste paden:
+
+| Pad                                   | Wat                                                                             |
+|---------------------------------------|---------------------------------------------------------------------------------|
+| `services/berichtenmagazijn/`         | Magazijn-service (PostgreSQL + Flyway, Aanlever-API)                             |
+| `services/berichtenuitvraag/`         | Uitvraag-service (frontend-API, aggregatie, SSE)                                 |
+| `services/demo-console/`              | Demo-bedieningspaneel                                                            |
+| `libraries/fbs-common/`               | Gedeelde JAX-RS filters, exception mappers, identificatienummers (BSN/RSIN/KvK/OIN), Profiel-client |
+| `libraries/fbs-magazijnregister/`     | Koppeling afzender-OIN ↔ magazijn (`Magazijnregister`-facade)                    |
+| `libraries/fbs-berichtensessiecache/` | In-process sessiecache op Redis (`Sessiecache`-facade)                           |
+| `bruno/`                              | Bruno-collecties met voorbeeldrequests per service                                |
+| `demo/`                               | Demo-stack: stubgenerator, smoke-test; `demo/environment/` bevat de FSC-federatieharness |
+| `docs/`                               | Architectuur (C4/Structurizr), runbooks, plannen, verantwoording                  |
+| `wiremock/`, `toxiproxy/`             | Stubs en fault-injection voor de lokale keten                                     |
+| `compose.yaml`                        | Lokale infrastructuur en de volledige demo-stack (`--profile demo`)               |
 
 ## Vereisten
 
@@ -62,7 +68,7 @@ docker compose up -d
 ```
 
 De services draaien elk in hun eigen Quarkus-dev-mode. Start ze in **aparte terminals**
-zodat beide live-reload en de devconsole blijven werken:
+zodat elke instantie live-reload en de devconsole houdt:
 
 ```bash
 # Terminal 1 — berichtenmagazijn (poort 8090)
@@ -74,20 +80,32 @@ zodat beide live-reload en de devconsole blijven werken:
 
 De `compile`-fase vóór `quarkus:dev` zorgt dat de gedeelde modules onder `libraries/`
 (via `-am`) eerst gebouwd worden; zonder `compile` draait Maven alleen het `quarkus:dev`-goal
-en faalt de resolution van bijvoorbeeld `fbs-common-0.1.0-SNAPSHOT.jar` zolang die niet in de
+en faalt de resolution van bijvoorbeeld `fbs-common-<versie>.jar` zolang die niet in de
 lokale Maven-repository staat.
 
 | Service              | API                                              | OpenAPI                                 |
 |----------------------|--------------------------------------------------|-----------------------------------------|
 | berichtenmagazijn    | `http://localhost:8090/api/v1/berichten`         | `http://localhost:8090/openapi.json`    |
 | berichtenuitvraag    | `http://localhost:8086/api/v1/berichten`         | `http://localhost:8086/openapi.json`    |
-| demo-console         | `http://localhost:8095`                          | —                                       |
 
-Een tweede magazijn draai je op 8091, zodat de uitvraag over meerdere magazijnen kan aggregeren:
+Wil je de uitvraag over méér dan één magazijn laten aggregeren, dan draai je een tweede magazijn
+op 8091. Dat is een tweede *organisatie*, dus die heeft een eigen OIN en een eigen database nodig —
+zonder die twee overrides publiceert de instantie onder de identiteit van magazijn A en deelt hij
+diens opslag:
 
 ```bash
-./mvnw quarkus:dev -pl services/berichtenmagazijn -Dquarkus.http.port=8091
+MAGAZIJN_OIN=00000001823288444000 \
+DB_JDBC_URL=jdbc:postgresql://localhost:5433/berichtenmagazijn \
+./mvnw compile quarkus:dev -pl services/berichtenmagazijn -am \
+  -Dquarkus.http.port=8091 -Ddebug=5006
 ```
+
+`localhost:5433` is de `postgres-b`-instantie uit `compose.yaml`; `-Ddebug=5006` voorkomt een
+conflict op de debug-poort van de eerste dev-mode. Voor meer dan twee magazijnen is de demo-stack
+handiger dan losse dev-modes.
+
+De demo-console (`http://localhost:8095`) hoort bij de demo-stack hieronder en start niet mee in
+dev-mode.
 
 ## Demo-stack (alles in containers)
 
@@ -128,7 +146,8 @@ Sla het generatiescript niet over: compose maakt een ontbrekend mount-pad aan al
 waarna `magazijnen-stubs.properties` een map wordt en de uitvraag niet meer start.
 
 Zónder `--profile demo` start compose alleen de infrastructuur (Redis, de drie
-Postgres-instanties, WireMock). Gebruik die modus tijdens het ontwikkelen en draai de services met
+Postgres-instanties en de WireMock-stubs voor magazijnen, profiel, aanmelden en
+notificaties). Gebruik die modus tijdens het ontwikkelen en draai de services met
 `quarkus:dev` zoals hierboven — in een container kost elke codewijziging een image-build.
 
 De poorten zijn in beide modi gelijk (8090, 8091, 8086), dus de Bruno-collectie en de
@@ -138,7 +157,7 @@ poortconflict.
 De demo-console draait op <http://localhost:8095> — een kaal paneel om de magazijnen te
 legen, de basisdataset te laden en random berichten op te voeren.
 
-### Tests draaien
+## Tests draaien
 
 Draai altijd `clean` vóór `test` of `verify`: een achtergebleven `target/` van een andere
 branch-state laat Surefire stale `.class`-bestanden draaien, wat misleidende fouten geeft in
@@ -147,13 +166,14 @@ ongewijzigde code.
 ```bash
 ./mvnw clean test -pl libraries/fbs-common -am                # pure JVM
 ./mvnw clean test -pl libraries/fbs-magazijnregister -am      # pure JVM
+./mvnw clean test -pl services/demo-console -am               # pure JVM
 ./mvnw clean test -pl libraries/fbs-berichtensessiecache -am  # Docker vereist (Testcontainers)
 ./mvnw clean test -pl services/berichtenmagazijn -am          # Docker vereist
 ./mvnw clean test -pl services/berichtenuitvraag -am          # Docker vereist
 ```
 
-`verify` draait bovendien de kwaliteitspoorten — JaCoCo (minimaal 90% line coverage) en
-detekt (`maxIssues: 0`, zonder baseline):
+`verify` draait bovendien de kwaliteitsgates — detekt (`maxIssues: 0`, zonder baseline) voor de
+hele repo, en JaCoCo met minimaal 90% line coverage voor beide services en alle libraries:
 
 ```bash
 ./mvnw clean verify -pl services/berichtenmagazijn -am
@@ -165,23 +185,28 @@ De OpenAPI-specs valideren tegen de NL API Design Rules:
 ```bash
 npx @stoplight/spectral-cli lint services/berichtenmagazijn/src/main/resources/openapi/berichtenmagazijn-api.yaml \
   --ruleset https://static.developer.overheid.nl/adr/ruleset.yaml
+npx @stoplight/spectral-cli lint services/berichtenuitvraag/src/main/resources/openapi/berichtenuitvraag-api.yaml \
+  --ruleset https://static.developer.overheid.nl/adr/ruleset.yaml
 ```
 
-### API-requests handmatig uitvoeren (Bruno)
+## API-requests handmatig uitvoeren (Bruno)
 
 De `bruno/`-folder bevat per service een collectie van voorbeeld-requests die je
 tegen de lokale dev-mode kunt uitvoeren met [Bruno](https://www.usebruno.com/).
 
 - `bruno/berichtenmagazijn/` — aanlever- en beheer-API
-- `bruno/berichtenuitvraag/` — frontend-facade (lijst, zoek, ophalen-SSE, detail, bijlage, PATCH/DELETE)
+- `bruno/berichtenuitvraag/` — frontend-facade (lijst, zoek, ophalen-SSE, detail, bijlage,
+  PATCH/DELETE) en de aanmeld-webhook
 
 Open de folder in Bruno, kies environment `lokaal` en run requests. De collectie
 spiegelt de OpenAPI-spec: nieuwe endpoints in de spec krijgen direct een
 bijbehorende `.bru`-request.
 
-### Configuratie
+## Configuratie
 
-De belangrijkste configuratie staat in `services/berichtenuitvraag/src/main/resources/application.properties`:
+De belangrijkste configuratie staat in
+`services/berichtenuitvraag/src/main/resources/application.properties`. Ingekort weergegeven —
+het bestand zelf bevat per magazijn ook nog de FSC-grant-hash:
 
 ```properties
 # Magazijnregister: de map-key is de afzender-OIN, de waarde het magazijn van die organisatie.
@@ -216,8 +241,9 @@ Verder lezen:
 ## Bijdragen
 
 Wijzigingen gaan altijd via een feature branch en een Pull Request; er wordt niet direct naar
-`main` gepusht. Elke PR draait tests met coverage-rapportage, detekt en CodeQL, en krijgt een
-eigen preview-omgeving. Zie [SUPPORT.md](SUPPORT.md) voor contact en
+`main` gepusht. Een PR die code raakt draait tests met coverage-rapportage en detekt; PR's op
+`main` draaien daarnaast CodeQL en krijgen een eigen preview-omgeving op ZAD. PR's die alleen
+documentatie wijzigen slaan die checks over. Zie [SUPPORT.md](SUPPORT.md) voor contact en
 [GOVERNANCE.md](GOVERNANCE.md) voor besluitvorming.
 
 ## Licentie

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # PoC MOZa Berichtenbox
 
 ![Project Status](https://img.shields.io/badge/life_cycle-pre_alpha-red)
-[![CI](https://github.com/ericwout-overheid/moza-fbs-berichtenbox/actions/workflows/ci.yml/badge.svg)](https://github.com/ericwout-overheid/moza-fbs-berichtenbox/actions/workflows/ci.yml)
+[![Test](https://github.com/MinBZK/moza-poc-fbs-berichtenbox/actions/workflows/test.yml/badge.svg)](https://github.com/MinBZK/moza-poc-fbs-berichtenbox/actions/workflows/test.yml)
+[![detekt](https://github.com/MinBZK/moza-poc-fbs-berichtenbox/actions/workflows/detekt.yml/badge.svg)](https://github.com/MinBZK/moza-poc-fbs-berichtenbox/actions/workflows/detekt.yml)
+[![CodeQL](https://github.com/MinBZK/moza-poc-fbs-berichtenbox/actions/workflows/codeql.yml/badge.svg)](https://github.com/MinBZK/moza-poc-fbs-berichtenbox/actions/workflows/codeql.yml)
 ![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/MinBZK/moza-poc-fbs-berichtenbox/badge)
 
 Proof of Concept Berichtenbox voor MijnOverheid Zakelijk (MOZa) binnen het Federatief Berichtenstelsel (FBS).
@@ -13,19 +15,44 @@ beschreven op https://www.logius.nl/onze-dienstverlening/interactie/federatief-b
 
 ## Doel
 
-Dit Open Source project is opgezet als PoC voor het ontvangen, opslaan en ophalen van berichten binnen MijnOverheid Zakelijk.
-De Berichtenbox bestaat uit de volgende onderdelen:
+Dit Open Source project is opgezet als PoC voor het ontvangen, opslaan en ophalen van berichten
+binnen MijnOverheid Zakelijk. Het stelsel is federatief: elke deelnemende organisatie houdt haar
+eigen berichten in haar eigen magazijn, en de uitvraag haalt ze bij een sessie op en aggregeert ze
+voor het portaal.
 
-- **Berichtensessiecache** - Ophalen en weergeven van berichten
-- **Berichtenmagazijn** - Opslaan van berichten
-- **Berichten Uitvraag Service** - Frontend-API voor het portaal (aggregeert sessiecache + magazijn)
-- **Berichtnotificatieprofiel** - Beheer van notificatievoorkeuren
+- **Berichtenmagazijn** — decentrale opslag per organisatie; ontvangt aangeleverde berichten
+  (Aanlever-API) en levert ze uit aan de uitvraag.
+- **Berichtenuitvraag** — frontend-API voor het portaal: bevraagt alle magazijnen van de ontvanger,
+  streamt voortgang via SSE en bedient lijst, zoeken, detail en bijlagen.
+- **Demo-console** — bedieningspaneel voor demonstraties (magazijnen legen, dataset laden,
+  berichten opvoeren).
+
+De uitvraag heeft geen losse berichtensessiecache-service meer: die is opgegaan in
+`berichtenuitvraag` als in-process library, met Redis als gedeelde backing store.
+Het berichtnotificatieprofiel en de notificatiedienst zitten niet in deze repository — lokaal en op
+de testomgeving draaien die als stubs.
+
+## Repostructuur
+
+| Pad                                | Wat                                                                        |
+|------------------------------------|----------------------------------------------------------------------------|
+| `services/berichtenmagazijn/`      | Magazijn-service (PostgreSQL + Flyway, Aanlever-API)                        |
+| `services/berichtenuitvraag/`      | Uitvraag-service (frontend-API, aggregatie, SSE)                            |
+| `services/demo-console/`           | Demo-bedieningspaneel                                                       |
+| `libraries/fbs-common/`            | Gedeelde JAX-RS filters, exception mappers, identificatienummers (BSN/RSIN/OIN) |
+| `libraries/fbs-magazijnregister/`  | Koppeling afzender-OIN ↔ magazijn (`Magazijnregister`-facade)               |
+| `libraries/fbs-berichtensessiecache/` | In-process sessiecache op Redis (`Sessiecache`-facade)                   |
+| `bruno/`                           | Bruno-collecties met voorbeeldrequests per service                          |
+| `demo/`                            | Demo-stack: stubgenerator, smoke-test, omgevingen                           |
+| `docs/`                            | Architectuur (C4/Structurizr), runbooks, plannen, verantwoording            |
+| `wiremock/`, `toxiproxy/`          | Stubs en fault-injectie voor de lokale keten                                |
 
 ## Vereisten
 
 - Java 21+
 - Maven 3.9+ (of gebruik de meegeleverde Maven wrapper `./mvnw`)
 - Docker (voor lokale services: Redis, WireMock, PostgreSQL)
+- Python 3 (alleen voor het genereren van de demo-magazijnstubs)
 
 ## Snel starten
 
@@ -45,23 +72,26 @@ zodat beide live-reload en de devconsole blijven werken:
 ./mvnw compile quarkus:dev -pl services/berichtenuitvraag -am
 ```
 
-De `compile`-fase vóór `quarkus:dev` zorgt dat de gedeelde module `libraries/fbs-common`
-(via `-am`) eerst gebouwd wordt; zonder `compile` draait Maven alleen het `quarkus:dev`-goal
-en faalt de resolution van `fbs-common-0.1.0-SNAPSHOT.jar` zolang die niet in de lokale
-Maven-repository staat.
+De `compile`-fase vóór `quarkus:dev` zorgt dat de gedeelde modules onder `libraries/`
+(via `-am`) eerst gebouwd worden; zonder `compile` draait Maven alleen het `quarkus:dev`-goal
+en faalt de resolution van bijvoorbeeld `fbs-common-0.1.0-SNAPSHOT.jar` zolang die niet in de
+lokale Maven-repository staat.
 
 | Service              | API                                              | OpenAPI                                 |
 |----------------------|--------------------------------------------------|-----------------------------------------|
 | berichtenmagazijn    | `http://localhost:8090/api/v1/berichten`         | `http://localhost:8090/openapi.json`    |
 | berichtenuitvraag    | `http://localhost:8086/api/v1/berichten`         | `http://localhost:8086/openapi.json`    |
+| demo-console         | `http://localhost:8095`                          | —                                       |
 
-De vroegere losse berichtensessiecache-service is opgegaan in `berichtenuitvraag`
-als in-process library (`libraries/fbs-berichtensessiecache`) met Redis als
-gedeelde backing store.
+Een tweede magazijn draai je op 8091, zodat de uitvraag over meerdere magazijnen kan aggregeren:
+
+```bash
+./mvnw quarkus:dev -pl services/berichtenmagazijn -Dquarkus.http.port=8091
+```
 
 ## Demo-stack (alles in containers)
 
-> **Volledige runbook** — opzet, persona's, alle bedieningsknoppen, de 14 scenario's stap voor stap
+> **Volledige runbook** — opzet, persona's, alle bedieningsknoppen, de scenario's stap voor stap
 > en de valkuilen: [`docs/demo-runbook.md`](docs/demo-runbook.md).
 
 Voor demonstraties draait de volledige keten in containers, zodat opstarten één commando
@@ -110,10 +140,31 @@ legen, de basisdataset te laden en random berichten op te voeren.
 
 ### Tests draaien
 
+Draai altijd `clean` vóór `test` of `verify`: een achtergebleven `target/` van een andere
+branch-state laat Surefire stale `.class`-bestanden draaien, wat misleidende fouten geeft in
+ongewijzigde code.
+
 ```bash
-./mvnw test -pl libraries/fbs-berichtensessiecache -am
-./mvnw test -pl services/berichtenmagazijn -am
-./mvnw test -pl services/berichtenuitvraag -am
+./mvnw clean test -pl libraries/fbs-common -am                # pure JVM
+./mvnw clean test -pl libraries/fbs-magazijnregister -am      # pure JVM
+./mvnw clean test -pl libraries/fbs-berichtensessiecache -am  # Docker vereist (Testcontainers)
+./mvnw clean test -pl services/berichtenmagazijn -am          # Docker vereist
+./mvnw clean test -pl services/berichtenuitvraag -am          # Docker vereist
+```
+
+`verify` draait bovendien de kwaliteitspoorten — JaCoCo (minimaal 90% line coverage) en
+detekt (`maxIssues: 0`, zonder baseline):
+
+```bash
+./mvnw clean verify -pl services/berichtenmagazijn -am
+./mvnw detekt:check                                           # alleen de statische analyse
+```
+
+De OpenAPI-specs valideren tegen de NL API Design Rules:
+
+```bash
+npx @stoplight/spectral-cli lint services/berichtenmagazijn/src/main/resources/openapi/berichtenmagazijn-api.yaml \
+  --ruleset https://static.developer.overheid.nl/adr/ruleset.yaml
 ```
 
 ### API-requests handmatig uitvoeren (Bruno)
@@ -143,6 +194,31 @@ magazijnen."00000000000000100000".naam=Magazijn A
 magazijnen."00000001823288444000".url=${MAGAZIJN_B_URL}
 magazijnen."00000001823288444000".naam=Magazijn B
 ```
+
+Voor productie-instellingen (TLS-eisen op Redis en het Logboek Dataverwerkingen, verplichte
+overrides) geldt de [operator-handleiding](docs/operator-handleiding.md).
+
+## Architectuur en achtergrond
+
+Het C4-model staat als Structurizr DSL in [`docs/architecture/`](docs/architecture/) en wordt
+gepubliceerd op <https://minbzk.github.io/moza-poc-fbs-berichtenbox/>; die site wordt ververst
+zodra er iets in `docs/architecture/` wijzigt (per PR ook als preview).
+
+Verder lezen:
+
+- [Aanpak en keuzes van de PoC](docs/aanpak-en-keuzes.md) — waarom federatief, welke standaarden
+- [Demo-runbook](docs/demo-runbook.md) — de demo-stack en alle scenario's
+- [Operator-handleiding](docs/operator-handleiding.md) — verplichte productie-overrides
+- [Vergelijking VoRijk (Blauwe Knop) vs. FBS Berichtenbox](docs/vergelijking-fbs-vorijk.md)
+- [Analyse: architectuur voor uniforme bronontsluiting](docs/analyse-architectuur-uniforme-bronontsluiting.md)
+- [`docs/plans/`](docs/plans/) — implementatieplannen met de gemaakte ontwerpkeuzes
+
+## Bijdragen
+
+Wijzigingen gaan altijd via een feature branch en een Pull Request; er wordt niet direct naar
+`main` gepusht. Elke PR draait tests met coverage-rapportage, detekt en CodeQL, en krijgt een
+eigen preview-omgeving. Zie [SUPPORT.md](SUPPORT.md) voor contact en
+[GOVERNANCE.md](GOVERNANCE.md) voor besluitvorming.
 
 ## Licentie
 

--- a/README.md
+++ b/README.md
@@ -88,140 +88,24 @@ lokale Maven-repository staat.
 | berichtenmagazijn    | `http://localhost:8090/api/v1/berichten`         | `http://localhost:8090/openapi.json`    |
 | berichtenuitvraag    | `http://localhost:8086/api/v1/berichten`         | `http://localhost:8086/openapi.json`    |
 
-Wil je de uitvraag over méér dan één magazijn laten aggregeren, dan draai je een tweede magazijn
-op 8091. Dat is een tweede *organisatie*, dus die heeft een eigen OIN en een eigen database nodig —
-zonder die twee overrides publiceert de instantie onder de identiteit van magazijn A en deelt hij
-diens opslag:
+## Demo-stack
 
-```bash
-MAGAZIJN_OIN=00000001823288444000 \
-DB_JDBC_URL=jdbc:postgresql://localhost:5433/berichtenmagazijn \
-./mvnw compile quarkus:dev -pl services/berichtenmagazijn -am \
-  -Dquarkus.http.port=8091 -Ddebug=5006
-```
-
-`localhost:5433` is de `postgres-b`-instantie uit `compose.yaml`; `-Ddebug=5006` voorkomt een
-conflict op de debug-poort van de eerste dev-mode. Voor meer dan twee magazijnen is de demo-stack
-handiger dan losse dev-modes.
-
-De demo-console (`http://localhost:8095`) hoort bij de demo-stack hieronder en start niet mee in
-dev-mode.
-
-## Demo-stack (alles in containers)
-
-> **Volledige runbook** — opzet, persona's, alle bedieningsknoppen, de scenario's stap voor stap
-> en de valkuilen: [`docs/demo-runbook.md`](docs/demo-runbook.md).
-
-Voor demonstraties draait de volledige keten in containers, zodat opstarten één commando
-is. Bouw eerst de images met jib — opnieuw nodig na elke codewijziging:
-
-```bash
-./mvnw clean package -DskipTests \
-  -pl services/berichtenmagazijn,services/berichtenuitvraag,services/demo-console -am \
-  -Dquarkus.container-image.build=true \
-  -Dquarkus.container-image.group=fbs-demo \
-  -Dquarkus.container-image.tag=demo
-```
-
-> **CORS voor de Berichtenbox-UI** is een runtime-property, uitsluitend gezet als env-var in
-> het demo-profiel van `compose.yaml` — de `application.properties` van `berichtenuitvraag`
-> bevat geen CORS-config. Enabled zónder `origins` laat alleen same-origin door en de UI op
-> `:8095` roept de API op `:8086` aan, dus de allowlist staat er in compose naast. Prod/ZAD
-> (profiel prod) krijgt geen enabled, dus die images blijven CORS-loos. Geen build-flag nodig.
-
-> **Apple Silicon / ARM:** jib bouwt standaard `linux/amd64` (de ZAD-cluster is amd64).
-> Op een ARM-host draaien die images onder emulatie — voeg
-> `-Dquarkus.jib.platforms=linux/arm64` toe voor native images. Deze flag hoort op de
-> commandoregel en niet in de config, anders wordt ook de CI-/ZAD-build arm64.
-
-Genereer daarna de stub-artefacten, start de stack en controleer de keten:
-
-```bash
-python3 demo/genereer-magazijnen.py   # vult demo/generated/ (git-ignored, dus altijd nodig)
-docker compose --profile demo up -d   # alles in containers
-./demo/smoke.sh                       # rookproef: aanleveren bij beide magazijnen + ophalen
-```
-
-Sla het generatiescript niet over: compose maakt een ontbrekend mount-pad aan als directory,
-waarna `magazijnen-stubs.properties` een map wordt en de uitvraag niet meer start.
+Voor demonstraties draait de volledige keten in containers — images bouwen met jib, stubs
+genereren, `docker compose --profile demo up -d`, en een bedieningspaneel op
+<http://localhost:8095>. Het [demo-runbook](docs/demo-runbook.md) beschrijft de opzet, de
+persona's, alle knoppen en de scenario's stap voor stap.
 
 Zónder `--profile demo` start compose alleen de infrastructuur (Redis, de drie
-Postgres-instanties en de WireMock-stubs voor magazijnen, profiel, aanmelden en
-notificaties). Gebruik die modus tijdens het ontwikkelen en draai de services met
-`quarkus:dev` zoals hierboven — in een container kost elke codewijziging een image-build.
+Postgres-instanties en de WireMock-stubs voor magazijnen, profiel, aanmelden en notificaties).
+Gebruik die modus tijdens het ontwikkelen en draai de services met `quarkus:dev` zoals hierboven —
+in een container kost elke codewijziging een image-build. De poorten zijn in beide modi gelijk,
+dus de Bruno-collectie werkt ongewijzigd; draai ze niet tegelijk, dat geeft een poortconflict.
 
-De poorten zijn in beide modi gelijk (8090, 8091, 8086), dus de Bruno-collectie en de
-omgeving `lokaal` werken ongewijzigd. Draai niet beide modi tegelijk: dat geeft een
-poortconflict.
+## Ontwikkelen
 
-De demo-console draait op <http://localhost:8095> — een kaal paneel om de magazijnen te
-legen, de basisdataset te laden en random berichten op te voeren.
-
-## Tests draaien
-
-Draai altijd `clean` vóór `test` of `verify`: een achtergebleven `target/` van een andere
-branch-state laat Surefire stale `.class`-bestanden draaien, wat misleidende fouten geeft in
-ongewijzigde code.
-
-```bash
-./mvnw clean test -pl libraries/fbs-common -am                # pure JVM
-./mvnw clean test -pl libraries/fbs-magazijnregister -am      # pure JVM
-./mvnw clean test -pl services/demo-console -am               # pure JVM
-./mvnw clean test -pl libraries/fbs-berichtensessiecache -am  # Docker vereist (Testcontainers)
-./mvnw clean test -pl services/berichtenmagazijn -am          # Docker vereist
-./mvnw clean test -pl services/berichtenuitvraag -am          # Docker vereist
-```
-
-`verify` draait bovendien de kwaliteitsgates — detekt (`maxIssues: 0`, zonder baseline) voor de
-hele repo, en JaCoCo met minimaal 90% line coverage voor beide services en alle libraries:
-
-```bash
-./mvnw clean verify -pl services/berichtenmagazijn -am
-./mvnw detekt:check                                           # alleen de statische analyse
-```
-
-De OpenAPI-specs valideren tegen de NL API Design Rules:
-
-```bash
-npx @stoplight/spectral-cli lint services/berichtenmagazijn/src/main/resources/openapi/berichtenmagazijn-api.yaml \
-  --ruleset https://static.developer.overheid.nl/adr/ruleset.yaml
-npx @stoplight/spectral-cli lint services/berichtenuitvraag/src/main/resources/openapi/berichtenuitvraag-api.yaml \
-  --ruleset https://static.developer.overheid.nl/adr/ruleset.yaml
-```
-
-## API-requests handmatig uitvoeren (Bruno)
-
-De `bruno/`-folder bevat per service een collectie van voorbeeld-requests die je
-tegen de lokale dev-mode kunt uitvoeren met [Bruno](https://www.usebruno.com/).
-
-- `bruno/berichtenmagazijn/` — aanlever- en beheer-API
-- `bruno/berichtenuitvraag/` — frontend-facade (lijst, zoek, ophalen-SSE, detail, bijlage,
-  PATCH/DELETE) en de aanmeld-webhook
-
-Open de folder in Bruno, kies environment `lokaal` en run requests. De collectie
-spiegelt de OpenAPI-spec: nieuwe endpoints in de spec krijgen direct een
-bijbehorende `.bru`-request.
-
-## Configuratie
-
-De belangrijkste configuratie staat in
-`services/berichtenuitvraag/src/main/resources/application.properties`. Ingekort weergegeven —
-het bestand zelf bevat per magazijn ook nog de FSC-grant-hash:
-
-```properties
-# Magazijnregister: de map-key is de afzender-OIN, de waarde het magazijn van die organisatie.
-# %dev vult de URL uit een env-var met de lokale poort als default, zodat dezelfde
-# configuratie in een container naar container-DNS wijst.
-# %dev-default van MAGAZIJN_A_URL: http://localhost:8090
-magazijnen."00000000000000100000".url=${MAGAZIJN_A_URL}
-magazijnen."00000000000000100000".naam=Magazijn A
-# %dev-default van MAGAZIJN_B_URL: http://localhost:8091
-magazijnen."00000001823288444000".url=${MAGAZIJN_B_URL}
-magazijnen."00000001823288444000".naam=Magazijn B
-```
-
-Voor productie-instellingen (TLS-eisen op Redis en het Logboek Dataverwerkingen, verplichte
-overrides) geldt de [operator-handleiding](docs/operator-handleiding.md).
+[`docs/ontwikkelen.md`](docs/ontwikkelen.md) beschrijft het lokale werk: tests per module, de
+kwaliteitsgates (JaCoCo, detekt), de OpenAPI-specs linten, een tweede magazijn draaien, de
+Bruno-collecties en de configuratie van het magazijnregister.
 
 ## Architectuur en achtergrond
 
@@ -232,8 +116,10 @@ zodra er iets in `docs/architecture/` wijzigt (per PR ook als preview).
 Verder lezen:
 
 - [Aanpak en keuzes van de PoC](docs/aanpak-en-keuzes.md) — waarom federatief, welke standaarden
+- [Ontwikkelen](docs/ontwikkelen.md) — tests, kwaliteitsgates, linting, lokale configuratie
 - [Demo-runbook](docs/demo-runbook.md) — de demo-stack en alle scenario's
 - [Operator-handleiding](docs/operator-handleiding.md) — verplichte productie-overrides
+- [`docs/operations/`](docs/operations/) — runbooks per operationele procedure (alerts, schema-bumps)
 - [Vergelijking VoRijk (Blauwe Knop) vs. FBS Berichtenbox](docs/vergelijking-fbs-vorijk.md)
 - [Analyse: architectuur voor uniforme bronontsluiting](docs/analyse-architectuur-uniforme-bronontsluiting.md)
 - [`docs/plans/`](docs/plans/) — implementatieplannen met de gemaakte ontwerpkeuzes

--- a/docs/demo-runbook.md
+++ b/docs/demo-runbook.md
@@ -71,11 +71,23 @@ Er zijn twee modi met dezelfde compose:
 > kan dat bestand daarna ook niet meer schrijven (eerst `rm -rf demo/generated/`). Het is één
 > idempotent commando; sla het niet over.
 
+Controleer de keten met een rookproef — aanleveren bij beide magazijnen en ophalen via de uitvraag:
+
+```bash
+./demo/smoke.sh
+```
+
 Openen na start:
 - **Bedieningspaneel:** <http://localhost:8095/>
 - **Berichtenbox (ondernemer):** <http://localhost:8095/berichtenbox.html>
 
 Afsluiten: `docker compose --profile demo down` (voeg `-v` toe om de Postgres-volumes te wissen).
+
+> **Waarom CORS geen build-flag is:** CORS is een runtime-property en staat uitsluitend als env-var
+> in het demo-profiel van `compose.yaml`; de `application.properties` van `berichtenuitvraag` bevat
+> geen CORS-config. Enabled zónder `origins` laat alleen same-origin door, en de UI op `:8095`
+> roept de API op `:8086` aan — vandaar de allowlist ernaast in compose. Het prod-profiel zet CORS
+> niet aan, dus de ZAD-images blijven CORS-loos zonder dat de build iets hoeft te weten.
 
 ### Podman in plaats van Docker
 

--- a/docs/ontwikkelen.md
+++ b/docs/ontwikkelen.md
@@ -1,0 +1,103 @@
+# Ontwikkelen aan de FBS Berichtenbox
+
+Alles wat je lokaal nodig hebt om te bouwen, testen en handmatig tegen de API's aan te praten.
+Voor het opzetten van de demo-stack: [`demo-runbook.md`](demo-runbook.md). Voor draaien in
+productie: [`operator-handleiding.md`](operator-handleiding.md).
+
+## Tests draaien
+
+Draai altijd `clean` vóór `test` of `verify`: een achtergebleven `target/` van een andere
+branch-state laat Surefire stale `.class`-bestanden draaien, wat misleidende fouten geeft in
+ongewijzigde code.
+
+```bash
+./mvnw clean test -pl libraries/fbs-common -am                # pure JVM
+./mvnw clean test -pl libraries/fbs-magazijnregister -am      # pure JVM
+./mvnw clean test -pl services/demo-console -am               # pure JVM
+./mvnw clean test -pl libraries/fbs-berichtensessiecache -am  # Docker vereist (Testcontainers)
+./mvnw clean test -pl services/berichtenmagazijn -am          # Docker vereist
+./mvnw clean test -pl services/berichtenuitvraag -am          # Docker vereist
+```
+
+De modules die Docker vereisen draaien hun infrastructuur via Quarkus Dev Services
+(Testcontainers) — je hoeft `docker compose up -d` daar niet apart voor te starten.
+
+## Kwaliteitsgates
+
+`verify` draait naast de tests de gates die ook in CI staan: detekt (`maxIssues: 0`, zonder
+baseline) voor de hele repo, en JaCoCo met minimaal 90% line coverage voor beide services en alle
+libraries. De demo-console heeft geen coverage-gate.
+
+```bash
+./mvnw clean verify -pl services/berichtenmagazijn -am
+./mvnw detekt:check                                           # alleen de statische analyse
+```
+
+Een detekt-bevinding faalt de build en hoort echt opgelost te worden; een bewuste, onvermijdelijke
+uitzondering krijgt een inline `@Suppress("Rule")` met motivatie, zodat de afweging in review
+zichtbaar is.
+
+## OpenAPI-specs linten
+
+De specs zijn de bron van waarheid voor beide API's en moeten voldoen aan de NL API Design Rules:
+
+```bash
+npx @stoplight/spectral-cli lint services/berichtenmagazijn/src/main/resources/openapi/berichtenmagazijn-api.yaml \
+  --ruleset https://static.developer.overheid.nl/adr/ruleset.yaml
+npx @stoplight/spectral-cli lint services/berichtenuitvraag/src/main/resources/openapi/berichtenuitvraag-api.yaml \
+  --ruleset https://static.developer.overheid.nl/adr/ruleset.yaml
+```
+
+## Een tweede magazijn draaien
+
+Het stelsel is federatief, dus interessant gedrag (aggregatie, partial failure) zie je pas met meer
+dan één magazijn. Een tweede instantie is een tweede *organisatie* en heeft daarom een eigen OIN en
+een eigen database nodig — zonder die twee overrides publiceert hij onder de identiteit van magazijn
+A en deelt hij diens opslag, en aggregeer je dus twee views op één magazijn:
+
+```bash
+MAGAZIJN_OIN=00000001823288444000 \
+DB_JDBC_URL=jdbc:postgresql://localhost:5433/berichtenmagazijn \
+./mvnw compile quarkus:dev -pl services/berichtenmagazijn -am \
+  -Dquarkus.http.port=8091 -Ddebug=5006
+```
+
+`localhost:5433` is de `postgres-b`-instantie uit `compose.yaml` (start mee met
+`docker compose up -d`); `-Ddebug=5006` voorkomt een conflict op de debug-poort van de eerste
+dev-mode. Voor meer dan twee magazijnen is de demo-stack handiger dan losse dev-modes.
+
+## API-requests handmatig uitvoeren (Bruno)
+
+De `bruno/`-folder bevat per service een collectie van voorbeeld-requests die je tegen de lokale
+dev-mode kunt uitvoeren met [Bruno](https://www.usebruno.com/).
+
+- `bruno/berichtenmagazijn/` — aanlever- en beheer-API
+- `bruno/berichtenuitvraag/` — frontend-facade (lijst, zoek, ophalen-SSE, detail, bijlage,
+  PATCH/DELETE) en de aanmeld-webhook
+
+Open de folder in Bruno, kies environment `lokaal` en run requests. De collectie spiegelt de
+OpenAPI-spec: nieuwe endpoints in de spec krijgen direct een bijbehorende `.bru`-request.
+
+## Configuratie
+
+De belangrijkste configuratie staat in
+`services/berichtenuitvraag/src/main/resources/application.properties`. Ingekort weergegeven —
+het bestand zelf bevat per magazijn ook nog de FSC-grant-hash:
+
+```properties
+# Magazijnregister: de map-key is de afzender-OIN, de waarde het magazijn van die organisatie.
+# %dev vult de URL uit een env-var met de lokale poort als default, zodat dezelfde
+# configuratie in een container naar container-DNS wijst.
+# %dev-default van MAGAZIJN_A_URL: http://localhost:8090
+magazijnen."00000000000000100000".url=${MAGAZIJN_A_URL}
+magazijnen."00000000000000100000".naam=Magazijn A
+# %dev-default van MAGAZIJN_B_URL: http://localhost:8091
+magazijnen."00000001823288444000".url=${MAGAZIJN_B_URL}
+magazijnen."00000001823288444000".naam=Magazijn B
+```
+
+Omdat de map-key de OIN is, zijn dubbele OIN's structureel onmogelijk; `ConfigMagazijnregister`
+valideert keys en URL's bij het opstarten en weigert buiten dev/test een niet-https-adres.
+
+Voor productie-instellingen — TLS-eisen op Redis en het Logboek Dataverwerkingen, verplichte
+overrides, tuning en monitoring — geldt de [operator-handleiding](operator-handleiding.md).

--- a/services/berichtenuitvraag/src/main/resources/application.properties
+++ b/services/berichtenuitvraag/src/main/resources/application.properties
@@ -270,7 +270,12 @@ profiel.resolver.cache.max-size=10000
 
 # %dev: twee lokaal-draaiende berichtenmagazijn-instances. Magazijn A op de
 # default-poort (8090); magazijn B start je in een tweede terminal op 8091 met:
-#     ./mvnw quarkus:dev -pl services/berichtenmagazijn -Dquarkus.http.port=8091
+#     MAGAZIJN_OIN=00000001823288444000 \
+#     DB_JDBC_URL=jdbc:postgresql://localhost:5433/berichtenmagazijn \
+#     ./mvnw compile quarkus:dev -pl services/berichtenmagazijn -am \
+#       -Dquarkus.http.port=8091 -Ddebug=5006
+# Zonder de OIN- en database-override publiceert die tweede instantie onder de identiteit
+# van magazijn A en deelt hij diens opslag; dan aggregeer je twee views op één magazijn.
 #
 # De env-vars horen op de %dev-regel zelf: die schaduwt de gelijknamige basissleutel
 # hierboven, dus de ${ENV} dáár bereikt dit profiel nooit. Sleutels zonder %dev-regel


### PR DESCRIPTION
## Aanleiding

De CI-badge in de README wees naar de vorige repository (`ericwout-overheid/moza-fbs-berichtenbox`) en naar een workflow `ci.yml` die hier niet bestaat — de badge was dus dubbel kapot. Dat was aanleiding om de hele README na te lopen; die was al een tijd niet bijgewerkt.

## Wat er verandert

**Badges**
- CI-badge vervangen door badges voor de workflows die deze repo echt draait: Test, detekt en CodeQL, allemaal op `MinBZK/moza-poc-fbs-berichtenbox`.

**Inhoud geactualiseerd**
- **Doel**: de componentenlijst stond nog op de oude indeling (losse berichtensessiecache-service, berichtnotificatieprofiel als onderdeel van deze repo). Nu: berichtenmagazijn, berichtenuitvraag en demo-console, met de opmerking dat de sessiecache een in-process library is en dat profiel/notificatie hier als stub draaien.
- **Repostructuur**: nieuwe tabel met `services/`, de drie `libraries/`, `bruno/`, `demo/`, `docs/`, `wiremock/`, `toxiproxy/`.
- **Vereisten**: Python 3 toegevoegd (nodig voor `demo/genereer-magazijnen.py`).
- **Poorten**: demo-console (8095) toegevoegd aan de tabel, plus het commando voor een tweede magazijn op 8091 — dat stond alleen in een comment in `application.properties`.
- **Tests**: commando's gebruiken nu `clean` (conform de werkwijze), `fbs-common` en `fbs-magazijnregister` toegevoegd, en de kwaliteitspoorten benoemd: JaCoCo 90%, `detekt:check`, Spectral-linting tegen de ADR-ruleset.
- **Architectuur en achtergrond**: nieuwe sectie met de gepubliceerde architectuursite (https://minbzk.github.io/moza-poc-fbs-berichtenbox/) en links naar de bestaande documenten in `docs/` die nergens vanuit de README bereikbaar waren.
- **Bijdragen**: korte sectie over branch/PR-werkwijze en wat CI op een PR doet.
- Verwijzing naar "de 14 scenario's" in het demo-runbook vervangen door een aantal-loze formulering, zodat het niet opnieuw verjaart.

## Verificatie

- Alle relatieve links en padverwijzingen in de README bestaan (gecontroleerd met een script over de gerenderde links).
- Architectuursite geeft HTTP 200.
- Badge-URL's wijzen naar bestaande workflowbestanden in `.github/workflows/`.
- Alleen documentatie; geen code- of configuratiewijziging, dus geen build-impact.